### PR TITLE
Make superlu available in all OPM modules again.

### DIFF
--- a/m4/opm_superlu.m4
+++ b/m4/opm_superlu.m4
@@ -143,6 +143,9 @@ AC_DEFUN([OPM_PATH_SUPERLU],[
     AC_REQUIRE([AC_F77_LIBRARY_LDFLAGS])
     AC_REQUIRE([AX_BLAS])
 
+  if test x$HAVE_SUPERLU = x1 ; then
+     AC_MSG_WARN([SuperLU test was already performed. Skipping it here])
+  else
     #
     # User hints ...
     #
@@ -331,4 +334,5 @@ AC_DEFUN([OPM_PATH_SUPERLU],[
     LDFLAGS="$ac_save_LDFLAGS"
     CPPFLAGS="$ac_save_CPPFLAGS"
     LIBS="$ac_save_LIBS"
+  fi
 ])


### PR DESCRIPTION
The new SuperLU test implemented in opm-core confused the SuperLU test in DUNE such that the other OPM modules would not have SuperLU correctly setup.

This pull request adds a guard to the SuperLU test in opm-core. If HAVE_SUPERLU is 1 from a run of the  SuperLU test within DUNE, we skip testing for it again as the additional test
would fail and then clear the SUPERLU_CPPFLAGS and other flags in the Makefiles of  the OPM modules and thus strip SUPERLU support.

This pull request fixes issue #106
