### PR TITLE
Made saveEGRID() method available unconditionally.

### DIFF
--- a/opm/core/eclipse/EclipseGridParser.cpp
+++ b/opm/core/eclipse/EclipseGridParser.cpp
@@ -958,7 +958,7 @@ ecl_grid_type * EclipseGridParser::newGrid( ) {
      }
 */
 
-void EclipseGridParser::saveEGRID( const std::string & filename) {
+void EclipseGridParser::saveEGRID( const std::string & filename) const {
   bool endian_flip = true;//ECL_ENDIAN_FLIP;
   bool fmt_file     = ecl_util_fmt_file( filename.c_str() );
   struct grdecl grdecl = get_grdecl();
@@ -1068,6 +1068,14 @@ void EclipseGridParser::saveEGRID_INIT( const std::string& output_dir , const st
   free( egrid_file );
   ecl_grid_free( ecl_grid );
 }
+#else
+
+void EclipseGridParser::saveEGRID( const std::string & filename) const
+{
+    static_cast<void>(filename); // Suppress "unused variable" warning.
+    THROW("Cannot write EGRID format without ert library support. Reconfigure opm-core with --with-ert and recompile.");
+}
+
 #endif
 
 // Read an imported fortio data file using Ert. 

--- a/opm/core/eclipse/EclipseGridParser.hpp
+++ b/opm/core/eclipse/EclipseGridParser.hpp
@@ -221,9 +221,11 @@ public:                                                                         
 
     struct grdecl get_grdecl() const;
 
+    /// Save grid parts of deck in EGRID format. 
+    void saveEGRID(const std::string & filename) const;
+
 #ifdef HAVE_ERT
   void saveEGRID_INIT( const std::string& output_dir , const std::string& basename, bool fmt_file = false);
-  void saveEGRID( const std::string & filename );
   void saveINIT( const std::string & filename , const ecl_grid_type * ecl_grid);
   ecl_grid_type * newGrid( );
 #endif


### PR DESCRIPTION
Will throw if called without ERT support, though.
