### PR TITLE
Allow build tree of SuiteSparse to be used as root

### DIFF
--- a/cmake/Modules/FindSuiteSparse.cmake
+++ b/cmake/Modules/FindSuiteSparse.cmake
@@ -161,13 +161,13 @@ foreach (module IN LISTS SuiteSparse_MODULES)
   find_path (${MODULE}_INCLUDE_DIR
 	NAMES ${module}.h
 	PATHS ${SuiteSparse_SEARCH_PATH}
-	PATH_SUFFIXES "include" "include/suitesparse" "include/ufsparse"
+	PATH_SUFFIXES "include" "include/suitesparse" "include/ufsparse" "${MODULE}/Include"
 	${_no_default_path}
 	)
   find_library (${MODULE}_LIBRARY
 	NAMES ${module}
 	PATHS ${SuiteSparse_SEARCH_PATH}
-	PATH_SUFFIXES "lib/.libs" "lib" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib/ufsparse"
+	PATH_SUFFIXES "lib/.libs" "lib" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib/ufsparse" "${MODULE}/Lib"
 	${_no_default_path}
 	)
   # start out by including the module itself; other dependencies will be added later


### PR DESCRIPTION
I almost forgot about this; it grew out of the discussion in #340: With this changeset, the build tree of SuiteSparse can be used as the root; the package does not have to be installed.

As it justs adds some extra paths to the directory to be searched it will not affect any current builds (that was already able to find SuiteSparse). And now I really want to get the rollup out. Thus, unless someone register any objections I am going to unceremoneously and unilaterally commit this at 2013-08-27 09:00 CEST.
