### PR TITLE
Support for pkg-config

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -304,3 +304,6 @@ opm/core/linalg/LinearSolverAGMG.hpp
 lib_libopmcore_la_LDFLAGS +=			\
 $(FCLIBS)
 endif
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = lib/pkgconfig/opm-core.pc

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,8 @@ AC_CONFIG_FILES([
  tests/Makefile
  examples/Makefile
  tutorials/Makefile
+ opm-core.pc
+ lib/pkgconfig/opm-core.pc
 ])
 
 AC_OUTPUT

--- a/lib/pkgconfig/opm-core.pc.in
+++ b/lib/pkgconfig/opm-core.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+Description: @PACKAGE_STRING@
+Version: @PACKAGE_VERSION@
+URL: @PACKAGE_URL@
+Libs: -L${libdir} -l@PACKAGE@
+Cflags: -I${includedir}

--- a/opm-core.pc.in
+++ b/opm-core.pc.in
@@ -1,0 +1,18 @@
+# This is the configuration for local builds. Use this by putting the
+# compilation output path (the directory in which you ran ./configure)
+# into the environment variable PKG_CONFIG_PATH. This will enable you
+# to use pkg-config in your code while making changes to opm-core.
+
+# This is NOT the file that is installed in the system directories when
+# you do `make install`. That is the one in lib/pkgconfig. However, if
+# you make changes here, you should consider that one as well.
+
+libdir=@abs_top_builddir@/lib/.libs
+includedir=@abs_top_srcdir@
+
+Name: @PACKAGE_NAME@
+Description: @PACKAGE_STRING@
+Version: @PACKAGE_VERSION@
+URL: @PACKAGE_URL@
+Libs: -L${libdir} -l@PACKAGE@
+Cflags: -I${includedir}


### PR DESCRIPTION
pkg-config is an attempt to provide a central database for discovery of available libraries.

This patch provides pkg-config support for discovering opm-core as a library. Samples and test-cases may then be compiled using simple one-liners like this:

  g++  `pkg-config --cflags --libs opm-core`   mytest.cxx

Unfortunately, pkg-config does not support prefix rewriting (discovering the location of the library based on the location of the .pc file) on Linux. Therefore, I have added two files: One which is geared towards being installed in the system directories, and one that picks up the location of the build itself.

If one sets the environment variable:

  export PKG_CONFIG_PATH=/path/to/build/directory:$PKG_CONFIG_PATH

a local build of opm-core will be picked up from the specified directory, and this enables us to do development of the library without changing the configuration of dependent projects (they can use pkg-config always).
