### PR TITLE
Version entry URL for repository

### DIFF
--- a/README
+++ b/README
@@ -100,7 +100,8 @@ sudo yum install boost-devel suitesparse-devel blas-devel lapack-devel
 sudo yum install tinyxml-devel
 
 # optional libraries
-sudo yum-config-manager --add-repo http://opm-project.org/packages/redhat/opm.repo
+sudo yum-config-manager --add-repo \
+    http://www.opm-project.org/packages/current/redhat/6/opm.repo
 sudo yum install libsuperlu3 ert.ecl-devel dune-istl-devel
 
 DOWNLOADING


### PR DESCRIPTION
Different set of packages may be necessary for various versions of the
RPM-based distros. Thus we need a way to know which one is indended to
be used (through the selection of the right url).

Also add a version number to the stem of the URL, so that later aliases
can be introduced to let one stay at previous versions.

Note that this depends on OPM/opm-web#5 to be fully functional.
