### PR TITLE
Disable build kluge that is no longer pertinent

### DIFF
--- a/opm/core/linalg/LinearSolverIstl.cpp
+++ b/opm/core/linalg/LinearSolverIstl.cpp
@@ -24,8 +24,6 @@
 
 #include <opm/core/linalg/LinearSolverIstl.hpp>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 // Silence compatibility warning from DUNE headers since we don't use
 // the deprecated member anyway (in this compilation unit)
 #define DUNE_COMMON_FIELDVECTOR_SIZE_IS_METHOD 1

--- a/tests/test_nonuniformtablelinear.cpp
+++ b/tests/test_nonuniformtablelinear.cpp
@@ -19,8 +19,6 @@
 */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #if defined(HAVE_DYNAMIC_BOOST_TEST)
 #define BOOST_TEST_DYN_LINK
 #endif

--- a/tests/test_uniformtablelinear.cpp
+++ b/tests/test_uniformtablelinear.cpp
@@ -18,8 +18,6 @@
 */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #if defined(HAVE_DYNAMIC_BOOST_TEST)
 #define BOOST_TEST_DYN_LINK
 #endif


### PR DESCRIPTION
The <have_boost_redef.hpp> header was introduced (commit 82369f9) as
a work-around for a particular interaction in the Autotools-based
setup of OPM-Core and the Dune core modules.  Notably, Dune's
"Enable" trick for Boost failed on some older Autoconf systems.  Now
that we're using CMake, however, that kluge is no longer needed
because we (OPM-Core) always

  #define HAVE_BOOST 1

i.e., as an explict true/false value.

Therefore, we need no longer include <have_boost_redef.hpp> .  The
header will be removed at a later time.
