### PR TITLE
C++-11 Features: add test for std::is_integral

### DIFF
--- a/cmake/Modules/FindCXX11Features.cmake
+++ b/cmake/Modules/FindCXX11Features.cmake
@@ -77,6 +77,7 @@ int main()
 {
     bool foo = std::is_convertible<int, double>::value;
     bool bar = std::is_base_of<Base, Derived>::value;
+    bool foobar = std::is_integral<double>::value;
     return 0;
 }
 "  HAVE_TYPE_TRAITS


### PR DESCRIPTION
also require the availability of std::is_integral from `type_traits`.

@rolk Once this is merged, do you want to percolate this patch to the other modules yourself or shall I do this? (I intend to push it directly so that spam people won't get spammed by PRs...)
