### PR TITLE
changed: remove internal tinyxml

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -130,10 +130,6 @@ opm/core/utility/parameters/Parameter.cpp		\
 opm/core/utility/parameters/ParameterGroup.cpp		\
 opm/core/utility/parameters/ParameterTools.cpp		\
 opm/core/utility/parameters/ParameterXML.cpp		\
-opm/core/utility/parameters/tinyxml/tinystr.cpp		\
-opm/core/utility/parameters/tinyxml/tinyxml.cpp		\
-opm/core/utility/parameters/tinyxml/tinyxmlerror.cpp	\
-opm/core/utility/parameters/tinyxml/tinyxmlparser.cpp	\
 opm/core/utility/writeECLData.cpp			\
 opm/core/utility/writeVtkData.cpp			\
 opm/core/vag_format/vag.cpp				\
@@ -142,6 +138,13 @@ opm/core/wells/ProductionSpecification.cpp		\
 opm/core/wells/WellCollection.cpp			\
 opm/core/wells/WellsGroup.cpp				\
 opm/core/wells/WellsManager.cpp
+
+if INTERNAL_TIXML
+lib_libopmcore_la_SOURCES += opm/core/utility/parameters/tinyxml/tinystr.cpp		\
+			     opm/core/utility/parameters/tinyxml/tinyxml.cpp		\
+			     opm/core/utility/parameters/tinyxml/tinyxmlerror.cpp	\
+			     opm/core/utility/parameters/tinyxml/tinyxmlparser.cpp
+endif
 
 nobase_include_HEADERS =				\
 opm/core/GridAdapter.hpp				\

--- a/m4/opm_core.m4
+++ b/m4/opm_core.m4
@@ -51,6 +51,15 @@ AC_SEARCH_LIBS([cholmod_l_start],      [cholmod])
 AC_SEARCH_LIBS([umfpack_dl_solve],     [umfpack],dnl
                [umfpack_lib=yes],      [umfpack_lib=no])
 
+# TinyXML
+AC_CHECK_LIB([tinyxml],     [main],, tixml_lib=no)
+AM_CONDITIONAL([INTERNAL_TIXML], [test x"$tixml_lib" = x"no"])
+
+# Doesn't use AM_COND_IF since this is required
+if test x"$tixml_lib" = x"no"; then
+  CPPFLAGS="$CPPFLAGS -Iopm/core/utilities/parameters/tinyxml"
+fi
+
 AM_CONDITIONAL([UMFPACK],
   [test "x$umfpack_header" != "xno" -a "x$umfpack_lib" != "xno"])
 


### PR DESCRIPTION
this library is provided on the system level on modern oses. embedding it in the build tree obliterates any chance of ever getting into e.g. debian.

now afaict there are no modifications to the in-tree copy, unless there was some in the originally imported files.

only tested on ubuntu, but tixml api has been stable for quite some time so i don't expect issues on redhat (famous last words).
