### PR TITLE
Build system: make it work for modules which do not need libraries

### DIFF
--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -91,7 +91,7 @@ find_and_append_package_list_to (${project} ${${project}_DEPS})
 
 # remove the dependency on the testing framework from the main library;
 # it is not possible to query for Boost twice with different components.
-list (REMOVE_ITEM ${project}_LIBRARIES ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+list (REMOVE_ITEM "${project}_LIBRARIES" "${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}")
 
 # don't import more libraries than we need to
 include (UseOnlyNeeded)


### PR DESCRIPTION
this adds some missing quotes which are only required if the Boost_UNIT_TEST_FRAMEWORK_LIBRARY variable happens to be empty.
