### PR TITLE
Link Boost.Filesystem Explicitly Where Needed.

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -7,6 +7,20 @@ $(OPM_BOOST_CPPFLAGS)
 LDADD =						\
 $(top_builddir)/lib/libopmcore.la
 
+# Convenience definition for targets that use Boost.Filesystem directly.
+# While libopmcore depends on (and references) Boost.Filesystem (through
+# the $(BOOST_FILESYSTEM_LIB) macro) this indirect dependency is not
+# sufficient to satisfy the requirements of targets that use the indirect
+# libraries directly.
+#
+# Additional details at
+#   https://fedoraproject.org/wiki/UnderstandingDSOLinkChange
+#
+LINK_BOOST_FILESYSTEM =				\
+$(OPM_BOOST_LDFLAGS)				\
+$(BOOST_FILESYSTEM_LIB)				\
+$(BOOST_SYSTEM_LIB)
+
 # ----------------------------------------------------------------------
 # Declare products (i.e., the example programs).
 #
@@ -28,9 +42,16 @@ wells_example
 # Please maintain sort order from "noinst_PROGRAMS".
 
 refine_wells_SOURCES          = refine_wells.cpp
+
 sim_2p_comp_reorder_SOURCES   = sim_2p_comp_reorder.cpp
+sim_2p_comp_reorder_LDADD     = $(LDADD) $(LINK_BOOST_FILESYSTEM)
+
 sim_2p_incomp_reorder_SOURCES = sim_2p_incomp_reorder.cpp
+sim_2p_incomp_reorder_LDADD   = $(LDADD) $(LINK_BOOST_FILESYSTEM)
+
 sim_wateroil_SOURCES          = sim_wateroil.cpp
+sim_wateroil_LDADD            = $(LDADD) $(LINK_BOOST_FILESYSTEM)
+
 wells_example_SOURCES         = wells_example.cpp
 
 # ----------------------------------------------------------------------
@@ -42,5 +63,6 @@ noinst_PROGRAMS += spu_2p
 spu_2p_SOURCES   = spu_2p.cpp
 spu_2p_LDADD     =				\
 $(LDADD)					\
+$(LINK_BOOST_FILESYSTEM)			\
 $(LAPACK_LIBS) $(BLAS_LIBS) $(LIBS)
 endif


### PR DESCRIPTION
While libopmcore, following commit 37e14f, depends on (and references)
Boost.Filesystem (through the $(BOOST_FILESYSTEM_LIB) macro) this
indirect dependency is not sufficient to satisfy the requirements of
targets that use the indirect libraries directly.

Additional details at
   https://fedoraproject.org/wiki/UnderstandingDSOLinkChange

This change reportedly fixes Issue #46 .
