### PR TITLE
Add find module for opm-verteq to build system

### DIFF
--- a/cmake/Modules/Findopm-verteq.cmake
+++ b/cmake/Modules/Findopm-verteq.cmake
@@ -11,16 +11,15 @@
 # This code is licensed under The GNU General Public License v3.0
 
 # use the generic find routine
+include (opm-verteq-prereqs)
 include (OpmPackage)
 find_opm_package (
   # module name
   "opm-verteq"
 
   # dependencies
-  "CXX11Features;
-  Boost 1.39.0
-    COMPONENTS system unit_test_framework REQUIRED;
-  "
+  "${opm-verteq_DEPS}"
+
   # header to search for
   "opm/verteq/verteq.hpp"
 


### PR DESCRIPTION
These patches are only of interest for (future) clients of opm-verteq, but submitted here so that this can be the canonical repository. (However, it is debatable if the find modules have any value, since we always install -config.cmake modules). Sorry that the patch is divided in two; that is to avoid a merge on my part.
