### PR TITLE
Describe how to get extra packages from OPM repo

### DIFF
--- a/README
+++ b/README
@@ -99,6 +99,9 @@ sudo yum install boost-devel suitesparse-devel blas-devel lapack-devel
 # libraries necessary for OPM
 sudo yum install tinyxml-devel
 
+# optional libraries
+sudo yum-config-manager --add-repo http://opm-project.org/packages/redhat/opm.repo
+sudo yum install libsuperlu3 ert.ecl-devel dune-istl-devel
 
 DOWNLOADING
 -----------


### PR DESCRIPTION
I actually done expect this to get committed (yet), since it contains reference to the mythological URL http://opm-project.org/packages/redhat, but at least it kicks off the discussion about where to host the APEL (Arne Morten's Packages for Enterprise Linux ;-)) packages.

(If anyone has virtual machines in abundance, they can use the URL http://folk.uib.no/rka081/pkgs/rpm instead, where I have put up a snapshot I got earlier (before it was complete, you must --disable-ert))
