### PR TITLE
Only use Clang-specific pragma if compiler is Clang

### DIFF
--- a/opm/core/simulator/initState_impl.hpp
+++ b/opm/core/simulator/initState_impl.hpp
@@ -39,9 +39,10 @@ namespace Opm
 
     namespace
     {
-
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+#endif /* __clang__ */
         // Find the cells that are below and above a depth.
         // TODO: add 'anitialiasing', obtaining a more precise split
         //       by f. ex. subdividing cells cut by the split depths.
@@ -63,7 +64,9 @@ namespace Opm
                 }
             }
         }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif /* __clang__ */
 
         enum WaterInit { WaterBelow, WaterAbove };
 

--- a/tests/test_velocityinterpolation.cpp
+++ b/tests/test_velocityinterpolation.cpp
@@ -62,8 +62,10 @@ namespace
         }
     }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+#endif /* __clang__ */
     // Compute flux corresponding to a velocity vector v = v0 + x*v1.
     void computeFluxLinear(const UnstructuredGrid& grid,
                            const std::vector<double>& v0,
@@ -82,7 +84,9 @@ namespace
             flux[face] = std::inner_product(v.begin(), v.end(), grid.face_normals + face*dim, 0.0);
         }
     }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif /* __clang__ */
 
     double vectorDiff2(const std::vector<double>& v1, const std::vector<double>& v2)
     {


### PR DESCRIPTION
Otherwise the compiler will probably give us a warning that these pragmas are unknown. By default that warning is disabled with our own build system, but we also want to be able to link to our library without incorporating the entire build system too.

This shouldn't have any repercussions; I suggest testing it together with some other pull request to not spend too much time on that.
