### PR TITLE
Suppress warning about unused variable in !HAVE_ERT case.

### DIFF
--- a/opm/core/eclipse/EclipseGridParser.cpp
+++ b/opm/core/eclipse/EclipseGridParser.cpp
@@ -1130,6 +1130,7 @@ void EclipseGridParser::getNumericErtFields(const string& filename)
     }
     ecl_file_close(ecl_file);
 #else
+    static_cast<void>(filename); // Suppress "unused variable" warning.
     THROW("Cannot use IMPORT keyword without ert library support. Reconfigure opm-core with --with-ert and recompile.");
 #endif  // HAVE_ERT
 }


### PR DESCRIPTION
This applies the standard trick of using

``` C++
static_cast<void>(variable)
```

to suppress the GCC warning about an unused variable.  This particular warning happens only in the `!HAVE_ERT` case.
