### PR TITLE
Update recommendations for building OPM

### DIFF
--- a/README
+++ b/README
@@ -64,6 +64,8 @@ sudo apt-get install libdune-common-dev libdune-istl-dev libdune-grid-dev
 # libraries necessary for OPM
 sudo apt-get install -y libxml2-dev
 
+Note: You should compile the OPM modules using the same toolchain that
+      was used to build DUNE. Otherwise, you can get strange ABI errors.
 
 DEPENDENCIES FOR SUSE BASED DISTRIBUTIONS
 -----------------------------------------


### PR DESCRIPTION
(1) Added option to at least have some parallelity in builds for those who simply paste the description

(2) Added warning about building with DUNE libraries from a different (version of) the compiler.
