### PR TITLE
Changed std::tr1 occurences to boost.

### DIFF
--- a/opm/core/io/eclipse/CornerpointChopper.hpp
+++ b/opm/core/io/eclipse/CornerpointChopper.hpp
@@ -27,7 +27,7 @@
 #include <string>
 #include <vector>
 #include <stdexcept>
-#include <tr1/memory>
+#include <boost/shared_ptr.hpp>
 
 namespace Opm
 {
@@ -253,7 +253,7 @@ namespace Opm
             }
 
             EclipseGridParser sp;
-            std::tr1::shared_ptr<SPECGRID> sg(new SPECGRID);
+            boost::shared_ptr<SPECGRID> sg(new SPECGRID);
             for (int dd = 0; dd < 3; ++dd) {
                 sg->dimensions[dd] = new_dims_[dd];
             }

--- a/opm/core/io/eclipse/EclipseGridInspector.cpp
+++ b/opm/core/io/eclipse/EclipseGridInspector.cpp
@@ -45,6 +45,7 @@
 #include <opm/core/io/eclipse/EclipseGridInspector.hpp>
 #include <opm/core/io/eclipse/EclipseGridParser.hpp>
 #include <opm/core/io/eclipse/SpecialEclipseFields.hpp>
+#include <boost/array.hpp>
 
 namespace Opm
 {
@@ -100,7 +101,7 @@ std::pair<double,double> EclipseGridInspector::cellDips(int i, int j, int k) con
     }
 
     // Pick ZCORN-value for all 8 corners of the given cell
-    std::tr1::array<double, 8> cellz = cellZvals(i, j, k);
+    boost::array<double, 8> cellz = cellZvals(i, j, k);
 
     // Compute rise in positive x-direction for all four edges (and then find mean)
     // Current implementation is for regularly placed and vertical pillars!
@@ -125,7 +126,7 @@ std::pair<double,double> EclipseGridInspector::cellDips(int i, int j, int k) con
     // don't follow an overall dip for the model if it exists.
     int x_edges = 4;
     int y_edges = 4;
-    std::tr1::array<double, 6> gridlimits = getGridLimits();
+    boost::array<double, 6> gridlimits = getGridLimits();
     double zmin = gridlimits[4];
     double zmax = gridlimits[5];
     // LLL -> HLL
@@ -169,11 +170,11 @@ std::pair<double,double> EclipseGridInspector::cellDips(int i, int j, int k) con
 */
 std::pair<double,double> EclipseGridInspector::cellDips(int cell_idx) const
 {
-    std::tr1::array<int, 3> idxs = cellIdxToLogicalCoords(cell_idx);
+    boost::array<int, 3> idxs = cellIdxToLogicalCoords(cell_idx);
     return cellDips(idxs[0], idxs[1], idxs[2]);
 }
 
-std::tr1::array<int, 3> EclipseGridInspector::cellIdxToLogicalCoords(int cell_idx) const
+boost::array<int, 3> EclipseGridInspector::cellIdxToLogicalCoords(int cell_idx) const
 {
     
     int i,j,k; // Position of cell in cell hierarchy
@@ -188,8 +189,8 @@ std::tr1::array<int, 3> EclipseGridInspector::cellIdxToLogicalCoords(int cell_id
     j = (horIdx-i)/logical_gridsize_[0]+1;
     k = ((cell_idx+1)-logical_gridsize_[0]*(j-1)-1)/(logical_gridsize_[0]*logical_gridsize_[1])+1;
 
-    std::tr1::array<int, 3> a = {{i-1, j-1, k-1}};
-    return a; //std::tr1::array<int, 3> {{i-1, j-1, k-1}};
+    boost::array<int, 3> a = {{i-1, j-1, k-1}};
+    return a; //boost::array<int, 3> {{i-1, j-1, k-1}};
 }
 
 double EclipseGridInspector::cellVolumeVerticalPillars(int i, int j, int k) const
@@ -242,7 +243,7 @@ double EclipseGridInspector::cellVolumeVerticalPillars(int i, int j, int k) cons
 
 double EclipseGridInspector::cellVolumeVerticalPillars(int cell_idx) const
 {
-    std::tr1::array<int, 3> idxs = cellIdxToLogicalCoords(cell_idx);
+    boost::array<int, 3> idxs = cellIdxToLogicalCoords(cell_idx);
     return cellVolumeVerticalPillars(idxs[0], idxs[1], idxs[2]);
 }
 
@@ -257,7 +258,7 @@ void EclipseGridInspector::checkLogicalCoords(int i, int j, int k) const
 }
 
 
