### PR TITLE
Remove unused "typedef"s

### DIFF
--- a/opm/core/props/pvt/BlackoilPvtProperties.cpp
+++ b/opm/core/props/pvt/BlackoilPvtProperties.cpp
@@ -43,7 +43,6 @@ namespace Opm
 
     void BlackoilPvtProperties::init(const EclipseGridParser& deck, const int samples)
     {
-        typedef std::vector<std::vector<std::vector<double> > > table_t;
         // If we need multiple regions, this class and the SinglePvt* classes must change.
         region_number_ = 0;
 

--- a/opm/core/props/pvt/PvtPropertiesIncompFromDeck.cpp
+++ b/opm/core/props/pvt/PvtPropertiesIncompFromDeck.cpp
@@ -37,7 +37,6 @@ namespace Opm
 
     void PvtPropertiesIncompFromDeck::init(const EclipseGridParser& deck)
     {
-        typedef std::vector<std::vector<std::vector<double> > > table_t;
         // If we need multiple regions, this class and the SinglePvt* classes must change.
         int region_number = 0;
 

--- a/opm/core/transport/implicit/ImplicitAssembly.hpp
+++ b/opm/core/transport/implicit/ImplicitAssembly.hpp
@@ -205,8 +205,6 @@ namespace Opm {
             const int ndof  = DofPerCell;
             const int ndof2 = ndof * ndof;
 
-            typedef std::vector<int>::size_type sz_t;
-
             const double* J1 = &asm_buffer_[0];
             const double* J2 = J1 + ((1*nconn_ + 1) * ndof2);
 

--- a/opm/core/transport/implicit/SinglePointUpwindTwoPhase.hpp
+++ b/opm/core/transport/implicit/SinglePointUpwindTwoPhase.hpp
@@ -593,7 +593,6 @@ namespace Opm {
                         NewtonIterate&        it   ) {
             // Nothing to do at end of iteration in this model.
             (void) state;  (void) g;  (void) it;
-            typedef typename NewtonIterate::vector_type vector_t;
         }
 
         template <class Grid          ,


### PR DESCRIPTION
CLang and recent versions of GCC warn about unused "typedef"s.  This change-set removes currently known instances in opm-core.

This is a first step towards fixing the most egregious transgressions highlighted by http://www.opm-project.org/CDash/viewBuildError.php?type=1&buildid=6031
