### PR TITLE
Probe for library without using STL

### DIFF
--- a/cmake/Modules/Finddune-grid.cmake
+++ b/cmake/Modules/Finddune-grid.cmake
@@ -34,12 +34,9 @@ find_opm_package (
 
   # test program
 "#include <dune/grid/onedgrid.hh>
-#include <vector>
 int main (void) {
-  std::vector<Dune::OneDGrid::ctype> coords;
-  Dune::OneDGrid grid(coords);
+  Dune::OneDGrid grid(1, 0., 1.);
   return grid.lbegin<0>(0) == grid.lend<0>(0);
-  return 0;
 }
 "
   # config variables


### PR DESCRIPTION
If dune-grid has been compiled with _GLIBCXX_DEBUG, linking the test
program will fail since probing doesn't get the flags that are specified
for the main project, and thus configuration halts. Instead, we use a
smaller test program which doesn't need proper STL linkage to compile
and link.
