### PR TITLE
Disable warning for using DUNE's FieldVector::size

### DIFF
--- a/opm/core/linalg/LinearSolverIstl.cpp
+++ b/opm/core/linalg/LinearSolverIstl.cpp
@@ -26,6 +26,10 @@
 
 #include <opm/core/utility/have_boost_redef.hpp>
 
+// Silence compatibility warning from DUNE headers since we don't use
+// the deprecated member anyway (in this compilation unit)
+#define DUNE_COMMON_FIELDVECTOR_SIZE_IS_METHOD 1
+
 // TODO: clean up includes.
 #include <dune/common/deprecated.hh>
 #include <dune/istl/bvector.hh>


### PR DESCRIPTION
In DUNE 2.2 FieldVector::size changed from being a member to being a
method. A compatibility warning is issued if you include the relevant
headers.

This warning can be silenced for DUNE modules by using passing the
option --enable-fieldvector-size-is-method to ./configure. This patch
effectively does the same, but through the define. (I don't see any
point in disabling it, so I haven't made it an option).
