### PR TITLE
require opm-core from the opm-material module

### DIFF
--- a/cmake/Modules/opm-material-prereqs.cmake
+++ b/cmake/Modules/opm-material-prereqs.cmake
@@ -13,6 +13,8 @@ set (opm-material_DEPS
 	"C99"
 	# compile with C++0x/11 support if available
 	"CXX11Features REQUIRED"
+	# prerequisite OPM modules
+	"opm-core REQUIRED"
 	# DUNE dependency
 	"dune-common REQUIRED"
 	"dune-istl REQUIRED"


### PR DESCRIPTION
this is required to use the exception code of opm-core in
opm-material. Also, the Dune prerequisites of opm-material can be
removed once PR #345 is merged into opm-core...

Once this is in, I will push this change to all other OPM modules (if nobody objects).
