### PR TITLE
Probe again later if ERT isn't found now

### DIFF
--- a/cmake/Modules/FindERT.cmake
+++ b/cmake/Modules/FindERT.cmake
@@ -108,10 +108,11 @@ if (ERT_INCLUDE_DIR MATCHES "-NOTFOUND" OR ERT_LIBRARIES MATCHES "-NOTFOUND")
 	DEFAULT_MSG
 	ERT_INCLUDE_DIR ERT_LIBRARY
 	)
-  # write unsuccessful result to the cache, as the check_c_source_compiles
-  # would do if it failed
+  # clear the cache so the find probe is attempted again if files becomes
+  # available (only upon a unsuccessful *compile* should we disable further
+  # probing)
   set (HAVE_ERT)
-  set (HAVE_ERT "${HAVE_ERT}" CACHE INTERNAL "Did an ERT sample program compile?")
+  unset (HAVE_ERT CACHE)
   return ()
 endif (ERT_INCLUDE_DIR MATCHES "-NOTFOUND" OR ERT_LIBRARIES MATCHES "-NOTFOUND")
 
@@ -204,10 +205,11 @@ int main (void) {
 }" HAVE_ERT)
   cmake_pop_check_state ()
 else (NOT (ERT_INCLUDE_DIR MATCHES "-NOTFOUND" OR ERT_LIBRARIES MATCHES "-NOTFOUND"))
-  # write unsuccessful result to the cache, as the check_c_source_compiles
-  # would do if it failed
+  # clear the cache so the find probe is attempted again if files becomes
+  # available (only upon a unsuccessful *compile* should we disable further
+  # probing)
   set (HAVE_ERT)
-  set (HAVE_ERT "${HAVE_ERT}" CACHE INTERNAL "Did an ERT sample program compile?")
+  unset (HAVE_ERT CACHE)
 endif (NOT (ERT_INCLUDE_DIR MATCHES "-NOTFOUND" OR ERT_LIBRARIES MATCHES "-NOTFOUND"))
 
 # if the test program didn't compile, but was required to do so, bail


### PR DESCRIPTION
If we write a blank value into the cache, we tell CMake that ERT isn't
found and it won't check again. If we delete it from the cache in case
we didn't find the directories, then CMake will run the find module
again the next time we configure. Just probing for directories is cheap
so this is no problem. This allows us to install ERT, do a reconfigure
and it will then be picked up by the build system.

If we find ERT and it doesn't compile properly, a blank value will still
be written, and it won't try again the next time, so you must wipe the
cache if you _upgrade_ ERT into a newer and more compatible version.

A longer explanation is outlined in OPM/opm-core#279.

This pull request supersedes OPM/opm-core#280.
