### PR TITLE
Correct a number of latent issues in `tarjan.c`

### DIFF
--- a/opm/core/transport/reorder/tarjan.c
+++ b/opm/core/transport/reorder/tarjan.c
@@ -196,7 +196,7 @@ tarjan (int nv, const int *ia, const int *ja, int *vert, int *comp,
                 }
                 else
                 {
-                    assert(status[child] = DONE);
+                    assert(status[child] == DONE);
                 }
             }
         }


### PR DESCRIPTION
This set of changes installs a number of corrections to latent issues in the `tarjan.c` module.

Specifically,
- Uses a portable method of zeroing a vector `int`s
- Eliminates a few redundant explicit type conversions
- Eliminates a release-mode only build-time warning
- Replaces an assignment (within an `assert()`) with the intended equality test
