### PR TITLE
Write ecl active

### DIFF
--- a/opm/core/eclipse/EclipseGridParser.cpp
+++ b/opm/core/eclipse/EclipseGridParser.cpp
@@ -395,9 +395,9 @@ void EclipseGridParser::readImpl(istream& is)
                     // This will only ever happen in the first epoch,
                     // upon first encountering a timestepping keyword.
                     if (hasField("START")) {
-                        start_date_ = getSTART().date;
+                      start_date_ = getSTART().date;
                     } else {
-                        start_date_ = boost::gregorian::date(1983, 1, 1);
+                      start_date_ = boost::gregorian::date( 1983 , 1 , 1 );
                     }
                 }
                 if (current_reading_mode_ == Regular) {
@@ -658,6 +658,12 @@ void EclipseGridParser::setCurrentEpoch(int epoch)
     current_epoch_ = epoch;
 }
 
+//-----------------------------------------------------------------
+boost::gregorian::date EclipseGridParser::getStartDate() const
+//---------------------------------------------------------------------------
+{
+  return start_date_;
+}
 
 //---------------------------------------------------------------------------
 const std::vector<int>& EclipseGridParser::getIntegerValue(const std::string& keyword) const

--- a/opm/core/eclipse/EclipseGridParser.hpp
+++ b/opm/core/eclipse/EclipseGridParser.hpp
@@ -95,7 +95,6 @@ namespace Opm
     /// converted to SI units.
     explicit EclipseGridParser(const std::string& filename, bool convert_to_SI = true);
 
-
     static FieldType classifyKeyword(const std::string& keyword);
     static bool readKeyword(std::istream& is, std::string& keyword);
 
@@ -127,6 +126,9 @@ namespace Opm
     /// Valid arguments are in [0, ..., numberOfEpochs() - 1].
     /// After reading, current epoch always starts at 0.
     void setCurrentEpoch(int epoch);
+
+    /// Returns the start_date_
+    boost::gregorian::date getStartDate() const;
 
     /// Returns a reference to a vector containing the values
     /// corresponding to the given integer keyword.

--- a/opm/core/simulator/SimulatorTimer.hpp
+++ b/opm/core/simulator/SimulatorTimer.hpp
@@ -22,6 +22,8 @@
 
 #include <iosfwd>
 #include <vector>
+#include <boost/date_time/gregorian/gregorian.hpp>
+#include <boost/date_time/posix_time/posix_time_types.hpp>
 
 namespace Opm
 {
@@ -33,57 +35,60 @@ namespace Opm
     class SimulatorTimer
     {
     public:
-	/// Default constructor.
-	SimulatorTimer();
+        /// Default constructor.
+        SimulatorTimer();
 
-	/// Initialize from parameters. Accepts the following:
-	///    num_psteps    (default 1)
-	///    stepsize_days (default 1)
-	void init(const parameter::ParameterGroup& param);
+        /// Initialize from parameters. Accepts the following:
+        ///    num_psteps    (default 1)
+        ///    stepsize_days (default 1)
+        void init(const parameter::ParameterGroup& param);
 
-	/// Initialize from TSTEP field.
-	void init(const EclipseGridParser& deck);
+        /// Initialize from TSTEP field.
+        void init(const EclipseGridParser& deck);
 
-	/// Total number of steps.
-	int numSteps() const;
+        /// Total number of steps.
+        int numSteps() const;
 
-	/// Current step number.
-	int currentStepNum() const;
+        /// Current step number.
+        int currentStepNum() const;
 
         /// Set current step number.
         void setCurrentStepNum(int step);
 
-	/// Current step length.
-	/// Note: if done(), it is an error to call currentStepLength().
-	double currentStepLength() const;
+        /// Current step length.
+        /// Note: if done(), it is an error to call currentStepLength().
+        double currentStepLength() const;
 
-	/// Current time.
-	double currentTime() const;
+        /// Current time.
+        double currentTime() const;
 
-	/// Total time.
-	double totalTime() const;
+        boost::posix_time::ptime currentDateTime() const;
+
+        /// Total time.
+        double totalTime() const;
 
         /// Set total time.
         /// This is primarily intended for multi-epoch schedules,
         /// where a timer for a given epoch does not have
         /// access to later timesteps.
-	void setTotalTime(double time);
+        void setTotalTime(double time);
 
-	/// Print a report with current and total time etc.
-	/// Note: if done(), it is an error to call report().
-	void report(std::ostream& os) const;
+        /// Print a report with current and total time etc.
+        /// Note: if done(), it is an error to call report().
+        void report(std::ostream& os) const;
 
-	/// Next step.
-	SimulatorTimer& operator++();
+        /// Next step.
+        SimulatorTimer& operator++();
 
-	/// Return true if op++() has been called numSteps() times.
-	bool done() const;
+        /// Return true if op++() has been called numSteps() times.
+        bool done() const;
 
     private:
-	std::vector<double> timesteps_;
-	int current_step_;
-	double current_time_;
-	double total_time_;
+        std::vector<double> timesteps_;
+        int current_step_;
+        double current_time_;
+        double total_time_;
+        boost::gregorian::date start_date_;
     };
 
 

--- a/opm/core/utility/writeECLData.cpp
+++ b/opm/core/utility/writeECLData.cpp
@@ -90,9 +90,9 @@ namespace Opm
                     const std::string& output_dir,
                     const std::string& base_name) {
     
-    ecl_file_enum file_type = ECL_UNIFIED_RESTART_FILE;
+    ecl_file_enum file_type = ECL_UNIFIED_RESTART_FILE;  // Alternatively ECL_RESTART_FILE for multiple restart files.
     bool fmt_file           = true; 
-
+    
     int step                = simtimer.currentStepNum();
     char * filename         = ecl_util_alloc_filename(output_dir.c_str() , base_name.c_str() , file_type , fmt_file , step );
     int phases              = ECL_OIL_PHASE + ECL_WATER_PHASE;
@@ -103,6 +103,15 @@ namespace Opm
     int nz                  = grid.cartdims[2];
     int nactive             = grid.number_of_cells;
     ecl_rst_file_type * rst_file;
+    
+    {
+      using namespace boost::posix_time;
+      ptime t1 = simtimer.currentDateTime();
+      ptime t0( boost::gregorian::date(1970 , 1 ,1) );
+      time_duration::sec_type seconds = (t1 - t0).total_seconds();
+      
+      date = time_t( seconds );
+    }
     
     if (step > 0 && file_type == ECL_UNIFIED_RESTART_FILE)
       rst_file = ecl_rst_file_open_append( filename );


### PR DESCRIPTION
The pull request consist of two commits:
1. The first commit mainly documents the ECLIPSE conventions for formatted/unformatted unified/multiple restart files, and also makes sure that only active cell data is stored.
2. The second commit introduces a boost::gregorian::date property start_date_ in the SimulatorTimer class. This is later used in the writeECLData function to set the correct date value for the solution fields (up til now everything happened at January 1. 1970 - funny eh?
