### PR TITLE
added: spec file for redhat packaging

### DIFF
--- a/redhat/opm-core.spec
+++ b/redhat/opm-core.spec
@@ -1,0 +1,84 @@
+#
+# spec file for package opm-core
+#
+
+Name:           opm-core
+Version:        2013.03
+Release:        0
+Summary:        Open Porous Media - core library
+License:        GPL-3.0
+Group:          Development/Libraries/C and C++
+Url:            http://www.opm-project.org/
+Source0:        %{name}-%{version}.tar.gz
+BuildRequires:  blas-devel gcc-c++ gcc-gfortran lapack-devel dune-common-devel
+BuildRequires:  boost-devel git suitesparse-devel cmake28 doxygen bc
+BuildRequires:  tinyxml-devel dune-istl-devel
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+Requires:       libopm-core1 = %{version}
+
+%description
+The Open Porous Media (OPM) initiative provides a set of open-source tools centered around the simulation of flow and transport of fluids in porous media. The goal of the initiative is to establish a sustainable environment for the development of an efficient and well-maintained software suite.
+
+%package -n libopm-core1
+Summary:        Open Porous Media - core library
+Group:          System/Libraries
+
+%description -n libopm-core1
+The Open Porous Media (OPM) initiative provides a set of open-source tools centered around the simulation of flow and transport of fluids in porous media. The goal of the initiative is to establish a sustainable environment for the development of an efficient and well-maintained software suite.
+
+%package devel
+Summary:        Development and header files for opm-core
+Group:          Development/Libraries/C and C++
+Requires:       %{name} = %{version}
+Requires:       blas-devel
+Requires:       lapack-devel
+Requires:       suitesparse-devel
+Requires:       libopm-core1 = %{version}
+BuildArch:	noarch
+
+%description devel
+This package contains the development and header files for opm-core
+
+%package doc
+Summary:        Documentation files for opm-core
+Group:          Documentation
+BuildArch:	noarch
+
+%description doc
+This package contains the documentation files for opm-core
+
+%prep
+%setup -q
+
+%build
+cmake28 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{_prefix} -DCMAKE_INSTALL_DOCDIR=share/doc/%{name}-%{version}
+make
+
+%install
+make install DESTDIR=${RPM_BUILD_ROOT}
+make install-html DESTDIR=${RPM_BUILD_ROOT}
+
+%clean
+rm -rf %{buildroot}
+
+%post -n libopm-core1 -p /sbin/ldconfig
+
+%postun -n libopm-core1 -p /sbin/ldconfig
+
+%files
+%doc COPYING README
+
+%files doc
+%{_docdir}/*
+
+%files -n libopm-core1
+%defattr(-,root,root,-)
+%{_libdir}/*.so.*
+
+%files devel
+%defattr(-,root,root,-)
+%{_libdir}/*.so
+%{_libdir}/dunecontrol/*
+%{_libdir}/pkgconfig/*
+%{_includedir}/*
+%{_datadir}/cmake/*


### PR DESCRIPTION
This adds redhat (centos) 6.x packaging for opm-core.

I had to package some predeps, the specs and patches required for those are (temporarily) available at git://github.com/akva2/APEL.git

APEL refers to roland's toungue-in-cheek 'arnes packages for enterprise linux'

the pre-steps i did in a hurry, so most of them will likely require revisiting. i don't know of any issues with the opm-core file in the pull request.

i stuck it in a directory on the top of the tree called 'redhat'. there is no strict requirement of this as there is no such thing as in-tree packaging of RPMs. as such, the file can be moved around wherever you want, including a separate repository should you prefer that.
