### PR TITLE
Fix build if ERT is installed in a non-default location

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,9 +1,8 @@
 # Build-time flags needed to form example programs
-ERT_INCLUDE_PATH = $(ERT_ROOT)/include
 
 AM_CPPFLAGS =                                   \
 -I$(top_srcdir)                                 \
--I$(ERT_INCLUDE_PATH)                           \
+$(ERT_CPPFLAGS)					\
 $(OPM_BOOST_CPPFLAGS)
 
 # All targets link to the library

--- a/tutorials/Makefile.am
+++ b/tutorials/Makefile.am
@@ -1,5 +1,6 @@
 AM_CPPFLAGS =					\
 -I$(top_srcdir)					\
+$(ERT_CPPFLAGS)					\
 $(OPM_BOOST_CPPFLAGS)
 
 AM_LDFLAGS = $(OPM_BOOST_LDFLAGS)


### PR DESCRIPTION
The existing description did not properly account for ERT (or, more
appropriately, the "libecl" part of ERT) being installed in a
non-default location (e.g., somewhere below ${HOME}).

As EclipseGridParser.hpp declares various ERT-dependent types and
functions if a build configuration supports ERT (activated by the
`--with-ert' configure option), we need a proper include path to
reference the ERT headers.  The fix is simple--just insert the
$(ERT_CPPFLAGS) into the already existing $(AM_CPPFLAGS).
