### PR TITLE
Mark known feature variables as used

### DIFF
--- a/cmake/Modules/OpmKnown.cmake
+++ b/cmake/Modules/OpmKnown.cmake
@@ -1,6 +1,13 @@
 # -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t; compile-command: "cmake -Wdev" -*-
 # vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
 
+# features that may be used by some packages (Fortran wrappers
+# for instance), and this set options for, but which is included
+# conditionally and thus does not exist in other packages
+set (FEATURE_VARS
+	USE_UNDERSCORING
+	)
+
 # emulate the with-xxx feature of autotools to not give warnings
 # if we specify the directories of packages that are known to the
 # family but not necessarily used
@@ -45,3 +52,7 @@ foreach (family IN ITEMS ${KNOWN_FAMILIES})
 		endforeach (var)
 	endforeach (package)
 endforeach (family)
+
+foreach (feature IN ITEMS ${FEATURE_VARS})
+	set (_dummy ${${feature}})
+endforeach (feature)


### PR DESCRIPTION
Some features, such as the Fortran wrappers, are enabled by options, and it may be usable to have those set in a common definition file.

However, as these features are included conditionally based on use, their option variables may not exist in other projects, giving a CMake warning for them.

Here we list such variables too. Reading them at the end corresponds to the Autotools convention of ignoring unknown --enable-xxx options.

This should really have been a part of #330, but wasn't discovered before due to insufficient across-the-board-testing.
