### PR TITLE
Remove dependency on Boost.Test from main library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,10 @@ list (APPEND opm-core_DEPS
 	)
 find_and_append_package_list_to (opm-core ${opm-core_DEPS})
 
+# remove the dependency on the testing framework from the main library;
+# it is not possible to query for Boost twice with different components.
+list (REMOVE_ITEM opm-core_LIBRARIES ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+
 # put debug information into every executable
 include (UseDebugSymbols)
 

--- a/cmake/Modules/OpmSatellites.cmake
+++ b/cmake/Modules/OpmSatellites.cmake
@@ -54,7 +54,15 @@ macro (opm_compile_satellites opm satellite excl_all test_regexp)
 	set_target_properties (${_sat_NAME} PROPERTIES
 	  LINK_FLAGS "${${opm}_LINKER_FLAGS_STR}"
 	  )
-	target_link_libraries (${_sat_NAME} ${${opm}_TARGET} ${${opm}_LIBRARIES})
+	# are we building a test? luckily, the testing framework doesn't
+	# require anything else, so we don't have to figure out where it
+	# should go in the library list
+	if (NOT ${test_regexp} STREQUAL "")
+	  set (_test_lib "${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}")
+	else (NOT ${test_regexp} STREQUAL "")
+	  set (_test_lib "")
+	endif (NOT ${test_regexp} STREQUAL "")
+	target_link_libraries (${_sat_NAME} ${${opm}_TARGET} ${${opm}_LIBRARIES} ${_test_lib})
 	strip_debug_symbols (${_sat_NAME} _sat_DEBUG)
 	list (APPEND ${satellite}_DEBUG ${_sat_DEBUG})
 


### PR DESCRIPTION
The unit tests are not bundled with the runtime, so it is an unnecessary
dependency. (It is still of course a dependency for the development
package).
