### PR TITLE
Make configure.ac compatible with automake 1.12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,10 @@ AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
+# Needed for automake since version 1.12 because extra-portability
+# warnings were then added to -Wall. Ifdef makes it backwards compatible.
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([opm/core/grid.h])
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
Since automake 1.12 warnings in the category 'extra-portability' are
enabled with -Wall [1]. In automake 1.11.2 the AM_PROG_AR macro was
added and is required when compiling with extra-compatibility [2].

Don't know if you like the explanatory comments in configure.ac or if it's too wordy?

[1] http://lists.gnu.org/archive/html/automake/2012-04/msg00060.html
[2] http://lists.gnu.org/archive/html/automake/2011-12/msg00055.html
