### PR TITLE
[Build System] Catch up to opm-material reorganisation.

### DIFF
--- a/cmake/Modules/Findopm-material.cmake
+++ b/cmake/Modules/Findopm-material.cmake
@@ -21,7 +21,7 @@ find_opm_package (
   "${opm-material_DEPS}"
 
   # header to search for
-  "opm/material/constants.hh"
+  "opm/material/Constants.hpp"
 
   # library to search for
   ""
@@ -30,7 +30,7 @@ find_opm_package (
   ""
 
   # test program
-"#include <opm/material/constants.hh>
+"#include <opm/material/Constants.hpp>
 int main (void) {
   double c = Opm::Constants<double>::c;
   return 0;  


### PR DESCRIPTION
Specifically, the file `<opm/material/constants.hh>` was renamed to `<opm/material/Constants.hpp>` (PR OPM/opm-material#11) and this renaming must be reflected in the CMake probe for opm-material.

This change restores the build of modules that depend on opm-material and must be propagated to those modules (currently opm-porsol, opm-upscaling and opm-benchmarks as far as I know).

Tested in debug and release mode on Ubuntu 10.04 LTS (CMake 2.8.0, GCC 4.4) and CentOS 5.9 (CMake 2.8.10.1, GCC 4.4) in modules opm-porsol and opm-upscaling.

I didn't catch this problem earlier because I had a previously _installed_ version of opm-material in (a reachable location of) my tree.  That version was old enough that the `constants.hh` file was still present.

@rolk: Care to evaluate the change for correctness?
