### PR TITLE
Simplify setting of flag that indicates shared object

### DIFF
--- a/cmake/Modules/OpmDefaults.cmake
+++ b/cmake/Modules/OpmDefaults.cmake
@@ -10,18 +10,14 @@ macro (opm_defaults opm)
 
   # default to building a static library, but let user override
   if (DEFINED BUILD_SHARED_LIBS)
-	set (_shared_def ${BUILD_SHARED_LIBS})
+	if (BUILD_SHARED_LIBS)
+	  set (${opm}_LIBRARY_TYPE SHARED)
+	else (BUILD_SHARED_LIBS)
+	  set (${opm}_LIBRARY_TYPE STATIC)
+	endif (BUILD_SHARED_LIBS)
   else (DEFINED BUILD_SHARED_LIBS)
-	set (_shared_def OFF)
-  endif (DEFINED BUILD_SHARED_LIBS)
-  string (TOUPPER "${${opm}_NAME}" opm_UPPER)
-  string (REPLACE "-" "_" opm_UPPER "${opm_UPPER}")
-  option (BUILD_${opm_UPPER}_SHARED "Build ${${opm}_NAME} as a shared library" ${_shared_def})
-  if (BUILD_${opm_UPPER}_SHARED)
-	set (${opm}_LIBRARY_TYPE SHARED)
-  else (BUILD_${opm_UPPER}_SHARED)
 	set (${opm}_LIBRARY_TYPE STATIC)
-  endif (BUILD_${opm_UPPER}_SHARED)
+  endif (DEFINED BUILD_SHARED_LIBS)
 
   # precompile standard headers to speed up compilation
   # unfortunately, this functionality is buggy and tends to segfault at

--- a/configure
+++ b/configure
@@ -3,9 +3,6 @@
 # where is the source tree located
 srcdir=$(dirname "$0")
 
-# name of the project
-project=$(sed -n "s,^Module:[\ \t]*\([^\ \t]*\),\1,p" "${srcdir}/dune.module")
-
 # display help text
 usage () {
   cat <<EOF
@@ -279,10 +276,8 @@ for OPT in "$@"; do
               shared=""
               ;;
           esac
-          projuppr=${project^^}
-          projuppr=${projuppr/-/_}
           test -n "${shared}" && \
-          FEATURES="${FEATURES} -DBUILD_${projuppr}_SHARED:BOOL=${shared}"
+          FEATURES="${FEATURES} -DBUILD_SHARED_LIBS:BOOL=${shared}"
           ;;
         *)
           # remove everything *after* the equal sign
@@ -314,6 +309,6 @@ done
 
 # pass everything on to CMake
 CMDLINE="env ${ENVVARS} ${CMAKE_COMMAND} \"${srcdir}\" \"-DCMAKE_INSTALL_PREFIX=$prefix\" -DCMAKE_BUILD_TYPE=${buildtype}${pch_use}${silent_rules}${debug_loc}${use_openmp} ${FEATURES}"
-echo --- calling CMake for ${project} ---
+echo --- calling CMake ---
 echo ${CMDLINE}
 eval exec ${CMDLINE}


### PR DESCRIPTION
Instead of having the name of the module set for each flag, use the
available standard option. Mixing shared objects and static libraries
in the same build is not a very realistic scenario anyway.

This enables us to call configure without actually having a particular
module; the script may then be used on a group level.
