### PR TITLE
Reduce likelihood of shadowing symbols in OPM_THROW

### DIFF
--- a/opm/core/utility/ErrorMacros.hpp
+++ b/opm/core/utility/ErrorMacros.hpp
@@ -48,12 +48,12 @@
 // std::runtime_error.
 //
 // Usage: OPM_THROW(ExceptionClass, "Error message " << value);
-#define OPM_THROW(Exception, message)                            \
+#define OPM_THROW(Exception, message)                                   \
     do {                                                                \
-        std::ostringstream oss;                                         \
-        oss << "[" << __FILE__ << ":" << __LINE__ << "] " << message;   \
+        std::ostringstream oss__;                                       \
+        oss__ << "[" << __FILE__ << ":" << __LINE__ << "] " << message; \
         OPM_MESSAGE(message);                                           \
-        throw Exception(oss.str());                                     \
+        throw Exception(oss__.str());                                   \
     } while (false)
 
 // throw an exception if a condition is true


### PR DESCRIPTION
The OPM_THROW macro uses an internal symbol, `oss`, which is, strictly
speaking, in the client's namespace.  Moreover, as the
`EclipseGridParseHelpers.hpp` header uses the same symbol, and for
similar purposes, this produces warnings at `-Wshadow` in GCC when
compiling that header.

Rename the macro's symbol to `oss__` (double trailing underscore) to
reduce the likelihood of shadowing a previous definition.
