### PR TITLE
Fix signed-vs-unsigned comparison warning

### DIFF
--- a/opm/core/utility/writeECLData.cpp
+++ b/opm/core/utility/writeECLData.cpp
@@ -46,7 +46,9 @@ namespace Opm
                                        int offset , 
                                        int stride ) {
 
-    if (grid.number_of_cells != data->size() / stride)   
+    if (stride <= 0)
+      THROW("Vector strides must be positive. Got stride = " << stride);
+    if ((stride * std::vector<double>::size_type(grid.number_of_cells)) != data->size())
       THROW("Internal mismatch grid.number_of_cells: " << grid.number_of_cells << " data size: " << data->size() / stride);
     {
       ecl_kw_type * ecl_kw = ecl_kw_alloc( kw_name.c_str() , grid.number_of_cells , ECL_FLOAT_TYPE );


### PR DESCRIPTION
The existing code compared the output of `data->size()`, which is a

``` c++
std::vector<double>::size_type
```

(typically `std::size_t`) and therefore an unsigned integer type to the
number `grid.number_of_cells` which is a (signed) `int`.

This leads to an annoying warning when increasing the
warning level in GCC.

While here, also insert code to verify that the `stride` is a positive
number lest the subsequent assignment loop reference `(*data)` elements
out of bounds.
