### PR TITLE
Dont run non unit tests

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -147,7 +147,6 @@ list (APPEND TEST_SOURCE_FILES
 	tests/test_column_extract.cpp
 	tests/test_geom2d.cpp
 	tests/test_param.cpp
-  tests/not-unit/test_newfluidinterface.cpp
 	)
 
 # originally generated with the command:


### PR DESCRIPTION
The `test_newfluidinterface.cpp` executable is currently not suitable for inclusion in the automatic test portfolio of OPM-Core.  Disable it until such time as that has been rectified.
