### PR TITLE
Findewoms.cmake: fix typo

### DIFF
--- a/cmake/Modules/Findewoms.cmake
+++ b/cmake/Modules/Findewoms.cmake
@@ -21,7 +21,7 @@ find_opm_package (
   "${ewoms_DEPS}"
   
   # header to search for
-  "ewoms/common/start.h"
+  "ewoms/common/start.hh"
 
   # library to search for
   ""


### PR DESCRIPTION
it's 'start.hh', not 'start.h'...
