### PR TITLE
Don't use '==' when '=' is equally good

### DIFF
--- a/m4/ax_lapack.m4
+++ b/m4/ax_lapack.m4
@@ -104,7 +104,7 @@ fi
 # don't probe if explicitly defined; by bailing out here if the
 # argument is set, we guard against typo, incompatible libs. etc.
 # being inadvertedly overrided by another (random) implementation
-if test "x$with_lapack" == x; then
+if test "x$with_lapack" = x; then
 
 # LAPACK linked to by default?  (is sometimes included in BLAS lib)
 if test $ax_lapack_ok = no; then

--- a/m4/cxx0x_compiler.m4
+++ b/m4/cxx0x_compiler.m4
@@ -33,7 +33,7 @@ AC_DEFUN([GXX0X],[
       dune_cv_gplusplus_accepts_cplusplus11=disabled
     fi
   ])
-  if test "x$dune_cv_gplusplus_accepts_cplusplus11" == "xyes" ; then
+  if test "x$dune_cv_gplusplus_accepts_cplusplus11" = "xyes" ; then
     CXX="$save_CXX -std=c++11"
     CXXCPP="$CXXCPP -std=c++11"
   else
@@ -56,7 +56,7 @@ AC_DEFUN([GXX0X],[
         dune_cv_gplusplus_accepts_cplusplus0x=disabled
       fi
     ])
-    if test "x$dune_cv_gplusplus_accepts_cplusplus0x" == "xyes" ; then
+    if test "x$dune_cv_gplusplus_accepts_cplusplus0x" = "xyes" ; then
       CXX="$save_CXX -std=c++0x"
       CXXCPP="$CXXCPP -std=c++0x"
     else

--- a/m4/ert.m4
+++ b/m4/ert.m4
@@ -48,7 +48,7 @@ AS_IF([test x"${with_ert}" != x"no"],
   LDFLAGS="${_ert_LDFLAGS_SAVE}"
   CFLAGS="${_ert_CFLAGS_SAVE}"
 
-  AS_IF([test x"${use_ert}" == x"yes"],
+  AS_IF([test x"${use_ert}" = x"yes"],
    [AC_SUBST([ERT_CPPFLAGS])
     AC_SUBST([ERT_LDFLAGS])
     AC_SUBST([ERT_LIBS])


### PR DESCRIPTION
There is no need to use Bash-specific operators when the pure sh(1)
built-in test operators have the exact same semantics.  This increases
portability to systems for which /bin/sh is _not_ Bash (or Dash).
