### PR TITLE
Issue a CMake warning if client project is incompatible

### DIFF
--- a/cmake/Modules/ConfigVars.cmake
+++ b/cmake/Modules/ConfigVars.cmake
@@ -75,6 +75,14 @@ function (configure_vars obj syntax filename verb)
 	  set (_prev_verbatim TRUE)
 	  
 	else ("${_var}" MATCHES "^/[/*]")
+
+	  # write a CMake statements that warns if the value has changed
+	  if ("${syntax}" STREQUAL "CMAKE")
+		set (_db "\${") # to avoid parsing problems
+		file (APPEND "${filename}" "if (DEFINED ${_var} AND NOT \"${_db}${_var}}\" STREQUAL \"${${_var}}\")\n")
+		file (APPEND "${filename}" "\tmessage (WARNING \"Incompatible value \\\"${_db}${_var}}\\\" of variable \\\"${_var}\\\"\")\n")
+		file (APPEND "${filename}" "endif ()\n")
+	  endif ()
 	  
 	  # check for empty variable; variables that are explicitly set to false
 	  # is not included in this clause


### PR DESCRIPTION
This puts a test into the ${project}-config.cmake file which warns
if the client project is built with a variable which is incompatible
with the build of opm-core.

Consider this minimal project:

```
cmake_minimum_required (VERSION 2.8)
set (HAVE_MPI 1)
find_package (opm-core)
```

If linked with `-Dopm-core_DIR=` path to an opm-core tree which is
build _without_ MPI-support, this will issue a warning when building
the client project.

This doesn't catch all cases (if a variable isn't defined, we cannot
know if it is an omission or if it has intentionally been left blank),
but at least it catches some.
