### PR TITLE
Update m4 files to look in sub-directory for library

### DIFF
--- a/m4/opm_core_check_modules.m4
+++ b/m4/opm_core_check_modules.m4
@@ -155,7 +155,7 @@ AC_DEFUN([OPM_CORE_CHECK_MODULES],[
       ifelse(_dune_symbol,,
         [_DUNE_MODULE[]_LIBDIR=""
          _dune_cm_LIBS=""],
-        [_DUNE_MODULE[]_LIBDIR="$_DUNE_MODULE[]_ROOT"
+        [_DUNE_MODULE[]_LIBDIR="$_DUNE_MODULE[]_ROOT/lib"
          _dune_cm_LIBS="-L$_DUNE_MODULE[]_LIBDIR -l[]_dune_lib"])
       # set expanded module path
       with_[]_dune_module="$_DUNE_MODULE[]_ROOT"


### PR DESCRIPTION
Since commit 9005e43 library files are put in lib/ also in the
development tree; other projects with dependencies to opm-core now
needs to look there.
