### PR TITLE
Require explicit enabling of experimental OpenMP support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,13 @@ include (UseFastBuilds)
 # precompiled headers
 include (UsePrecompHeaders)
 
+# optimize full if we're not doing a debug build
+include (UseOptimization)
+
+# turn on all warnings; this must be done before adding any
+# dependencies, in case they alter the list of warnings
+include (UseWarnings)
+
 # macro to set standard variables (INCLUDE_DIRS, LIBRARIES etc.)
 include (OpmFind)
 find_and_append_package_list_to (${project} ${${project}_DEPS})
@@ -93,12 +100,6 @@ include (UseOnlyNeeded)
 
 # put debug information into every executable
 include (UseDebugSymbols)
-
-# optimize full if we're not doing a debug build
-include (UseOptimization)
-
-# turn on all warnings
-include (UseWarnings)
 
 # detect if Boost is in a shared library
 include (UseDynamicBoost)

--- a/cmake/Modules/OpmDefaults.cmake
+++ b/cmake/Modules/OpmDefaults.cmake
@@ -38,6 +38,9 @@ macro (opm_defaults opm)
 	message (STATUS "Precompiled headers: disabled")
   endif(NOT PRECOMPILE_HEADERS)
 
+  # Use of OpenMP is considered experimental
+  set (USE_OPENMP_DEFAULT OFF)
+
   # if we are on a system where CMake 2.6 is the default (Hi RHEL 6!),
   # the configuration files for Boost will trip up the library paths
   # (look for /usr/lib64/lib64/ in the log) when used with FindBoost

--- a/cmake/Modules/UseOpenMP.cmake
+++ b/cmake/Modules/UseOpenMP.cmake
@@ -23,6 +23,13 @@
 
 include (AddOptions)
 macro (find_openmp opm)
+  # user code can be conservative by setting USE_OPENMP_DEFAULT
+  if (NOT DEFINED USE_OPENMP_DEFAULT)
+	set (USE_OPENMP_DEFAULT ON)
+  endif (NOT DEFINED USE_OPENMP_DEFAULT)
+  option (USE_OPENMP "Enable OpenMP for parallelization" ${USE_OPENMP_DEFAULT})
+  if (USE_OPENMP)
+
   # enabling OpenMP is supposedly enough to make the compiler link with
   # the appropriate libraries
   find_package (OpenMP ${${opm}_QUIET})
@@ -38,4 +45,16 @@ macro (find_openmp opm)
   if (CMAKE_USE_PTHREADS_INIT)
 	list (APPEND ${opm}_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
   endif (CMAKE_USE_PTHREADS_INIT)
+
+  else (USE_OPENMP)
+	message (STATUS "OpenMP: disabled")
+
+	# if we don't have OpenMP support, then don't show warnings that these
+	# pragmas are unknown
+	if (CMAKE_COMPILER_IS_GNUCXX)
+	  add_options (ALL_LANGUAGES ALL_BUILDS "-Wno-unknown-pragmas")
+	elseif (MSVC)
+	  add_options (ALL_LANGUAGES ALL_BUILDS "-wd4068")
+	endif(CMAKE_COMPILER_IS_GNUCXX)
+  endif (USE_OPENMP)
 endmacro (find_openmp opm)

--- a/configure
+++ b/configure
@@ -25,6 +25,7 @@ Optional Features:
   --disable-silent-rules  print every compilation statement as executed
   --enable-system-debug   put .debug files in global GDB debug dir
                           [default=yes if prefix=/usr, no otherwise]
+  --enable-openmp         activate experimental support for OpenMP
   --disable-option-checking  ignore unrecognized --enable/--with options
 
 Optional Packages:
@@ -87,6 +88,8 @@ prefix=/usr/local
 buildtype=Debug
 #pch_use=" -DPRECOMPILE_HEADERS:BOOL=ON"
 pch_use=
+#use_openmp=" -DUSE_OPENMP=OFF"
+use_openmp=
 #silent_rules=" -DCMAKE_VERBOSE_MAKEFILE=OFF"
 silent_rules=
 #debug_loc=" -DSYSTEM_DEBUG=OFF"
@@ -213,6 +216,10 @@ while getopts -- ":-:" optchar; do
               debug_loc=" -DSYSTEM_DEBUG=OFF"
               pkgname=""
               ;;
+            openmp)
+              use_openmp=" -DUSE_OPENMP=OFF"
+              pkgname=""
+              ;;
             agmg |\
             ert  |\
             superlu)
@@ -239,6 +246,11 @@ while getopts -- ":-:" optchar; do
           case "${kind}" in
             system-debug)
               debug_loc=" -DSYSTEM_DEBUG=ON"
+              # special flag; don't set shared/static
+              shared=""
+              ;;
+            openmp)
+              use_openmp=" -DUSE_OPENMP=ON"
               # special flag; don't set shared/static
               shared=""
               ;;
@@ -287,7 +299,7 @@ for a in "$@"; do
 done
 
 # pass everything on to CMake
-CMDLINE="env ${ENVVARS} ${CMAKE_COMMAND} \"${srcdir}\" \"-DCMAKE_INSTALL_PREFIX=$prefix\" -DCMAKE_BUILD_TYPE=${buildtype}${pch_use}${silent_rules}${debug_loc} ${FEATURES}"
+CMDLINE="env ${ENVVARS} ${CMAKE_COMMAND} \"${srcdir}\" \"-DCMAKE_INSTALL_PREFIX=$prefix\" -DCMAKE_BUILD_TYPE=${buildtype}${pch_use}${silent_rules}${debug_loc}${use_openmp} ${FEATURES}"
 echo --- calling CMake for ${project} ---
 echo ${CMDLINE}
 eval exec ${CMDLINE}


### PR DESCRIPTION
As usage of OpenMP is still experimental, the user must enable this through an option for it to be used.
