### PR TITLE
Don't search for disabled packages

### DIFF
--- a/cmake/Modules/OpmFind.cmake
+++ b/cmake/Modules/OpmFind.cmake
@@ -129,18 +129,24 @@ macro (find_and_append_package_to prefix name)
 	unset (${name}_DIR CACHE)
   endif ((NOT (_${name}_exempted EQUAL -1)) AND (DEFINED ${name}_DIR))
 
-  # using config mode is better than using module (aka. find) mode
-  # because then the package has already done all its probes and
-  # stored them in the config file for us
-  if (NOT ${NAME}_FOUND)
-	if (${name}_DIR)
-	  message (STATUS "Finding package ${name} using config mode")
-	  find_package (${name} ${ARGN} NO_MODULE PATHS ${${name}_DIR} NO_DEFAULT_PATH)
-	else (${name}_DIR)
-	  message (STATUS "Finding package ${name} using module mode")
-	  find_package (${name} ${ARGN})
-	endif (${name}_DIR)
-  endif (NOT ${NAME}_FOUND)
+  # if we're told not to look for the package, pretend it was never found
+  if (CMAKE_DISABLE_FIND_PACKAGE_${name})
+	set (${name}_FOUND FALSE)
+	set (${NAME}_FOUND FALSE)
+  else ()
+	# using config mode is better than using module (aka. find) mode
+	# because then the package has already done all its probes and
+	# stored them in the config file for us
+	if (NOT (${name}_FOUND OR ${NAME}_FOUND))
+	  if (${name}_DIR)
+		message (STATUS "Finding package ${name} using config mode")
+		find_package (${name} ${ARGN} NO_MODULE PATHS ${${name}_DIR} NO_DEFAULT_PATH)
+	  else (${name}_DIR)
+		message (STATUS "Finding package ${name} using module mode")
+		find_package (${name} ${ARGN})
+	  endif (${name}_DIR)
+	endif (NOT (${name}_FOUND OR ${NAME}_FOUND))
+  endif (CMAKE_DISABLE_FIND_PACKAGE_${name})
 
   # the variable "NAME" may be replaced during find_package (as this is
   # now a macro, and not a function anymore), so we must reinitialize


### PR DESCRIPTION
Setting CMAKE_DISABLE_FIND_PACKAGE_xxx flag should make find_package
not doing anything, but this does not seem to work with older versions
of CMake. Anyway, we can test this flag and make sure that we don't
call find_package in that case.

Also includes a check for both upper- and same-case versions of found
flag, as some modules, most notably Boost, does not set the upper-case
version of their _FOUND flag; this tests for both.

This is already tested in opm/opm-porsol#63 (they compare binary equal), so I guess it could just be rubber-stamped.
