### PR TITLE
Fixes setting the verbosity for AGMG.

### DIFF
--- a/opm/core/linalg/LinearSolverAGMG.cpp
+++ b/opm/core/linalg/LinearSolverAGMG.cpp
@@ -124,7 +124,7 @@ namespace Opm
             nrest = 10;         // Suggested default number of GCR restarts.
         }
 
-        int iprint = linsolver_verbosity_;         // Suppress most output
+        int iprint = linsolver_verbosity_?6:-1;         // Suppress most output
         DAGMG_(& size, & a[0], & j[0], & i[0], rhs, solution,
                & ijob, & iprint, & nrest, & rpt.iterations, & rtol_);
 


### PR DESCRIPTION
The iprint parameter of AGMG indicates unit number where to print information to. Previously the ISTL verbosity numbers were used which resulted in odd behaviour.

With this patch the following holds:
If verbosity is true, we set the iprint parameter such that the
output is print to standard out. If not, we use a negative number
such that only error messages are printed to standard out.
