### PR TITLE
Don't search in architecture-irrelevant directories

### DIFF
--- a/cmake/Modules/FindERT.cmake
+++ b/cmake/Modules/FindERT.cmake
@@ -46,12 +46,15 @@ find_path (ERT_GEN_INCLUDE_DIR
   )
 
 # need all of these libraries
+if (CMAKE_SIZEOF_VOID_P)
+  math (EXPR _BITS "8 * ${CMAKE_SIZEOF_VOID_P}")
+endif (CMAKE_SIZEOF_VOID_P)
 find_library (ERT_LIBRARY_ECL
   NAMES "ecl"
   HINTS "${ERT_ROOT}"
   PATHS "${PROJECT_BINARY_DIR}/../ert" "${PROJECT_BINARY_DIR}/../ert-build"
         "${PROJECT_BINARY_DIR}/../ert/devel"
-  PATH_SUFFIXES "lib" "lib64" "lib32" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+  PATH_SUFFIXES "lib" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
   DOC "Path to ERT Eclipse library archive/shared object files"
   )
 find_library (ERT_LIBRARY_GEOMETRY
@@ -59,7 +62,7 @@ find_library (ERT_LIBRARY_GEOMETRY
   HINTS "${ERT_ROOT}"
   PATHS "${PROJECT_BINARY_DIR}/../ert" "${PROJECT_BINARY_DIR}/../ert-build"
         "${PROJECT_BINARY_DIR}/../ert/devel"
-  PATH_SUFFIXES "lib" "lib64" "lib32" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+  PATH_SUFFIXES "lib" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
   DOC "Path to ERT Geometry library archive/shared object files"
   )
 find_library (ERT_LIBRARY_UTIL
@@ -67,7 +70,7 @@ find_library (ERT_LIBRARY_UTIL
   HINTS "${ERT_ROOT}"
   PATHS "${PROJECT_BINARY_DIR}/../ert" "${PROJECT_BINARY_DIR}/../ert-build"
         "${PROJECT_BINARY_DIR}/../ert/devel"
-  PATH_SUFFIXES "lib" "lib64" "lib32" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+  PATH_SUFFIXES "lib" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
   DOC "Path to ERT Utilities library archive/shared object files"
   )
 # the "library" found here is actually a list of several files

--- a/cmake/Modules/FindSUPERLU.cmake
+++ b/cmake/Modules/FindSUPERLU.cmake
@@ -49,18 +49,23 @@ find_path(SUPERLU_INCLUDE_DIR
   PATH_SUFFIXES "superlu" "include/superlu" "include" "SRC"
 )
 
+# only search in architecture-relevant directory
+if (CMAKE_SIZEOF_VOID_P)
+  math (EXPR _BITS "8 * ${CMAKE_SIZEOF_VOID_P}")
+endif (CMAKE_SIZEOF_VOID_P)
+
 # look for library, only at positions given by the user
 find_library(SUPERLU_LIBRARY
   NAMES "superlu_4.3" "superlu_4.2" "superlu_4.1" "superlu_4.0" "superlu_3.1" "superlu_3.0" "superlu"
   PATHS ${SUPERLU_PREFIX} ${SUPERLU_ROOT}
-  PATH_SUFFIXES "lib" "lib32" "lib64" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+  PATH_SUFFIXES "lib" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
   NO_DEFAULT_PATH
 )
 
 # look for library files, including default paths
 find_library(SUPERLU_LIBRARY
   NAMES "superlu_4.3" "superlu_4.2" "superlu_4.1" "superlu_4.0" "superlu_3.1" "superlu_3.0" "superlu"
-  PATH_SUFFIXES "lib" "lib32" "lib64" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+  PATH_SUFFIXES "lib" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
 )
 
 # check version specific macros

--- a/cmake/Modules/FindSuiteSparse.cmake
+++ b/cmake/Modules/FindSuiteSparse.cmake
@@ -120,13 +120,18 @@ if (SuiteSparse_EVERYTHING_FOUND)
   return ()
 endif (SuiteSparse_EVERYTHING_FOUND)
 
+# only search in architecture-relevant directory
+if (CMAKE_SIZEOF_VOID_P)
+  math (EXPR _BITS "8 * ${CMAKE_SIZEOF_VOID_P}")
+endif (CMAKE_SIZEOF_VOID_P)
+
 # if SuiteSparse >= 4.0 we must also link with libsuitesparseconfig
 # assume that this is the case if we find the library; otherwise just
 # ignore it (older versions don't have a file named like this)
 find_library (config_LIBRARY
   NAMES suitesparseconfig
   PATHS ${SuiteSparse_SEARCH_PATH}
-  PATH_SUFFIXES ".libs" "lib" "lib32" "lib64" "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib/ufsparse"
+  PATH_SUFFIXES ".libs" "lib" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib/ufsparse"
   )
 if (config_LIBRARY)
   list (APPEND SuiteSparse_EXTRA_LIBS ${config_LIBRARY})
@@ -149,7 +154,7 @@ foreach (module IN LISTS SuiteSparse_MODULES)
   find_library (${MODULE}_LIBRARY
 	NAMES ${module}
 	PATHS ${SuiteSparse_SEARCH_PATH}
-	PATH_SUFFIXES "lib/.libs" "lib" "lib32" "lib64" "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib/ufsparse"
+	PATH_SUFFIXES "lib/.libs" "lib" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib/ufsparse"
 	)
   # start out by including the module itself; other dependencies will be added later
   set (${MODULE}_INCLUDE_DIRS ${${MODULE}_INCLUDE_DIR})

--- a/cmake/Modules/OpmPackage.cmake
+++ b/cmake/Modules/OpmPackage.cmake
@@ -115,11 +115,14 @@ function (find_opm_package module deps header lib defs prog conf)
 
   # some modules are all in headers
   if (NOT "${lib}" STREQUAL "")
+	if (CMAKE_SIZEOF_VOID_P)
+	  math (EXPR _BITS "8 * ${CMAKE_SIZEOF_VOID_P}")
+	endif (CMAKE_SIZEOF_VOID_P)
 	find_library (${module}_LIBRARY
 	  NAMES "${lib}"
 	  PATHS ${_guess_bin}
 	  HINTS ${${module}_DIR} ${${module}_ROOT} ${${MODULE}_ROOT} ${PkgConf_${module}_LIBRARY_DIRS}
-	  PATH_SUFFIXES "lib" "lib/.libs" ".libs" "lib32" "lib64" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+	  PATH_SUFFIXES "lib" "lib/.libs" ".libs" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
 	  )
   else (NOT "${lib}" STREQUAL "")
 	set (${module}_LIBRARY "")


### PR DESCRIPTION
If a library is present in both lib{32,64}, the wrong one may be picked since both are searched (depending on your actual architecture and luck)
