### PR TITLE
add opm-material to the eWoms prerequisites

### DIFF
--- a/cmake/Modules/ewoms-prereqs.cmake
+++ b/cmake/Modules/ewoms-prereqs.cmake
@@ -17,6 +17,7 @@ set (ewoms_DEPS
 	"dune-geometry REQUIRED"
 	"dune-grid REQUIRED"
 	"dune-istl REQUIRED"
+	"opm-material REQUIRED"
 	# valgrind client requests
 	"Valgrind"
 	# quadruple precision floating point calculations


### PR DESCRIPTION
this is needed by the imminent switch of eWoms to the OPM build
system.
