### PR TITLE
build fails if UMFpack development package is not installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ if (NOT SuiteSparse_FOUND)
 		${PROJECT_SOURCE_DIR}/${tutorial_DIR}/tutorial4.cpp
 		)
 	list (REMOVE_ITEM examples_SOURCES
-		${PROJECT_SOURCE_DIR}/${examples_DIR}/spu2p.cpp
+		${PROJECT_SOURCE_DIR}/${examples_DIR}/spu_2p.cpp
 		)
 endif (NOT SuiteSparse_FOUND)
 
@@ -207,7 +207,6 @@ opm_cmake_config (opm-core)
 include (OpmSatellites)
 
 # tutorial programs are found in the tutorials/ directory
-opm_find_tutorials ()
 opm_compile_satellites (opm-core tutorial "" "")
 opm_compile_satellites (opm-core examples "" "")
 


### PR DESCRIPTION
although it is "just" a tutorial, so the library gets build. possibly, the tutorial should be not included in the build if umfpack is not found. the relevant parts of the output of "make VERBOSE=1" is the following:

[ 95%] Building CXX object CMakeFiles/tutorial2.dir/tutorials/tutorial2.cpp.o
/usr/bin/c++   -DHAVE_CONFIG_H=1 -DDUNE_COMMON_FIELDVECTOR_SIZE_IS_METHOD=1 -pipe -std=c++11 -fopenmp -ggdb3 -Wall -g -O0 -DDEBUG -I/home/and/src/opm-core    -o CMakeFiles/tutorial2.dir/tutorials/tutorial2.cpp.o -c /home/and/src/opm-core/tutorials/tutorial2.cpp
/home/and/src/opm-core/opm/core/transport/CSRMatrixUmfpackSolver.hpp:61: error: undefined reference to 'call_UMFPACK'
collect2: error: ld returned 1 exit status
