### PR TITLE
Simplify creation of Fortran function wrappers

### DIFF
--- a/cmake/Modules/UseFortranWrappers.cmake
+++ b/cmake/Modules/UseFortranWrappers.cmake
@@ -39,6 +39,16 @@ function (define_fc_func verb file)
   # the interaction -- don't load the Fortran compiler just to write
   # this macro (which apparently nobody uses then)
   if (needed)
+	# if this option is enabled, we skip detecting the Fortran externals
+	# using a real compiler (which may not be the same that compiled the
+	# library) and just write a macro that uses a single underscore (which
+	# is the assumption that FindLAPACK operates on anyway)
+	option (USE_UNDERSCORING "Assume that Fortran routines have underscore suffix" OFF)
+	if (USE_UNDERSCORING)
+	  message (STATUS "Assuming Fortran externals have underscore suffix")
+	  set (_str "#define FC_FUNC(name,NAME) name##_\n")
+	else (USE_UNDERSCORING)
+
 	# enable languages needed
 	if (NOT CMAKE_C_COMPILER_LOADED)
 	  enable_language (C)
@@ -64,6 +74,8 @@ function (define_fc_func verb file)
 
 	# massage it to look like the one AC_FC_WRAPPERS provide
 	string (REPLACE "FortranCInterface_GLOBAL" "FC_FUNC" _str ${_str})
+
+	endif (USE_UNDERSCORING)
 
 	# write this definition to the end of our own configuration file
 	file (${verb} ${file}

--- a/cmake/Scripts/configure
+++ b/cmake/Scripts/configure
@@ -30,7 +30,9 @@ Optional Features:
   --enable-parallel       process in parallel using MPI [default=no]
   --enable-openmp         activate experimental support for OpenMP
   --disable-option-checking  ignore unrecognized --enable/--with options
+  --enable-underscoring   assume Fortran routines have _ suffix [default=no]
   --enable-ninja          use Ninja build generator [default=no]
+                          (automatically implies --enable-underscoring)
 
 Optional Packages:
   --with-alugrid=PATH     use the ALUGrid library from a specified location
@@ -116,6 +118,8 @@ use_tests=
 use_samples=
 #use_ninja="-G\"Unix Makefiles\" "
 use_ninja=
+#use_underscoring=" -DUSE_UNDERSCORING=OFF"
+use_underscoring=
 
 # default is to warn for unknown options, but this can be disabled
 option_check=yes
@@ -348,7 +352,14 @@ for OPT in "$@"; do
               use_samples=" -DBUILD_EXAMPLES=ON"
               pkgname=""
               ;;
+            underscoring)
+              use_underscoring=" -DUSE_UNDERSCORING=ON"
+              pkgname=""
+              ;;
             ninja)
+              # Ninja doesn't support using the Fortran compiler, so
+              # we'll have to resort to making this assumption
+              use_underscoring=" -DUSE_UNDERSCORING=ON"
               use_ninja="-GNinja "
               pkgname=""
               ;;
@@ -400,7 +411,7 @@ for a in "${VARS[@]}"; do
 done
 
 # pass everything on to CMake
-CMDLINE="env ${ENVVARS} ${CMAKE_COMMAND} \"${srcdir}\" ${use_ninja}\"-DCMAKE_INSTALL_PREFIX=$prefix\"${buildtype}${pch_use}${silent_rules}${debug_loc}${use_openmp}${use_mpi}${use_lto}${use_runpath}${use_tests}${use_samples} ${FEATURES}"
+CMDLINE="env ${ENVVARS} ${CMAKE_COMMAND} \"${srcdir}\" ${use_ninja}\"-DCMAKE_INSTALL_PREFIX=$prefix\"${buildtype}${pch_use}${silent_rules}${debug_loc}${use_openmp}${use_mpi}${use_lto}${use_runpath}${use_tests}${use_samples}${use_underscoring} ${FEATURES}"
 echo --- calling CMake ---
 echo ${CMDLINE}
 eval exec ${CMDLINE}


### PR DESCRIPTION
The old version invoked a Fortran compiler to figure out the bindings necessary to link to a Fortran function. This creates a dependency on having a Fortran compiler, even though the project may not have any Fortran source it needs to compile!

Also, the Fortran compiler that is installed on the system may not be the same as was used to compile the library anyway, so we are not even sure that this is correct!

Furthermore, FindLAPACK operates on the assumption that names in that library is suffixed with a single underscore, so if that is not correct, we won't find any of the functions in that library anyway!

Thus, this patch enables us to assume that appending an underscore is the right thing to do without using the compiler. This option is on by default, since this is the most common case. In case we compile on a
platform where this is _not_ the case, we can set the option `USE_FORTRAN_UNDERSCORE=OFF` which will trigger more elaborate detection.

This enables us to build opm-upscaling without having a Fortran compiler installed (and consider that there is no LLVM Fortran compiler for the foreseeable future).
