### PR TITLE
Extracts the full compiler path and feeds it to cmake.

### DIFF
--- a/cmake/Scripts/configure
+++ b/cmake/Scripts/configure
@@ -145,7 +145,7 @@ VARS=()
 
 # command that launches cmake; look for 2.8 if available
 if [ "${CMAKE_COMMAND}" = "" ]; then
-  if which cmake28 >/dev/null 2>&1; then
+  if test -n "$(command -v cmake28)"; then
     CMAKE_COMMAND=cmake28
   else
     CMAKE_COMMAND=cmake


### PR DESCRIPTION
Previously, specifying the compiler name with a variable
to configure ("configure CC=gcc") lead to CMake complaining
that <builddir>/$CC was not a valid path. This patch fixes
this by extracting the full path with "which <compiler>".
Should fix issue #355.
