### PR TITLE
Report target architecture when configuring

### DIFF
--- a/cmake/Modules/UseSystemInfo.cmake
+++ b/cmake/Modules/UseSystemInfo.cmake
@@ -8,6 +8,9 @@ function (system_info)
   else (CMAKE_SYSTEM MATCHES "Linux")
 	message (STATUS "Operating system: ${CMAKE_SYSTEM}")
   endif (CMAKE_SYSTEM MATCHES "Linux")
+
+  target_architecture (TARGET_CPU)
+  message (STATUS "Target architecture: ${TARGET_CPU}")
 endfunction (system_info)
 
 # probe various system files that may be found
@@ -48,3 +51,120 @@ function (read_release valuename FROM filename INTO varname)
 	)
   set (${varname} "${${varname}}" PARENT_SCOPE)
 endfunction (read_release valuename FROM filename INTO varname)
+
+# the following code is adapted from commit f7467762 of the code at
+# <https://github.com/petroules/solar-cmake/blob/master/TargetArch.cmake>
+# which is Copyright (c) 2012 Petroules Corporation, and which at the
+# time of download (2013-04-07 12:30 CET) is made available with a BSD license.
+#
+# it attempts to compile a program which detects the architecture from the
+# preprocessor symbols and communicate this back to us through an error message(!)
+function (target_architecture output_var)
+  # OS X is capable of building for *several* architectures at once in
+  # the Mach-O binary, and there is a variable that tells us which those
+  # are, but they may be in any order, so they must be normalized
+  if (APPLE AND CMAKE_OSX_ARCHITECTURES)
+	# detect each of the possible candidates as a separate flag
+	set (osx_arch_list i386 x86_64)
+	foreach (osx_arch IN ITEMS ${CMAKE_OSX_ARCHITECTURES})
+	  foreach (candidate IN LISTS osx_arch_list)
+		if ("${osx_arch}" STREQUAL "${candidate}")
+		  set (osx_arch_${candidate} TRUE)
+		endif ("${osx_arch}" STREQUAL "${candidate}")
+	  endforeach (candidate)
+	endforeach (osx_arch)
+
+	# add all architectures back in normalized order
+	foreach (candidate IN LISTS osx_arch_list)
+	  if (osx_arch_${candidate})
+		list (APPEND ARCH ${candidate})
+	  endif (osx_arch_${candidate})
+	endforeach (candidate)
+
+  else (APPLE AND CMAKE_OSX_ARCHITECTURES)
+	# use the preprocessor defines to determine which target architectures
+	# that are available
+	set (arch_c_src "
+	  #if defined(__arm__) || defined(__TARGET_ARCH_ARM)
+	  #  if defined(__ARM_ARCH_7__) \\
+	     || defined(__ARM_ARCH_7A__) \\
+	     || defined(__ARM_ARCH_7R__) \\
+	     || defined(__ARM_ARCH_7M__) \\
+	     || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM-0 >= 7)
+	  #    error cmake_ARCH armv7
+	  #  elif defined(__ARM_ARCH_6__) \\
+	       || defined(__ARM_ARCH_6J__) \\
+	       || defined(__ARM_ARCH_6T2__) \\
+	       || defined(__ARM_ARCH_6Z__) \\
+	       || defined(__ARM_ARCH_6K__) \\
+	       || defined(__ARM_ARCH_6ZK__) \\
+	       || defined(__ARM_ARCH_6M__) \\
+	       || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM-0 >= 6)
+	  #    error cmake_ARCH armv6
+	  #  elif defined(__ARM_ARCH_5TEJ__) \\
+	      || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM-0 >= 5)
+	  #    error cmake_ARCH armv5
+	  #  else
+	  #    error cmake_ARCH arm
+	  #  endif
+	  #elif defined(__i386) \\
+         || defined(__i386__) \\
+         || defined(_M_IX86)
+	  #  error cmake_ARCH i386
+	  #elif defined(__x86_64) \\
+         || defined(__x86_64__) \\
+         || defined(__amd64) \\
+         || defined(_M_X64)
+	  #  error cmake_ARCH x86_64
+	  #elif defined(__ia64) \\
+         || defined(__ia64__) \\
+         || defined(_M_IA64)
+	  #  error cmake_ARCH ia64
+	  #elif defined(__ppc__) \\
+         || defined(__ppc) \\
+         || defined(__powerpc__) \\
+	     || defined(_ARCH_COM) \\
+         || defined(_ARCH_PWR) \\
+         || defined(_ARCH_PPC) \\
+	     || defined(_M_MPPC) \\
+         || defined(_M_PPC)
+	  #  if defined(__ppc64__) \\
+         || defined(__powerpc64__) \\
+         || defined(__64BIT__)
+	  #    error cmake_ARCH ppc64
+	  #  else
+	  #    error cmake_ARCH ppc
+	  #  endif
+	  #else
+	  #  error cmake_ARCH unknown
+	  #endif
+	  ")
+	
+	# write a temporary program that can be compiled to get the result
+	set (tmp_dir "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp")
+	set (arch_c "${tmp_dir}/arch.c")
+	file (WRITE "${arch_c}" "${arch_c_src}")
+	try_compile (
+	  compile_result_unused
+	  "${tmp_dir}"
+	  "${arch_c}"
+	  CMAKE_FLAGS CMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
+	  OUTPUT_VARIABLE ARCH
+	  )
+
+    # parse the architecture name from the compiler output
+    string (REGEX MATCH "cmake_ARCH ([a-zA-Z0-9_]+)" ARCH "${ARCH}")
+
+    # get rid of the value marker leaving just the architecture name
+    string (REPLACE "cmake_ARCH " "" ARCH "${ARCH}")
+
+    # if we are compiling with an unknown architecture this variable should
+    # already be set to "unknown" but in the case that it's empty (i.e. due
+    # to a typo in the code), then set it to unknown
+    if (NOT ARCH)
+      set (ARCH "unknown")
+    endif()
+  endif()
+
+  set (${output_var} "${ARCH}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
Provide extra debugging information in the configuration log; this should not affect the builds.
