### PR TITLE
Zero-initialize structure to avoid returning undefined

### DIFF
--- a/opm/core/linalg/LinearSolverUmfpack.cpp
+++ b/opm/core/linalg/LinearSolverUmfpack.cpp
@@ -56,7 +56,7 @@ namespace Opm
             const_cast<double*>(sa)
         };
         call_UMFPACK(&A, rhs, solution);
-        LinearSolverReport rep;
+        LinearSolverReport rep = {0};
         rep.converged = true;
         return rep;
     }


### PR DESCRIPTION
The compiler will otherwise complain that we are returning undefined
data. There is no way for the client code to know whether this was
the case.

See OPM/opm-core#275
