### PR TITLE
Print OS and CMake versions to configuration log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ enable_language (CXX)
 set (opm-core_MODULE_DIR "${PROJECT_SOURCE_DIR}/cmake/Modules")
 list (APPEND CMAKE_MODULE_PATH ${opm-core_MODULE_DIR})
 
+# print system information to better pinpoint issues from log alone
+include (UseSystemInfo)
+system_info ()
+
 # very early try to print repo id (to pinpoint version if something goes wrong)
 include (UseVCSInfo)
 vcs_info ()

--- a/cmake/Modules/UseSystemInfo.cmake
+++ b/cmake/Modules/UseSystemInfo.cmake
@@ -1,0 +1,23 @@
+# - Print CMake and OS distribution version
+#
+function (system_info)
+  message (STATUS "CMake version: ${CMAKE_VERSION}")
+  if (CMAKE_SYSTEM MATCHES "Linux")
+	read_lsb (ID INTO DISTRIB_ID)
+	read_lsb (RELEASE INTO DISTRIB_RELEASE)
+	read_lsb (CODENAME INTO DISTRIB_CODENAME)
+	message (STATUS "Linux distribution: ${DISTRIB_ID} \"${DISTRIB_CODENAME}\" ${DISTRIB_RELEASE}")
+  else (CMAKE_SYSTEM MATCHES "Linux")
+	message (STATUS "Operating system: ${CMAKE_SYSTEM}")
+  endif (CMAKE_SYSTEM MATCHES "Linux")
+endfunction (system_info)
+
+# read property from LSB information
+function (read_lsb suffix INTO varname)
+  file (STRINGS /etc/lsb-release _distrib
+	REGEX "^DISTRIB_${suffix}="
+	)
+  string (REGEX REPLACE
+	"^DISTRIB_${suffix}=\(.*\)" "\\1" ${varname} ${_distrib})
+  set (${varname} "${${varname}}" PARENT_SCOPE)
+endfunction (read_lsb suffix INTO varname)


### PR DESCRIPTION
It seems that we are always asking for each issue: "Which distribution/version do you have". With these commits, they are printed to the configuration log so we can read them directly from there!
