### PR TITLE
include <tuple> in Spline.hpp

### DIFF
--- a/opm/core/utility/Spline.hpp
+++ b/opm/core/utility/Spline.hpp
@@ -29,6 +29,7 @@
 
 #include <ostream>
 #include <vector>
+#include <tuple>
 
 namespace Opm
 {


### PR DESCRIPTION
it seems like this is implicitly included by some other header, but
only in debug mode. _grr_ thanks to @bska for catching this...
