### PR TITLE
Recognize Clang to be a GCC-compatible compiler

### DIFF
--- a/cmake/Modules/OpmDefaults.cmake
+++ b/cmake/Modules/OpmDefaults.cmake
@@ -1,6 +1,7 @@
 # - Default settings for the build
 
 include (UseCompVer)
+is_compiler_gcc_compatible ()
 include(TestCXXAcceptsFlag)
 
 macro (opm_defaults opm)
@@ -9,12 +10,12 @@ macro (opm_defaults opm)
   # distribution should disable this option.
   option (USE_RUNPATH "Embed original dependency paths in installed library" ON)
   if (USE_RUNPATH)
-	if (CMAKE_COMPILER_IS_GNUCXX)
+	if (CXX_COMPAT_GCC)
 	  check_cxx_accepts_flag ("-Wl,--enable-new-dtags" HAVE_RUNPATH)
 	  if (HAVE_RUNPATH)
 		list (APPEND ${opm}_LINKER_FLAGS "-Wl,--enable-new-dtags")
 	  endif (HAVE_RUNPATH)
-	endif (CMAKE_COMPILER_IS_GNUCXX)
+	endif ()
 	# set this to avoid CMake stripping it off again
 	set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
   endif (USE_RUNPATH)
@@ -38,12 +39,7 @@ macro (opm_defaults opm)
   # precompile standard headers to speed up compilation
   # unfortunately, this functionality is buggy and tends to segfault at
   # least up to version 4.7.2, so it should be disabled by default there
-  get_gcc_version (CXX GCC_VERSION)
-  if (GCC_VERSION VERSION_LESS "4.7.2")
-	set (_precomp_def OFF)
-  else (GCC_VERSION VERSION_LESS "4.7.2")
-	set (_precomp_def ON)
-  endif (GCC_VERSION VERSION_LESS "4.7.2")
+  set (_precomp_def OFF)
   option (PRECOMPILE_HEADERS "Precompile common headers for speed." ${_precomp_def})
   mark_as_advanced (PRECOMPILE_HEADERS)
   if (NOT PRECOMPILE_HEADERS)

--- a/cmake/Modules/UseCompVer.cmake
+++ b/cmake/Modules/UseCompVer.cmake
@@ -76,3 +76,33 @@ function (linker_info)
   get_ld_version (version)
   message (STATUS "Linker: ${version}")
 endfunction (linker_info)
+
+# sets CXX_COMPAT_GCC if we have either GCC or Clang
+macro (is_compiler_gcc_compatible)
+  # is the C++ compiler clang++?
+  string (TOUPPER "${CMAKE_CXX_COMPILER_ID}" _comp_id)
+  if (_comp_id MATCHES "CLANG")
+	set (CMAKE_COMPILER_IS_CLANGXX TRUE)
+  else ()
+	set (CMAKE_COMPILER_IS_CLANGXX FALSE)
+  endif ()
+  # is the C++ compiler g++ or clang++?
+  if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX)
+	set (CXX_COMPAT_GCC TRUE)
+  else ()
+	set (CXX_COMPAT_GCC FALSE)
+  endif ()
+  # is the C compiler clang?
+  string (TOUPPER "${CMAKE_C_COMPILER_ID}" _comp_id)
+  if (_comp_id MATCHES "CLANG")
+	set (CMAKE_COMPILER_IS_CLANG TRUE)
+  else ()
+	set (CMAKE_COMPILER_IS_CLANG FALSE)
+  endif ()
+  # is the C compiler gcc or clang?
+  if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
+	set (C_COMPAT_GCC TRUE)
+  else ()
+	set (C_COMPAT_GCC FALSE)
+  endif ()
+endmacro (is_compiler_gcc_compatible)

--- a/cmake/Modules/UseDebugSymbols.cmake
+++ b/cmake/Modules/UseDebugSymbols.cmake
@@ -10,9 +10,11 @@
 # This code is licensed under The GNU General Public License v3.0
 
 include (AddOptions)
+include (UseCompVer)
+is_compiler_gcc_compatible ()
 
 # only debugging using the GNU toolchain is supported for now
-if (CMAKE_COMPILER_IS_GNUCXX)
+if (CXX_COMPAT_GCC)
   # default debug level, if not specified by the user
   set_default_option (_dbg_flag "-ggdb3" "(^|\ )-g")
 
@@ -37,13 +39,13 @@ if (CMAKE_COMPILER_IS_GNUCXX)
   else (OBJCOPY)
 	message (WARNING "Looking for strip utility - not found")
   endif (OBJCOPY)
-endif (CMAKE_COMPILER_IS_GNUCXX)
+endif ()
 
 # command to separate the debug information from the executable into
 # its own file; this must be called for each target; optionally takes
 # the name of a variable to receive the list of .debug files
 function (strip_debug_symbols targets)
-  if (CMAKE_COMPILER_IS_GNUCXX AND OBJCOPY)
+  if (CXX_COMPAT_GCC AND OBJCOPY)
 	foreach (target IN LISTS targets)
 	  # libraries must retain the symbols in order to link to them, but
 	  # everything can be stripped in an executable
