### PR TITLE
Ert fix warnings

### DIFF
--- a/examples/import_rewrite.cpp
+++ b/examples/import_rewrite.cpp
@@ -147,7 +147,7 @@ static bool convertKeyword( const std::string& inputFile , const std::string& ou
 
 
 
-bool parseFile(const std::string& inputFile, std::string& outputFile, const std::string& indent = "") {
+static bool parseFile(const std::string& inputFile, std::string& outputFile, const std::string& indent = "") {
   bool updateFile = false;
   std::cout << indent << "Parsing " << inputFile << "\n";
   {


### PR DESCRIPTION
This change-set fixes two warnings that present when building OPM-Core with ERT support.  First, we remove a local variable that was never referenced but was redeclared in an inner scope.  Secondly, we declare a function that is only needed in a single file as "static" to avoid warnings about a missing previous declaration.
