### PR TITLE
Find module for opm-material

### DIFF
--- a/cmake/Modules/Findopm-material.cmake
+++ b/cmake/Modules/Findopm-material.cmake
@@ -11,15 +11,15 @@
 # This code is licensed under The GNU General Public License v3.0
 
 # use the generic find routine
+include (opm-material-prereqs)
 include (OpmPackage)
 find_opm_package (
   # module name
   "opm-material"
 
   # dependencies
-  "C99;
-  CXX11Features
-  "
+  "${opm-material_DEPS}"
+
   # header to search for
   "opm/material/constants.hh"
 
@@ -37,8 +37,7 @@ int main (void) {
 }
 "
   # config variables
-  "HAVE_MPI;
-  HAVE_VALGRIND
-  ")
+  "${opm-material_CONFIG_VAR}"
+  )
 include (UseDynamicBoost)
 #debug_find_vars ("opm-material")

--- a/cmake/Modules/opm-material-prereqs.cmake
+++ b/cmake/Modules/opm-material-prereqs.cmake
@@ -1,0 +1,31 @@
+# -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t; compile-command: "cmake -Wdev" -*-
+# vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
+
+# defines that must be present in config.h for our headers
+set (opm-material_CONFIG_VAR
+	HAVE_NULLPTR
+	HAVE_ARRAY
+	HAVE_ATTRIBUTE_ALWAYS_INLINE
+	HAS_ATTRIBUTE_UNUSED
+	HAS_ATTRIBUTE_DEPRECATED
+	HAS_ATTRIBUTE_DEPRECATED_MSG
+	HAVE_CONSTEXPR
+	HAVE_INTEGRAL_CONSTANT
+	HAVE_STATIC_ASSERT
+	HAVE_VARIADIC_TEMPLATES
+	HAVE_VARIADIC_CONSTRUCTOR_SFINAE
+	HAVE_RVALUE_REFERENCES
+	HAVE_TUPLE
+	HAVE_TR1_TUPLE
+	)
+
+# dependencies
+set (opm-material_DEPS
+	# compile with C99 support if available
+	"C99"
+	# compile with C++0x/11 support if available
+	"CXX11Features REQUIRED"
+	# DUNE dependency
+	"dune-common"
+	"dune-istl"
+	)


### PR DESCRIPTION
This should be needed in opm-porsol (if you don't have a standard directory structure). Should have no impact on opm-core itself.
