### PR TITLE
Probe explicitly for OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,12 @@ include (UseOptimization)
 # dependencies, in case they alter the list of warnings
 include (UseWarnings)
 
+### --- begin opm-core specific --- ###
+# parallel programming
+include (UseOpenMP)
+find_openmp (${project})
+### --- end opm-core specific --- ###
+
 # macro to set standard variables (INCLUDE_DIRS, LIBRARIES etc.)
 include (OpmFind)
 find_and_append_package_list_to (${project} ${${project}_DEPS})


### PR DESCRIPTION
opm-core contains code which has #pragma omp. Earlier, OpenMP was
detected as part of the probe for ERT. However, that probe got
smarter, and as a result doesn't probe for more than it needs. Thus,
we need to check for OpenMP explicitly in opm-core. (It is disabled
by default)
