### PR TITLE
Provide CMake config mode files for custom builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ m4/lt*.m4
 missing
 ar-lib
 tutorials/tutorial[1-4]
+opmcore-config.cmake
 
 # Ignoring executables
 *_test

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,7 @@ AC_CONFIG_FILES([
  tutorials/Makefile
  opm-core.pc
  lib/pkgconfig/opm-core.pc
+ opmcore-config.cmake
 ])
 
 AC_OUTPUT

--- a/opmcore-config.cmake.in
+++ b/opmcore-config.cmake.in
@@ -1,0 +1,36 @@
+# - Open Porous Media Initiative Core Library config mode
+#
+# Defines the following variables:
+#  @PACKAGE@_FOUND        - true
+#  @PACKAGE@_VERSION      - version of the opm-core library found, e.g. 0.2
+#  @PACKAGE@_DEFINITIONS  - defines to be made on the command line
+#  @PACKAGE@_INCLUDE_DIRS - include directories to be included in build
+#  @PACKAGE@_LIBRARIES    - library directories to be included in build
+#
+# You should put lines like this in your CMakeLists.txt
+#  set (@PACKAGE@_DIR "../@PACKAGE@" CACHE LOCATION "Build tree of @PACKAGE_NAME@")
+#  find_package (@PACKAGE@)
+
+# <http://www.vtk.org/Wiki/CMake/Tutorials/How_to_create_a_ProjectConfig.cmake_file>
+
+# propagate this property from one build system to the other
+set (@PACKAGE@_VERSION @PACKAGE_VERSION@)
+
+# these definitions may be necessary to make the header files behave the
+# same way as they did when the library was compiled
+set (@PACKAGE@_DEFINITIONS "@OPM_BOOST_CPPFLAGS@ @SUPERLU_CPPFLAGS@ @ERT_CPPFLAGS@")
+
+# include files come from the source tree where the template is stored
+set (@PACKAGE@_INCLUDE_DIRS "@abs_top_srcdir@")
+
+# user programs should link with this library (see comment in the header)
+set (@PACKAGE@_LIBRARIES "@PACKAGE@")
+
+# libraries come from the build tree where this file was generated
+find_library (@PACKAGE@_LOCATION NAMES "@PACKAGE@" PATHS "@abs_top_builddir@/lib/.libs")
+mark_as_advanced (@PACKAGE@_LOCATION)
+
+# add the library as a target, so that other things in the project including
+# this file may depend on it and get rebuild if this library changes.
+add_library (@PACKAGE@ UNKNOWN IMPORTED)
+set_property (TARGET @PACKAGE@ PROPERTY IMPORTED_LOCATION "${@PACKAGE@_LOCATION}")


### PR DESCRIPTION
With this patch, client program/libraries that uses CMake can find the OPM-core library with:

set (opmcore_DIR "../opm-core" CACHE LOCATION "Build tree of opm-core")
find_package (opmcore REQUIRED)

(The first line just sets the search path for the library to some sensible default).

This would provide a way for client programs to start using OPM Core as if it already were a CMake-library, making a later transition smoother.
