### PR TITLE
Test strings on length before content

### DIFF
--- a/cmake/Modules/DuneCompat.cmake
+++ b/cmake/Modules/DuneCompat.cmake
@@ -29,9 +29,19 @@ endif (CMAKE_GENERATOR MATCHES "Unix Makefiles")
 # source dir and most likely doesn't contain other projects) anyway,
 # i.e. we only copy if we are truly out-of-source
 string (LENGTH "${PROJECT_SOURCE_DIR}/" _src_dir_len)
-string (SUBSTRING "${PROJECT_BINARY_DIR}/" 0 ${_src_dir_len} _proj_prefix)
-if (NOT "${PROJECT_SOURCE_DIR}/" STREQUAL "${_proj_prefix}")
+string (LENGTH "${PROJECT_BINARY_DIR}/" _bin_dir_len)
+if (_src_dir_len GREATER _bin_dir_len)
+  set (_not_substring TRUE)
+else (_src_dir_len GREATER _bin_dir_len)
+  string (SUBSTRING "${PROJECT_BINARY_DIR}/" 0 ${_src_dir_len} _proj_prefix)
+  if ("${PROJECT_SOURCE_DIR}/" STREQUAL "${_proj_prefix}")
+	set (_not_substring FALSE)
+  else ("${PROJECT_SOURCE_DIR}/" STREQUAL "${_proj_prefix}")
+	set (_not_substring TRUE)
+  endif ("${PROJECT_SOURCE_DIR}/" STREQUAL "${_proj_prefix}")
+endif (_src_dir_len GREATER _bin_dir_len)
+if (_not_substring)
   execute_process (COMMAND
 	${CMAKE_COMMAND} -E copy_if_different ${PROJECT_SOURCE_DIR}/dune.module ${PROJECT_BINARY_DIR}/dune.module
 	)
-endif (NOT "${PROJECT_SOURCE_DIR}/" STREQUAL "${_proj_prefix}")
+endif (_not_substring)


### PR DESCRIPTION
A substring can of course not be longer that the full string. Also fixes
problems with CMake-versions that doesn't handle out-of-range parameters
to the SUBSTRING sub-command.