-std::tr1::array<double, 6> EclipseGridInspector::getGridLimits() const
+boost::array<double, 6> EclipseGridInspector::getGridLimits() const
 {
     if (! (parser_.hasField("COORD") && parser_.hasField("ZCORN") && parser_.hasField("SPECGRID")) ) {
         throw std::runtime_error("EclipseGridInspector: Grid does not have SPECGRID, COORD, and ZCORN, can't find dimensions.");
@@ -293,7 +294,7 @@ std::tr1::array<double, 6> EclipseGridInspector::getGridLimits() const
             ymin = coord[pillarindex * 6 + 4];
     }
 
-    std::tr1::array<double, 6> gridlimits = {{ xmin, xmax, ymin, ymax,
+    boost::array<double, 6> gridlimits = {{ xmin, xmax, ymin, ymax,
                                             *min_element(zcorn.begin(), zcorn.end()),
                                             *max_element(zcorn.begin(), zcorn.end()) }};
     return gridlimits;
@@ -301,16 +302,16 @@ std::tr1::array<double, 6> EclipseGridInspector::getGridLimits() const
 
 
 
-std::tr1::array<int, 3> EclipseGridInspector::gridSize() const
+boost::array<int, 3> EclipseGridInspector::gridSize() const
 {
-    std::tr1::array<int, 3> retval = {{ logical_gridsize_[0],
+    boost::array<int, 3> retval = {{ logical_gridsize_[0],
 				     logical_gridsize_[1],
 				     logical_gridsize_[2] }};
     return retval;
 }
 
 
-std::tr1::array<double, 8> EclipseGridInspector::cellZvals(int i, int j, int k) const
+boost::array<double, 8> EclipseGridInspector::cellZvals(int i, int j, int k) const
 {
     // Get the zcorn field.
     const std::vector<double>& z = parser_.getFloatingPointValue("ZCORN");
@@ -324,7 +325,7 @@ std::tr1::array<double, 8> EclipseGridInspector::cellZvals(int i, int j, int k) 
 		     2*logical_gridsize_[0],
 		     4*logical_gridsize_[0]*logical_gridsize_[1] };
     int ix = 2*(i*delta[0] + j*delta[1] + k*delta[2]);
-    std::tr1::array<double, 8> cellz = {{ z[ix], z[ix + delta[0]],
+    boost::array<double, 8> cellz = {{ z[ix], z[ix + delta[0]],
 				       z[ix + delta[1]], z[ix + delta[1] + delta[0]],
 				       z[ix + delta[2]], z[ix + delta[2] + delta[0]],
 				       z[ix + delta[2] + delta[1]], z[ix + delta[2] + delta[1] + delta[0]] }};

--- a/opm/core/io/eclipse/EclipseGridInspector.hpp
+++ b/opm/core/io/eclipse/EclipseGridInspector.hpp
@@ -36,7 +36,7 @@
 #define OPM_ECLIPSEGRIDINSPECTOR_HEADER
 
 #include <vector>
-#include <tr1/array>
+#include <boost/array.hpp>
 
 
 namespace Opm
@@ -76,22 +76,22 @@ public:
     std::pair<double,double> cellDips(int cell_idx) const;
 
     // Convert global cell index to logical ijk-coordinates
-    std::tr1::array<int, 3> cellIdxToLogicalCoords(int cell_idx) const;
+    boost::array<int, 3> cellIdxToLogicalCoords(int cell_idx) const;
     
     /// Returns a vector with the outer limits of grid (in the grid's unit).
     /// The vector contains [xmin, xmax, ymin, ymax, zmin, zmax], as 
     /// read from COORDS and ZCORN
-    std::tr1::array<double, 6> getGridLimits() const;
+    boost::array<double, 6> getGridLimits() const;
 
     /// Returns the extent of the logical cartesian grid
     /// as number of cells in the (i, j, k) directions.
-    std::tr1::array<int, 3> gridSize() const;
+    boost::array<int, 3> gridSize() const;
 
     /// Returns the eight z-values associated with a given cell.
     /// The ordering is such that i runs fastest. That is, with
     /// L = low and H = high:
     /// {LLL, HLL, LHL, HHL, LLH, HLH, LHH, HHH }.
-    std::tr1::array<double, 8> cellZvals(int i, int j, int k) const;
+    boost::array<double, 8> cellZvals(int i, int j, int k) const;
 
 private:
     const EclipseGridParser& parser_;

--- a/opm/core/io/eclipse/EclipseGridParser.cpp
+++ b/opm/core/io/eclipse/EclipseGridParser.cpp
@@ -710,7 +710,7 @@ const std::vector<double>& EclipseGridParser::getFloatingPointValue(const std::s
 
 
 //---------------------------------------------------------------------------
-const std::tr1::shared_ptr<SpecialBase> EclipseGridParser::getSpecialValue(const std::string& keyword) const
+const boost::shared_ptr<SpecialBase> EclipseGridParser::getSpecialValue(const std::string& keyword) const
 //---------------------------------------------------------------------------
 {
     SpecialMap::const_iterator it = special_field_by_epoch_[current_epoch_].find(keyword);
@@ -722,13 +722,13 @@ const std::tr1::shared_ptr<SpecialBase> EclipseGridParser::getSpecialValue(const
 }
 
 //---------------------------------------------------------------------------
-std::tr1::shared_ptr<SpecialBase>
+boost::shared_ptr<SpecialBase>
 EclipseGridParser::createSpecialField(std::istream& is,
                                       const std::string& fieldname)
 //---------------------------------------------------------------------------
 {
     string ukey = upcase(fieldname);
-    std::tr1::shared_ptr<SpecialBase> spec_ptr
+    boost::shared_ptr<SpecialBase> spec_ptr
         = Factory<SpecialBase>::createObject(fieldname);
     is >> ignoreWhitespace;
     spec_ptr->read(is);
@@ -736,13 +736,13 @@ EclipseGridParser::createSpecialField(std::istream& is,
 }
 
 //---------------------------------------------------------------------------
-std::tr1::shared_ptr<SpecialBase>
+boost::shared_ptr<SpecialBase>
 EclipseGridParser::cloneSpecialField(const std::string& fieldname,
-                                     const std::tr1::shared_ptr<SpecialBase> original)
+                                     const boost::shared_ptr<SpecialBase> original)
 //---------------------------------------------------------------------------
 {
     string ukey = upcase(fieldname);
-    std::tr1::shared_ptr<SpecialBase> spec_ptr
+    boost::shared_ptr<SpecialBase> spec_ptr
         = Factory<SpecialBase>::cloneObject(fieldname, original);
     return spec_ptr;
 }
@@ -766,7 +766,7 @@ void EclipseGridParser::setFloatingPointField(const std::string& keyword,
 
 //---------------------------------------------------------------------------
 void EclipseGridParser::setSpecialField(const std::string& keyword,
-                                        std::tr1::shared_ptr<SpecialBase> field)
+                                        boost::shared_ptr<SpecialBase> field)
 //---------------------------------------------------------------------------
 {
     special_field_by_epoch_[current_epoch_][keyword] = field;

--- a/opm/core/io/eclipse/EclipseGridParser.hpp
+++ b/opm/core/io/eclipse/EclipseGridParser.hpp
@@ -40,7 +40,7 @@
 #include <vector>
 #include <map>
 #include <set>
-#include <tr1/memory>
+#include <boost/shared_ptr.hpp>
 #include <opm/core/io/eclipse/SpecialEclipseFields.hpp>
 #include <opm/core/io/eclipse/EclipseUnits.hpp>
 #include <opm/core/utility/Factory.hpp>
@@ -138,7 +138,7 @@ namespace Opm
     /// corresponding to the given floating-point keyword.
     const std::vector<double>& getFloatingPointValue(const std::string& keyword) const;
 
-    typedef std::tr1::shared_ptr<SpecialBase> SpecialFieldPtr;
+    typedef boost::shared_ptr<SpecialBase> SpecialFieldPtr;
 
     /// Returns a reference to a vector containing pointers to the values 
     /// corresponding to the given keyword when the values are not only integers
@@ -244,7 +244,7 @@ private:
 
     SpecialFieldPtr createSpecialField(std::istream& is, const std::string& fieldname);
     SpecialFieldPtr cloneSpecialField(const std::string& fieldname,
-                                      const std::tr1::shared_ptr<SpecialBase> original);
+                                      const boost::shared_ptr<SpecialBase> original);
     void readImpl(std::istream& is);
     void getNumericErtFields(const std::string& filename);
 

--- a/opm/core/io/vtk/writeVtkData.cpp
+++ b/opm/core/io/vtk/writeVtkData.cpp
@@ -35,8 +35,8 @@
 namespace Opm
 {
 
-    void writeVtkData(const std::tr1::array<int, 3>& dims,
-                      const std::tr1::array<double, 3>& cell_size,
+    void writeVtkData(const boost::array<int, 3>& dims,
+                      const boost::array<double, 3>& cell_size,
                       const DataMap& data,
                       std::ostream& os)
     {

--- a/opm/core/io/vtk/writeVtkData.hpp
+++ b/opm/core/io/vtk/writeVtkData.hpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <map>
 #include <vector>
-#include <tr1/array>
+#include <boost/array.hpp>
 #include <iosfwd>
 #include <opm/core/utility/DataMap.hpp>
 
@@ -34,8 +34,8 @@ namespace Opm
 {
 
     /// Vtk output for cartesian grids.
-    void writeVtkData(const std::tr1::array<int, 3>& dims,
-                      const std::tr1::array<double, 3>& cell_size,
+    void writeVtkData(const boost::array<int, 3>& dims,
+                      const boost::array<double, 3>& cell_size,
                       const DataMap& data,
                       std::ostream& os);
 

--- a/opm/core/linalg/LinearSolverFactory.hpp
+++ b/opm/core/linalg/LinearSolverFactory.hpp
@@ -22,7 +22,7 @@
 
 
 #include <opm/core/linalg/LinearSolverInterface.hpp>
-#include <tr1/memory>
+#include <boost/shared_ptr.hpp>
 
 namespace Opm
 {
@@ -87,7 +87,7 @@ namespace Opm
         virtual double getTolerance() const;
 
     private:
-        std::tr1::shared_ptr<LinearSolverInterface> solver_;
+        boost::shared_ptr<LinearSolverInterface> solver_;
     };
 
 

--- a/opm/core/props/pvt/BlackoilPvtProperties.hpp
+++ b/opm/core/props/pvt/BlackoilPvtProperties.hpp
@@ -26,7 +26,7 @@
 #include <opm/core/props/BlackoilPhases.hpp>
 #include <opm/core/io/eclipse/EclipseGridParser.hpp>
 #include <string>
-#include <tr1/memory>
+#include <boost/shared_ptr.hpp>
 
 namespace Opm
 {
@@ -116,7 +116,7 @@ namespace Opm
 
         int region_number_;
 
-        std::vector<std::tr1::shared_ptr<SinglePvtInterface> > props_;
+        std::vector<boost::shared_ptr<SinglePvtInterface> > props_;
 
         double densities_[MaxNumPhases];
         mutable std::vector<double> data1_;

--- a/opm/core/props/pvt/PvtPropertiesIncompFromDeck.hpp
+++ b/opm/core/props/pvt/PvtPropertiesIncompFromDeck.hpp
@@ -22,7 +22,7 @@
 
 
 #include <opm/core/io/eclipse/EclipseGridParser.hpp>
-#include <tr1/array>
+#include <boost/array.hpp>
 
 namespace Opm
 {
@@ -64,9 +64,9 @@ namespace Opm
         const double* viscosity() const;
 
     private:
-        std::tr1::array<double, 2> surface_density_;
-        std::tr1::array<double, 2> reservoir_density_;
-        std::tr1::array<double, 2> viscosity_;
+        boost::array<double, 2> surface_density_;
+        boost::array<double, 2> reservoir_density_;
+        boost::array<double, 2> viscosity_;
     };
 
 }

--- a/opm/core/props/rock/RockFromDeck.cpp
+++ b/opm/core/props/rock/RockFromDeck.cpp
@@ -21,7 +21,7 @@
 #include "config.h"
 #include <opm/core/props/rock/RockFromDeck.hpp>
 #include <opm/core/grid.h>
-#include <tr1/array>
+#include <boost/array.hpp>
 
 namespace Opm
 {
@@ -32,11 +32,11 @@ namespace Opm
         enum PermeabilityKind { ScalarPerm, DiagonalPerm, TensorPerm, None, Invalid };
 
         PermeabilityKind classifyPermeability(const EclipseGridParser& parser);
-        void setScalarPermIfNeeded(std::tr1::array<int,9>& kmap,
+        void setScalarPermIfNeeded(boost::array<int,9>& kmap,
                                    int i, int j, int k);
         PermeabilityKind fillTensor(const EclipseGridParser&                 parser,
                                     std::vector<const std::vector<double>*>& tensor,
-                                    std::tr1::array<int,9>&                     kmap);
+                                    boost::array<int,9>&                     kmap);
     } // anonymous namespace
 
 
@@ -99,7 +99,7 @@ namespace Opm
         const std::vector<double> zero(num_global_cells, 0.0);
         tensor.push_back(&zero);
 
-        std::tr1::array<int,9> kmap;
+        boost::array<int,9> kmap;
         PermeabilityKind pkind = fillTensor(parser, tensor, kmap);
         if (pkind == Invalid) {
             THROW("Invalid permeability field.");
@@ -225,7 +225,7 @@ namespace Opm
         /// @param [in] i
         /// @param [in] j
         /// @param [in] k
-        void setScalarPermIfNeeded(std::tr1::array<int,9>& kmap,
+        void setScalarPermIfNeeded(boost::array<int,9>& kmap,
                                    int i, int j, int k)
         {
             if (kmap[j] == 0) { kmap[j] = kmap[i]; }
@@ -267,7 +267,7 @@ namespace Opm
         /// @param [out] kmap
         PermeabilityKind fillTensor(const EclipseGridParser&                 parser,
                                     std::vector<const std::vector<double>*>& tensor,
-                                    std::tr1::array<int,9>&                     kmap)
+                                    boost::array<int,9>&                     kmap)
         {
             PermeabilityKind kind = classifyPermeability(parser);
             if (kind == Invalid) {

--- a/opm/core/utility/Average.hpp
+++ b/opm/core/utility/Average.hpp
@@ -38,7 +38,7 @@
 
 
 #include <boost/static_assert.hpp>
-#include <tr1/type_traits>
+#include <boost/type_traits.hpp>
 #include <cmath>
 
 namespace Opm {
@@ -53,7 +53,7 @@ namespace Opm {
 	{
 	    // To avoid some user errors, we disallow taking averages of
 	    // integral values.
-	    BOOST_STATIC_ASSERT(std::tr1::is_integral<T>::value == false);
+	    BOOST_STATIC_ASSERT(boost::is_integral<T>::value == false);
 	    Tresult retval(t1);
 	    retval += t2;
 	    retval *= 0.5;
@@ -71,7 +71,7 @@ namespace Opm {
 	{
 	    // To avoid some user errors, we disallow taking averages of
 	    // integral values.
-	    BOOST_STATIC_ASSERT(std::tr1::is_integral<T>::value == false);
+	    BOOST_STATIC_ASSERT(boost::is_integral<T>::value == false);
 	    return std::sqrt(t1*t2);
 	}
 
@@ -84,7 +84,7 @@ namespace Opm {
 	{
 	    // To avoid some user errors, we disallow taking averages of
 	    // integral values.
-	    BOOST_STATIC_ASSERT(std::tr1::is_integral<T>::value == false);
+	    BOOST_STATIC_ASSERT(boost::is_integral<T>::value == false);
 	    return (2*t1*t2)/(t1 + t2);
 	}
 

--- a/opm/core/utility/Factory.hpp
+++ b/opm/core/utility/Factory.hpp
@@ -36,7 +36,7 @@
 #define OPM_FACTORY_HEADER
 
 #include <map>
-#include <tr1/memory>
+#include <boost/shared_ptr.hpp>
 
 namespace Opm
 {
@@ -52,7 +52,7 @@ namespace Opm
     {
     public:
         /// The type of pointer returned by createObject().
-        typedef std::tr1::shared_ptr<Base> ProductPtr;
+        typedef boost::shared_ptr<Base> ProductPtr;
 
         /// Creates a new object of the class associated with the given type string,
         /// and returns a pointer to it.
@@ -128,7 +128,7 @@ namespace Opm
             }
         };
 
-        typedef std::tr1::shared_ptr<Creator> CreatorPtr;
+        typedef boost::shared_ptr<Creator> CreatorPtr;
         typedef std::map<std::string, CreatorPtr> CreatorMap;
         // This map contains the whole factory, i.e. all the Creators.
         CreatorMap string_to_creator_;

--- a/opm/core/utility/parameters/ParameterGroup.cpp
+++ b/opm/core/utility/parameters/ParameterGroup.cpp
@@ -42,6 +42,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <boost/shared_ptr.hpp>
 
 #include <opm/core/utility/parameters/Parameter.hpp>
 #include <opm/core/utility/parameters/ParameterStrings.hpp>
@@ -172,7 +173,7 @@ namespace Opm {
 	}
 
 	void ParameterGroup::insert(const std::string& name,
-				    const std::tr1::shared_ptr<ParameterMapItem>& data)
+				    const boost::shared_ptr<ParameterMapItem>& data)
         {
 	    std::pair<std::string, std::string> name_path = split(name);
 	    map_type::const_iterator it = map_.find(name_path.first);
@@ -213,10 +214,10 @@ namespace Opm {
 	    map_type::const_iterator it = map_.find(name_path.first);
 	    if (it == map_.end()) {
 		if (name_path.second == "") {
-		    std::tr1::shared_ptr<ParameterMapItem> data(new Parameter(value, ID_param_type__cmdline));
+		    boost::shared_ptr<ParameterMapItem> data(new Parameter(value, ID_param_type__cmdline));
 		    map_[name_path.first] = data;
 		} else {
-		    std::tr1::shared_ptr<ParameterMapItem> data(new ParameterGroup(this->path() + ID_delimiter_path + name_path.first,
+		    boost::shared_ptr<ParameterMapItem> data(new ParameterGroup(this->path() + ID_delimiter_path + name_path.first,
 										   this));
 		    ParameterGroup& child = dynamic_cast<ParameterGroup&>(*data);
 		    child.insertParameter(name_path.second, value);
@@ -234,7 +235,7 @@ namespace Opm {
 			      << ID_xmltag__param
 			      << " element.\n";
 		}
-		std::tr1::shared_ptr<ParameterMapItem> data(new Parameter(value, ID_param_type__cmdline));
+		boost::shared_ptr<ParameterMapItem> data(new Parameter(value, ID_param_type__cmdline));
 		map_[name_path.first] = data;
 	    } else {
 		ParameterGroup& pg = dynamic_cast<ParameterGroup&>(*(*it).second);

--- a/opm/core/utility/parameters/ParameterGroup.hpp
+++ b/opm/core/utility/parameters/ParameterGroup.hpp
@@ -40,8 +40,7 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <tr1/memory>
-
+#include <boost/shared_ptr.hpp>
 #include <opm/core/utility/parameters/ParameterMapItem.hpp>
 #include <opm/core/utility/parameters/ParameterRequirement.hpp>
 
@@ -263,13 +262,13 @@ namespace Opm {
 
             /// Insert a new item into the group.
 	    void insert(const std::string& name,
-                        const std::tr1::shared_ptr<ParameterMapItem>& data);
+                        const boost::shared_ptr<ParameterMapItem>& data);
 
             /// Insert a new parameter item into the group.
 	    void insertParameter(const std::string& name, const std::string& value);
 
 	private:
-	    typedef std::tr1::shared_ptr<ParameterMapItem> data_type;
+	    typedef boost::shared_ptr<ParameterMapItem> data_type;
 	    typedef std::pair<std::string, data_type> pair_type;
 	    typedef std::map<std::string, data_type> map_type;
 

--- a/opm/core/utility/parameters/ParameterXML.cpp
+++ b/opm/core/utility/parameters/ParameterXML.cpp
@@ -44,6 +44,7 @@
 #include <iostream>
 #include <string>
 #include <boost/filesystem.hpp>
+#include <boost/shared_ptr.hpp>
 
 
 #include <opm/core/utility/parameters/tinyxml/tinyxml.h>
@@ -104,7 +105,7 @@ namespace Opm {
 			    continue;
 			}
 			std::string name = getProperty(ID_xmlatt__name, elem);
-			std::tr1::shared_ptr<ParameterMapItem> data;
+			boost::shared_ptr<ParameterMapItem> data;
 			if (tag_name == ID_xmltag__param) {
 			    std::string value = getProperty(ID_xmlatt__value, elem);
 			    std::string type = getProperty(ID_xmlatt__type, elem);

--- a/opm/core/wells/WellCollection.cpp
+++ b/opm/core/wells/WellCollection.cpp
@@ -19,6 +19,7 @@
 
 #include "config.h"
 #include <opm/core/wells/WellCollection.hpp>
+#include <boost/shared_ptr.hpp>
 
 namespace Opm
 {
@@ -32,7 +33,7 @@ namespace Opm
             roots_.push_back(createWellsGroup(parent_name, deck));
             parent = roots_[roots_.size() - 1].get();
         }
-        std::tr1::shared_ptr<WellsGroupInterface> child;
+        boost::shared_ptr<WellsGroupInterface> child;
 
         for (size_t i = 0; i < roots_.size(); ++i) {
             if (roots_[i]->name() == child_name) {
@@ -98,7 +99,7 @@ namespace Opm
     /// \param[in] child   the child node
     /// \param[in] parent  name of parent node
 
-    void WellCollection::addChild(std::tr1::shared_ptr<WellsGroupInterface>& child_node,
+    void WellCollection::addChild(boost::shared_ptr<WellsGroupInterface>& child_node,
                                   const std::string& parent_name)
     {
         WellsGroupInterface* parent = findNode(parent_name);
@@ -115,7 +116,7 @@ namespace Opm
 
     /// Adds the node to the collection (as a root node)
 
-    void WellCollection::addChild(std::tr1::shared_ptr<WellsGroupInterface>& child_node)
+    void WellCollection::addChild(boost::shared_ptr<WellsGroupInterface>& child_node)
     {
         roots_.push_back(child_node);
         if (child_node->isLeafNode()) {

--- a/opm/core/wells/WellCollection.hpp
+++ b/opm/core/wells/WellCollection.hpp
@@ -26,6 +26,7 @@
 #include <opm/core/wells/WellsGroup.hpp>
 #include <opm/core/grid.h>
 #include <opm/core/io/eclipse/EclipseGridParser.hpp>
+#include <boost/shared_ptr.hpp>
 
 namespace Opm
 {
@@ -47,11 +48,11 @@ namespace Opm
         /// and appends it to parent's children.
         /// \param[in] child   the child node
         /// \param[in] parent  name of parent node
-        void addChild(std::tr1::shared_ptr<WellsGroupInterface>& child_node,
+        void addChild(boost::shared_ptr<WellsGroupInterface>& child_node,
                       const std::string& parent);
         
         /// Adds the node to the collection (as a root node)
-        void addChild(std::tr1::shared_ptr<WellsGroupInterface>& child_node);
+        void addChild(boost::shared_ptr<WellsGroupInterface>& child_node);
 
         /// Checks if each condition is met, applies well controls where needed
         /// (that is, it either changes the active control of violating wells, or shuts
@@ -112,7 +113,7 @@ namespace Opm
         
     private:
         // To account for the possibility of a forest
-        std::vector<std::tr1::shared_ptr<WellsGroupInterface> > roots_;
+        std::vector<boost::shared_ptr<WellsGroupInterface> > roots_;
         
         // This will be used to traverse the bottom nodes.
         std::vector<WellNode*> leaf_nodes_;

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -401,7 +401,7 @@ namespace Opm
         return true;
     }
 
-    void WellsGroup::addChild(std::tr1::shared_ptr<WellsGroupInterface> child)
+    void WellsGroup::addChild(boost::shared_ptr<WellsGroupInterface> child)
     {
         children_.push_back(child);
     }
@@ -1041,12 +1041,12 @@ namespace Opm
         }
     } // anonymous namespace
 
-    std::tr1::shared_ptr<WellsGroupInterface> createWellsGroup(const std::string& name,
+    boost::shared_ptr<WellsGroupInterface> createWellsGroup(const std::string& name,
                                                                const EclipseGridParser& deck)
     {
         PhaseUsage phase_usage = phaseUsageFromDeck(deck);
 
-        std::tr1::shared_ptr<WellsGroupInterface> return_value;
+        boost::shared_ptr<WellsGroupInterface> return_value;
         // First we need to determine whether it's a group or just a well:
         bool isWell = false;
         if (deck.hasField("WELSPECS")) {

--- a/opm/core/wells/WellsGroup.hpp
+++ b/opm/core/wells/WellsGroup.hpp
@@ -26,7 +26,7 @@
 #include <opm/core/grid.h>
 #include <opm/core/props/BlackoilPhases.hpp>
 #include <string>
-
+#include <boost/shared_ptr.hpp>
 
 namespace Opm
 {
@@ -232,7 +232,7 @@ namespace Opm
 
         virtual WellsGroupInterface* findGroup(const std::string& name_of_node);
 
-        void addChild(std::tr1::shared_ptr<WellsGroupInterface> child);
+        void addChild(boost::shared_ptr<WellsGroupInterface> child);
         
         virtual bool conditionsMet(const std::vector<double>& well_bhp,
                                    const std::vector<double>& well_reservoirrates_phase,
@@ -301,7 +301,7 @@ namespace Opm
                                                       const std::vector<double>& well_surfacerates_phase);
 
     private:
-        std::vector<std::tr1::shared_ptr<WellsGroupInterface> > children_;
+        std::vector<boost::shared_ptr<WellsGroupInterface> > children_;
     };
 
 
@@ -402,7 +402,7 @@ namespace Opm
     /// Creates the WellsGroupInterface for the given name
     /// \param[in] name the name of the wells group.
     /// \param[in] deck the deck from which to fetch information.
-    std::tr1::shared_ptr<WellsGroupInterface> createWellsGroup(const std::string& name, 
+    boost::shared_ptr<WellsGroupInterface> createWellsGroup(const std::string& name, 
                                                                const EclipseGridParser& deck);
 
 

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -27,7 +27,7 @@
 #include <opm/core/wells/WellCollection.hpp>
 #include <opm/core/props/phaseUsageFromDeck.hpp>
 
-#include <tr1/array>
+#include <boost/array.hpp>
 #include <algorithm>
 #include <cassert>
 #include <cmath>
@@ -141,10 +141,10 @@ namespace
     } // namespace InjectionControl
 
 
-    std::tr1::array<double, 3> getCubeDim(const UnstructuredGrid& grid, int cell)
+    boost::array<double, 3> getCubeDim(const UnstructuredGrid& grid, int cell)
     {
         using namespace std;
-        tr1::array<double, 3> cube;
+        boost::array<double, 3> cube;
         int num_local_faces = grid.cell_facepos[cell + 1] - grid.cell_facepos[cell];
         vector<double> x(num_local_faces);
         vector<double> y(num_local_faces);
@@ -169,7 +169,7 @@ namespace
     // cell_permeability is the permeability tensor of the given cell.
     // returns the well index of the cell.
     double computeWellIndex(const double radius,
-                            const std::tr1::array<double, 3>& cubical,
+                            const boost::array<double, 3>& cubical,
                             const double* cell_permeability,
                             const double skin_factor)
     {
@@ -386,7 +386,7 @@ namespace Opm
                                 radius = 0.5*unit::feet;
                                 MESSAGE("**** Warning: Well bore internal radius set to " << radius);
                             }
-                            std::tr1::array<double, 3> cubical = getCubeDim(grid, cell);
+                            boost::array<double, 3> cubical = getCubeDim(grid, cell);
                             const double* cell_perm = &permeability[grid.dimensions*grid.dimensions*cell];
                             pd.well_index = computeWellIndex(radius, cubical, cell_perm,
                                                              compdat.compdat[kw].skin_factor_);

--- a/tests/not-unit/test_writeVtkData.cpp
+++ b/tests/not-unit/test_writeVtkData.cpp
@@ -20,11 +20,12 @@
 #include "config.h"
 #include <opm/core/utility/writeVtkData.hpp>
 #include <fstream>
+#include <boost/array.hpp>
 
 int main()
 {
-    std::tr1::array<int, 3> dims = {{ 2, 2, 2 }};
-    std::tr1::array<double, 3> cell_size = {{ 1.0, 2.0, 3.0 }};
+    boost::array<int, 3> dims = {{ 2, 2, 2 }};
+    boost::array<double, 3> cell_size = {{ 1.0, 2.0, 3.0 }};
     Opm::DataMap m;
     double foov[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
     std::vector<double> foo(foov, foov + sizeof foov/sizeof foov[0]);

--- a/tests/test_blackoilfluid.cpp
+++ b/tests/test_blackoilfluid.cpp
@@ -19,6 +19,7 @@
 #define BOOST_TEST_MODULE BlackoilFluidTest
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
+#include <boost/shared_ptr.hpp>
 #include <iostream>
 #include <iterator>
 #include <vector>
@@ -37,7 +38,7 @@ BOOST_AUTO_TEST_CASE(test_blackoilfluid)
     const EclipseGridParser deck (filename);
 
     // setup pvt interface
-    std::vector<std::tr1::shared_ptr<SinglePvtInterface> > props_;
+    std::vector<boost::shared_ptr<SinglePvtInterface> > props_;
     PhaseUsage phase_usage_ = phaseUsageFromDeck(deck);
     enum PhaseIndex { Aqua = 0, Liquid = 1, Vapour = 2 };
     int samples = 0;

--- a/tutorials/tutorial4.cpp
+++ b/tutorials/tutorial4.cpp
@@ -264,7 +264,7 @@ int main ()
     ///          what the interface expects. The first argument is the (unique) name of the group.
     /// \snippet tutorial4.cpp injection specification
     /// \internal[injection specification]
-    std::tr1::shared_ptr<WellsGroupInterface> well_group(new WellsGroup("group", well_group_prod_spec, InjectionSpecification(), 
+    boost::shared_ptr<WellsGroupInterface> well_group(new WellsGroup("group", well_group_prod_spec, InjectionSpecification(), 
                                                                         phase_usage));
     /// \internal[injection specification]
     /// \endinternal
@@ -289,7 +289,7 @@ int main ()
         well_name << "well" << i;
         ProductionSpecification production_specification;
         production_specification.control_mode_ = ProductionSpecification::GRUP;
-        std::tr1::shared_ptr<WellsGroupInterface> well_leaf_node(new WellNode(well_name.str(), production_specification, InjectionSpecification(), 
+        boost::shared_ptr<WellsGroupInterface> well_leaf_node(new WellNode(well_name.str(), production_specification, InjectionSpecification(), 
                                                                               phase_usage));
         well_collection.addChild(well_leaf_node, "group");
         


### PR DESCRIPTION
std::tr1 might not be supported by all compilers and will eventually
be dropped by others. Using boost instead makes this more
portable.

Pull requests for the other modules will follow shortly.