@@ -97,6 +99,6 @@ function (strip_debug_symbols targets)
 	if (ARGV1)
 	  set (${ARGV1} ${_debug_files} PARENT_SCOPE)
 	endif (ARGV1)
-  endif (CMAKE_COMPILER_IS_GNUCXX AND OBJCOPY)
+  endif ()
 endfunction (strip_debug_symbols targets)
 

--- a/cmake/Modules/UseFastBuilds.cmake
+++ b/cmake/Modules/UseFastBuilds.cmake
@@ -2,7 +2,10 @@
 
 # faster builds by using a pipe instead of temp files
 include (AddOptions)
-if (CMAKE_COMPILER_IS_GNUCXX)
+include (UseCompVer)
+is_compiler_gcc_compatible ()
+
+if (CXX_COMPAT_GCC)
 	add_options (ALL_LANGUAGES ALL_BUILDS "-pipe")
-endif (CMAKE_COMPILER_IS_GNUCXX)
+endif ()
 

--- a/cmake/Modules/UseOpenMP.cmake
+++ b/cmake/Modules/UseOpenMP.cmake
@@ -22,6 +22,9 @@
 #	remove_dup_deps (opm-core)
 
 include (AddOptions)
+include (UseCompVer)
+is_compiler_gcc_compatible ()
+
 macro (find_openmp opm)
   # default is that OpenMP is not considered to be there; if we set this
   # to a blank definition, it may be added but it cannot be removed if
@@ -58,10 +61,10 @@ macro (find_openmp opm)
 
 	# if we don't have OpenMP support, then don't show warnings that these
 	# pragmas are unknown
-	if (CMAKE_COMPILER_IS_GNUCXX)
+	if (CXX_COMPAT_GCC)
 	  add_options (ALL_LANGUAGES ALL_BUILDS "-Wno-unknown-pragmas")
 	elseif (MSVC)
 	  add_options (ALL_LANGUAGES ALL_BUILDS "-wd4068")
-	endif(CMAKE_COMPILER_IS_GNUCXX)
+	endif()
   endif (USE_OPENMP)
 endmacro (find_openmp opm)

--- a/cmake/Modules/UseOptimization.cmake
+++ b/cmake/Modules/UseOptimization.cmake
@@ -2,6 +2,8 @@
 
 include(TestCXXAcceptsFlag)
 include (AddOptions)
+include (UseCompVer)
+is_compiler_gcc_compatible ()
 
 # mapping from profile name (in CMAKE_BUILD_TYPE) to variable part
 set (_prof_DEBUG "Debug")
@@ -11,7 +13,7 @@ set (_prof_RELEASE "Release;RelWithDebInfo;MinSizeRel")
 # otherwise, turn them on. indicate to the code what we have done
 # so it can turn on assertions etc.
 
-if (CMAKE_COMPILER_IS_GNUCXX)
+if (CXX_COMPAT_GCC)
   # extra flags passed for optimization
   set (_opt_flags "")
 
@@ -44,7 +46,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
   # use these options for release builds - full optimization
   add_options (ALL_LANGUAGES "${_prof_RELEASE}" ${_opt_rel} "-DNDEBUG" ${_opt_flags})
 
-else (CMAKE_COMPILER_IS_GNUCXX)
+else ()
   # default information from system
   foreach (lang IN ITEMS C CXX Fortran)
 	if (lang STREQUAL "Fortran")
@@ -59,4 +61,4 @@ else (CMAKE_COMPILER_IS_GNUCXX)
 	  endif (NOT CMAKE_${lang}_FLAGS_${profile})
 	endforeach (profile)
   endforeach (lang)
-endif (CMAKE_COMPILER_IS_GNUCXX)
+endif ()

--- a/cmake/Modules/UseWarnings.cmake
+++ b/cmake/Modules/UseWarnings.cmake
@@ -1,11 +1,14 @@
 # - Turn on warnings when compiling
 
 include (AddOptions)
-if (CMAKE_COMPILER_IS_GNUCXX)
+include (UseCompVer)
+is_compiler_gcc_compatible ()
+
+if (CXX_COMPAT_GCC)
   # default warnings flags, if not set by user
   set_default_option (_warn_flag "-Wall" "(^|\ )-W")
   if (_warn_flag)
 	message (STATUS "All warnings enabled: ${_warn_flag}")
 	add_options (ALL_LANGUAGES ALL_BUILDS "${_warn_flag}")
   endif (_warn_flag)
-endif (CMAKE_COMPILER_IS_GNUCXX)
+endif ()


### PR DESCRIPTION
Clang aims to be compatible with GCC when it comes to command-line
parameters. Where we enable functionality based on the presence of
a GCC-compiler, we can use the same functionality with Clang.

This patch introduces a new variable CXX_COMPAT_GCC which is true if
the compiler handles the same options as GCC, and this variable is
subsequently used in tests instead of CMAKE_COMPILER_IS_GNUCXX (which
remains if we need to test if we really have GCC, e.g. for version)
