### PR TITLE
Fix LinearSolverIstl cleanup also for fast AMG branch

### DIFF
--- a/opm/core/linalg/LinearSolverIstl.cpp
+++ b/opm/core/linalg/LinearSolverIstl.cpp
@@ -385,11 +385,12 @@ namespace Opm
         // Construct preconditioner.
         Operator opA(A);
         Criterion criterion;
-        setUpCriterion(criterion, linsolver_prolongate_factor, verbosity);
+        const int smooth_steps = 1;
+        setUpCriterion(criterion, linsolver_prolongate_factor, verbosity, smooth_steps);
         Dune::Amg::Parameters parms;
         parms.setDebugLevel(verbosity);
-        parms.setNoPreSmoothSteps(1);
-        parms.setNoPostSmoothSteps(1);
+        parms.setNoPreSmoothSteps(smooth_steps);
+        parms.setNoPostSmoothSteps(smooth_steps);
         parms.setProlongationDampingFactor(linsolver_prolongate_factor);
         Precond precond(opA, criterion, parms);
 


### PR DESCRIPTION
To avoid deprecation warnings the number of smoothing steps was passed through the Criterion instead of directly to the constructor in commit a7f32b934b.

However, due to an insufficient test matrix this was not tested using the fast AMG variant of DUNE so it breaks the builds if `-DHAS_DUNE_FAST_AMG` is defined.

This change should apply the same type of change to this branch as for the others. The number of smoothing steps is put into a constant to avoid the magic number 1 to appear in too many places (although I am not sure the number for pre- and post-smoothing always should be the same).
