### PR TITLE
Fix associativity bug in get_zcorn_sign

### DIFF
--- a/opm/core/grid/cpgpreprocess/preprocess.c
+++ b/opm/core/grid/cpgpreprocess/preprocess.c
@@ -587,7 +587,7 @@ get_zcorn_sign(int nx, int ny, int nz, const int *actnum,
                     z1 = sign*zcorn[i+2*nx*(j+2*ny*(k))];
                     z2 = sign*zcorn[i+2*nx*(j+2*ny*(k+1))];
 
-                    c1 = i/2 + nx*(j/2 + ny*k/2);
+                    c1 = i/2 + nx*(j/2 + ny*(k/2));
                     c2 = i/2 + nx*(j/2 + ny*((k+1)/2));
 
                     if (((actnum == NULL) ||


### PR DESCRIPTION
The bug can also cause c2 to be larger than the length of
actnum, leading to segmentation faults.

Since I am new to both OPM and github, please do check this pull request for sanity on both counts :-)
