### PR TITLE
Remove subdirectory from SuiteSparse include

### DIFF
--- a/opm/core/linalg/call_umfpack.c
+++ b/opm/core/linalg/call_umfpack.c
@@ -37,7 +37,7 @@
 #include <assert.h>
 #include <stdlib.h>
 
-#include <suitesparse/umfpack.h>
+#include <umfpack.h>
 
 #include <opm/core/linalg/sparse_sys.h>
 #include <opm/core/linalg/call_umfpack.h>


### PR DESCRIPTION
SuiteSparse may or may not be installed in a suitesparse/ directory.

FindSuiteSparse will look in a suitesparse/ subdirectory when trying to locate umfpack.h, but it will add the full directory to the compiler command-line (e.g. `-I/usr/include/suitesparse`) and not that of the parent. Since the parent is usually included too, it is not noticed that it is advertedly using another include paths than its own.

However, if we have SuiteSparse installed in a non-system location, using the subdirectory in the `#include` statement may now cause an error, even though configuration actually found SuiteSparse!
