### PR TITLE
Link issues in release/2013.03 branch on CentOS 5.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,6 @@ include (OpmDefaults)
 opm_defaults (opm-core)
 message (STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
-# don't import more libraries than we need to
-include (UseOnlyNeeded)
-
 # use tricks to do faster builds
 include (UseFastBuilds)
 
@@ -77,6 +74,9 @@ find_and_append_package_list_to (opm-core ${opm-core_DEPS})
 # remove the dependency on the testing framework from the main library;
 # it is not possible to query for Boost twice with different components.
 list (REMOVE_ITEM opm-core_LIBRARIES ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+
+# don't import more libraries than we need to
+include (UseOnlyNeeded)
 
 # put debug information into every executable
 include (UseDebugSymbols)

--- a/cmake/Modules/UseOnlyNeeded.cmake
+++ b/cmake/Modules/UseOnlyNeeded.cmake
@@ -11,8 +11,26 @@ function (prepend var_name value)
   endif (${var_name})
 endfunction (prepend var_name value)
 
-if (CMAKE_CXX_PLATFORM_ID STREQUAL "Linux")
-  prepend (CMAKE_EXE_LINKER_FLAGS "-Wl,--as-needed")
-  prepend (CMAKE_MODULE_LINKER_FLAGS "-Wl,--as-needed")
-  prepend (CMAKE_SHARED_LINKER_FLAGS "-Wl,--as-needed")
-endif (CMAKE_CXX_PLATFORM_ID STREQUAL "Linux")
+# only ELF shared objects can be underlinked, and only GNU will accept
+# these parameters; otherwise just leave it to the defaults
+if ((CMAKE_CXX_PLATFORM_ID STREQUAL "Linux") AND CMAKE_COMPILER_IS_GNUCC)
+  # these are the modules whose probes will turn up incompatible
+  # flags on some systems
+  set (_maybe_underlinked
+	SuiteSparse
+	)
+  # check if any modules actually reported problems (by setting an
+  # appropriate linker flag)
+  set (_underlinked FALSE)
+  foreach (_module IN LISTS _maybe_underlinked)
+	if ("${${_module}_LINKER_FLAGS}" MATCHES "-Wl,--no-as-needed")
+	  set (_underlinked TRUE)
+	endif ("${${_module}_LINKER_FLAGS}" MATCHES "-Wl,--no-as-needed")
+  endforeach (_module)
+  # if we didn't have any problems, then go ahead and add
+  if (NOT _underlinked)
+	prepend (CMAKE_EXE_LINKER_FLAGS "-Wl,--as-needed")
+	prepend (CMAKE_MODULE_LINKER_FLAGS "-Wl,--as-needed")
+	prepend (CMAKE_SHARED_LINKER_FLAGS "-Wl,--as-needed")
+  endif (NOT _underlinked)
+endif ((CMAKE_CXX_PLATFORM_ID STREQUAL "Linux")  AND CMAKE_COMPILER_IS_GNUCC)


### PR DESCRIPTION
I've been trying to get the `release/2013.03` branch to build using default setup (GCC 4.1.2) on CentOS 5.9.  Apparently, the use of the link-time dependency check flag `-Wl,--as-needed` (through `UseOnlyNeeded`, introduced in commit a0e0535) leads to linker failures when building executables such as `compute_tof`.

In particular, I get the messages listed below when I execute the command

``` sh
$ make compute_tof VERBOSE=1
```

This is indeed unique to building executables that link to `libopmcore.so` and I don't know what the underlying issue is.  However, simply executing the build command directly without `-Wl,--as-needed`, i.e.,

``` sh
/usr/bin/c++ -pipe -fopenmp -ggdb3 -Wall -g -O0 -DDEBUG CMakeFiles/compute_tof.dir/examples/compute_tof.cpp.o  -o bin/compute_tof  -L/work/lib64 -rdynamic lib/libopmcore.a -lumfpack -lamd -llapack -lblas /work/lib64/libboost_date_time.so /work/lib64/libboost_filesystem.so /work/lib64/libboost_system.so -Wl,-rpath,/work/lib64
```

produces executables that run without issue.

I _suspect_ that `-Wl,--as-needed` is perhaps a bit too greedy and fails to incorporate indirect/transitive dependencies introduced by linking to `-lopmcore`.  It may well be a bug in the toolchain for all I know.  In any case, removing `-Wl,--as-needed` by disabling the `UseOnlyNeeded` module from `CMakeLists.txt`, leads to a successful build on CentOS 5.9 using the default toolcain (and a non-standard Boost).  This may be papering over another issue, however, so I would like to ask what the proper course of action should be.

```
/work/encap/cmake-2.8.10.1+0/bin/cmake -H/home/bska/work/opm/code/cxx0x-build/opm-core-release -B/home/bska/work/opm/code/cxx0x-build/build/cmake/dbg --check-build-system CMakeFiles/Makefile.cmake 0
make -f CMakeFiles/Makefile2 compute_tof
/work/encap/cmake-2.8.10.1+0/bin/cmake -H/home/bska/work/opm/code/cxx0x-build/opm-core-release -B/home/bska/work/opm/code/cxx0x-build/build/cmake/dbg --check-build-system CMakeFiles/Makefile.cmake 0
/work/encap/cmake-2.8.10.1+0/bin/cmake -E cmake_progress_start /home/bska/work/opm/code/cxx0x-build/build/cmake/dbg/CMakeFiles 78
make -f CMakeFiles/Makefile2 CMakeFiles/compute_tof.dir/all
make -f CMakeFiles/opmcore.dir/build.make CMakeFiles/opmcore.dir/depend
cd /home/bska/work/opm/code/cxx0x-build/build/cmake/dbg && /work/encap/cmake-2.8.10.1+0/bin/cmake -E cmake_depends "Unix Makefiles" /home/bska/work/opm/code/cxx0x-build/opm-core-release /home/bska/work/opm/code/cxx0x-build/opm-core-release /home/bska/work/opm/code/cxx0x-build/build/cmake/dbg /home/bska/work/opm/code/cxx0x-build/build/cmake/dbg /home/bska/work/opm/code/cxx0x-build/build/cmake/dbg/CMakeFiles/opmcore.dir/DependInfo.cmake --color=
make -f CMakeFiles/opmcore.dir/build.make CMakeFiles/opmcore.dir/build
make[4]: Nothing to be done for `CMakeFiles/opmcore.dir/build'.
/work/encap/cmake-2.8.10.1+0/bin/cmake -E cmake_progress_report /home/bska/work/opm/code/cxx0x-build/build/cmake/dbg/CMakeFiles  8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84
[ 98%] Built target opmcore
make -f CMakeFiles/compute_tof.dir/build.make CMakeFiles/compute_tof.dir/depend
cd /home/bska/work/opm/code/cxx0x-build/build/cmake/dbg && /work/encap/cmake-2.8.10.1+0/bin/cmake -E cmake_depends "Unix Makefiles" /home/bska/work/opm/code/cxx0x-build/opm-core-release /home/bska/work/opm/code/cxx0x-build/opm-core-release /home/bska/work/opm/code/cxx0x-build/build/cmake/dbg /home/bska/work/opm/code/cxx0x-build/build/cmake/dbg /home/bska/work/opm/code/cxx0x-build/build/cmake/dbg/CMakeFiles/compute_tof.dir/DependInfo.cmake --color=
Dependee "/home/bska/work/opm/code/cxx0x-build/build/cmake/dbg/CMakeFiles/compute_tof.dir/DependInfo.cmake" is newer than depender "/home/bska/work/opm/code/cxx0x-build/build/cmake/dbg/CMakeFiles/compute_tof.dir/depend.internal".
Dependee "/home/bska/work/opm/code/cxx0x-build/build/cmake/dbg/CMakeFiles/CMakeDirectoryInformation.cmake" is newer than depender "/home/bska/work/opm/code/cxx0x-build/build/cmake/dbg/CMakeFiles/compute_tof.dir/depend.internal".
Scanning dependencies of target compute_tof
make -f CMakeFiles/compute_tof.dir/build.make CMakeFiles/compute_tof.dir/build
/work/encap/cmake-2.8.10.1+0/bin/cmake -E cmake_progress_report /home/bska/work/opm/code/cxx0x-build/build/cmake/dbg/CMakeFiles 1
[100%] Building CXX object CMakeFiles/compute_tof.dir/examples/compute_tof.cpp.o
/usr/bin/c++   -DHAVE_CONFIG_H=1 -pipe -fopenmp -ggdb3 -Wall -g -O0 -DDEBUG -I/home/bska/work/opm/code/cxx0x-build/build/cmake/dbg -I/usr/include/suitesparse -I/work/include -I/home/bska/work/opm/code/cxx0x-build/opm-core-release    -o CMakeFiles/compute_tof.dir/examples/compute_tof.cpp.o -c /home/bska/work/opm/code/cxx0x-build/opm-core-release/examples/compute_tof.cpp
Linking CXX executable bin/compute_tof
/work/encap/cmake-2.8.10.1+0/bin/cmake -E cmake_link_script CMakeFiles/compute_tof.dir/link.txt --verbose=1
/usr/bin/c++   -pipe -fopenmp -ggdb3 -Wall -g -O0 -DDEBUG  -Wl,--as-needed   CMakeFiles/compute_tof.dir/examples/compute_tof.cpp.o  -o bin/compute_tof  -L/work/lib64 -rdynamic lib/libopmcore.a -lumfpack -lamd -llapack -lblas /work/lib64/libboost_date_time.so /work/lib64/libboost_filesystem.so /work/lib64/libboost_system.so -Wl,-rpath,/work/lib64 
/usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libumfpack.so: undefined reference to `amd_postorder'
/usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libumfpack.so: undefined reference to `amd_l_defaults'
/usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libumfpack.so: undefined reference to `amd_defaults'
/usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libumfpack.so: undefined reference to `amd_l_postorder'
/usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libumfpack.so: undefined reference to `amd_aat'
/usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libumfpack.so: undefined reference to `amd_1'
/usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libumfpack.so: undefined reference to `amd_realloc'
/usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libumfpack.so: undefined reference to `amd_valid'
/usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libumfpack.so: undefined reference to `amd_l_valid'
/usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libumfpack.so: undefined reference to `amd_malloc'
/usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libumfpack.so: undefined reference to `amd_printf'
/usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libumfpack.so: undefined reference to `amd_free'
/usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libumfpack.so: undefined reference to `amd_l_aat'
/usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libumfpack.so: undefined reference to `amd_l1'
collect2: ld returned 1 exit status
make[4]: *** [bin/compute_tof] Error 1
make[3]: *** [CMakeFiles/compute_tof.dir/all] Error 2
make[2]: *** [CMakeFiles/compute_tof.dir/rule] Error 2
make[1]: *** [compute_tof] Error 2
make: *** [__everything] Error 2
```
