### PR TITLE
OPM Porsol now depends on OPM Material

### DIFF
--- a/cmake/Modules/opm-porsol-prereqs.cmake
+++ b/cmake/Modules/opm-porsol-prereqs.cmake
@@ -21,5 +21,6 @@ set (opm-porsol_DEPS
 	dune-istl REQUIRED;
 	dune-grid REQUIRED;
 	opm-core REQUIRED;
+	opm-material REQUIRED;
 	dune-cornerpoint REQUIRED"
 	)


### PR DESCRIPTION
In the new build scheme, the prerequisites of each module is declared
in this file as the canonical version, and everything else includes it.
