### PR TITLE
Check that test prog. compiled before declared found

### DIFF
--- a/cmake/Modules/OpmPackage.cmake
+++ b/cmake/Modules/OpmPackage.cmake
@@ -195,7 +195,7 @@ function (find_opm_package module deps header lib defs prog conf)
   find_package_handle_standard_args (
 	${module}
 	DEFAULT_MSG
-	${module}_INCLUDE_DIR ${_lib_var}
+	${module}_INCLUDE_DIR ${_lib_var} HAVE_${MODULE}
 	)
 
   # allow the user to override these from user interface


### PR DESCRIPTION
The previous version did the test and setting of the config variable
right, but reported that the module was found only if the files were
located, independently of the result of the compile.
