### PR TITLE
Enable dunecontrol to use a build tree as module dir

### DIFF
--- a/cmake/Modules/DuneCompat.cmake
+++ b/cmake/Modules/DuneCompat.cmake
@@ -21,3 +21,11 @@ if (CMAKE_GENERATOR MATCHES "Unix Makefiles")
 	COMMENT "Patching Makefile to be DUNE compatible"
 	)
 endif (CMAKE_GENERATOR MATCHES "Unix Makefiles")
+
+# dunecontrol refuses to use a build tree as module directory unless
+# there is a dune.module in it
+if (NOT PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+  execute_process (COMMAND
+	${CMAKE_COMMAND} -E copy_if_different ${PROJECT_SOURCE_DIR}/dune.module ${PROJECT_BINARY_DIR}/dune.module
+	)
+endif (NOT PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)

--- a/cmake/Modules/OpmDistClean.cmake
+++ b/cmake/Modules/OpmDistClean.cmake
@@ -39,7 +39,7 @@ macro (opm_dist_clean opm)
   # only remove these files if they were actually copied
   if (NOT PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
 	list (APPEND DISTCLEAN_FILES
-	  GNUmakefile
+	  dune.module
 	  )
   endif (NOT PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
   # script to remove empty directories (can't believe this isn't included!)


### PR DESCRIPTION
dunecontrol looks for a dune.module to determine whether a directory
contains a module or not. By copying this file to the build tree, we
can use (out-of-source!) build trees in dunecontrol too.
