### PR TITLE
Handle ERT not found condition gracefully

### DIFF
--- a/cmake/Modules/FindERT.cmake
+++ b/cmake/Modules/FindERT.cmake
@@ -173,7 +173,10 @@ int main (void) {
 }" HAVE_ERT)
   cmake_pop_check_state ()
 else (NOT (ERT_INCLUDE_DIR MATCHES "-NOTFOUND" OR ERT_LIBRARIES MATCHES "-NOTFOUND"))
-  set (HAVE_ERT 0)
+  # write unsuccessful result to the cache, as the check_c_source_compiles
+  # would do if it failed
+  set (HAVE_ERT)
+  set (HAVE_ERT "${HAVE_ERT}" CACHE INTERNAL "Did an ERT sample program compile?")
 endif (NOT (ERT_INCLUDE_DIR MATCHES "-NOTFOUND" OR ERT_LIBRARIES MATCHES "-NOTFOUND"))
 
 # if the test program didn't compile, but was required to do so, bail


### PR DESCRIPTION
If the files for ERT is not found, then the find module cheats and
indicates that it didn't compile either (since there are some later
tests for HAVE_ERT).

However, erraneously, it gave this variable the value 0, which tests
for false in the CMake code but not in the #ifdef checks in the C++
code. This error is cancelled in opm-core by the fact that it didn't
store it as a cache variable, but resurfaced in opm-polymer when it
probes the second time (as both opm-core as a dependency and
opm-polymer itself declare a dependency on ERT).

It is now stored in a way that should be satisfactory to both
projects.
