### PR TITLE
Dependent packages fail if opm-core uses embedded TinyXML

### DIFF
--- a/cmake/Modules/OpmPackage.cmake
+++ b/cmake/Modules/OpmPackage.cmake
@@ -136,6 +136,13 @@ macro (find_opm_package module deps header lib defs prog conf)
 	list (APPEND _deps ${_name_only})
   endforeach (_dep)
 
+  # since find_and_append_package_to is a macro, this variable have
+  # probably been overwritten (due to its common name); it is now
+  # this module's last dependency instead of the name of the module
+  # itself, so it must be restored
+  string (TOUPPER ${module} MODULE_UPPER)
+  string (REPLACE "-" "_" MODULE ${MODULE_UPPER})
+
   # compile with this option to avoid avalanche of warnings
   set (${module}_DEFINITIONS "${${module}_DEFINITIONS}")
   foreach (_def IN ITEMS ${defs})


### PR DESCRIPTION
If opm-core is built using the embedded TinyXML packages, other packages that uses Findopm-core.cmake will fail because they probe for TinyXML, but haven't been told to see the embedded directory inside the opm-core source.

Most likely fix is to take out the TinyXML-dependency from Findopm-core, but **not** from opm-core/CMakeLists.txt. Since we have an embedded version, we don't need to know whether TinyXML is found to put something in config.h; opm-core **always** has access to TinyXML.
