### PR TITLE
Publicly depend on version of dune-grid

### DIFF
--- a/cmake/Modules/dune-cornerpoint-prereqs.cmake
+++ b/cmake/Modules/dune-cornerpoint-prereqs.cmake
@@ -4,6 +4,9 @@
 # defines that must be present in config.h for our headers
 set (dune-cornerpoint_CONFIG_VAR
 	HAVE_DYNAMIC_BOOST_TEST
+	DUNE_GRID_VERSION_MAJOR
+	DUNE_GRID_VERSION_MINOR
+	DUNE_GRID_VERSION_REVISION
 	)
 
 # dependencies


### PR DESCRIPTION
The interface of the class PersistentContainer changed between DUNE
2.2 and DUNE 2.3 in an incompatible way, so we need to present
different versions of the class depending on the version of DUNE linked
with. This changeset adds the version variables for dune-grid to the
list of publicly necessary #defines that must go into using
dune-cornerpoint.

Notice that this will cause the definition of DUNE_GRID_VERSION_XXX
to be added to the flags list of dune-cornerpoint. This can be seen as
either a bug or a feature. If you try to link first dune-cornerpoint to
one version and then to another version of DUNE later, there is a very
good chance that you'll end up with problems anyway.
