### PR TITLE
Tentative solution to problem of RESV injectors in `ifs_tpfa.c`

### DIFF
--- a/opm/core/pressure/tpfa/ifs_tpfa.c
+++ b/opm/core/pressure/tpfa/ifs_tpfa.c
@@ -364,7 +364,7 @@ assemble_well_contrib(int                   nc ,
 
         if (ctrls->current < 0) {
 
-            /* Threat this well as a shut well, isolated from the domain. */
+            /* Treat this well as a shut well, isolated from the domain. */
 
             assemble_shut_well(nc, w, W, mt, h);
 


### PR DESCRIPTION
This is a tentative solution to Issue #360 concerning the current impossibility of specifying injector wells constrained by total reservoir volume flow rate (`RESV`) when using the incompressible solver `ifs_tpfa.c` and, by extension, the wrapping class `IncompTpfa`.

The suggested solution is to restrict the consistency checking on phase distributions, introduced in commit b7d1634, to producing wells only.  Using this code I can no longer reproduce the symptoms of Issue #360, but further testing is likely needed.
