### PR TITLE
Added integer flag to ecl_file_open: To allign with ert commit: bd542a45

### DIFF
--- a/opm/core/io/eclipse/EclipseGridParser.cpp
+++ b/opm/core/io/eclipse/EclipseGridParser.cpp
@@ -1090,7 +1090,7 @@ void EclipseGridParser::getNumericErtFields(const string& filename)
 {
 #ifdef HAVE_ERT
     // Read file
-    ecl_file_type * ecl_file = ecl_file_open(filename.c_str());
+  ecl_file_type * ecl_file = ecl_file_open(filename.c_str() , 0);
     if (ecl_file == NULL) {
         THROW("Could not open IMPORTed file " << filename);
     }


### PR DESCRIPTION
I have added a integer flag to the ert function ecl_file_open(). This was added in ert commit: 

https://github.com/Ensembles/ert/commit/bd542a45c5e72e94cbe79c8b9dd17feeace4e7b5

This PR adjusts opm-core align with the ert change.
