### PR TITLE
Dependency update for Ubuntu 12.04

### DIFF
--- a/README
+++ b/README
@@ -56,10 +56,10 @@ sudo add-apt-repository -y ppa:opm/ppa
 sudo apt-get update
 
 # parts of DUNE needed
-sudo apt-get install libdune-common-dev libdune-istl-dev
+sudo apt-get install libdune-common-dev libdune-istl-dev libdune-grid-dev
 
 # libraries necessary for OPM
-sudo apt-get install -y libxml0-dev
+sudo apt-get install -y libxml2-dev
 
 
 DEPENDENCIES FOR SUSE BASED DISTRIBUTIONS


### PR DESCRIPTION
Changed libxml0-dev to libxml2-dev since the former does not exist.
