### PR TITLE
Use dSYM bundles as debugging containers (on MacOS X)

### DIFF
--- a/cmake/Modules/OpmInstall.cmake
+++ b/cmake/Modules/OpmInstall.cmake
@@ -44,8 +44,14 @@ macro (opm_install opm)
   # static libraries don't have their debug info stripped, so there is
   # only a separate file when we are building shared objects
   if (${opm}_LIBRARY_TYPE STREQUAL "SHARED" AND ${opm}_TARGET AND ${opm}_DEBUG)
+	# on MacOS X, debug files are actually bundles (directories)
+	if (APPLE)
+	  set (_dbg_type DIRECTORY)
+	else ()
+	  set (_dbg_type FILES)
+	endif ()
 	install (
-	  FILES ${PROJECT_BINARY_DIR}/${${opm}_DEBUG}
+	  ${_dbg_type} ${PROJECT_BINARY_DIR}/${${opm}_DEBUG}
 	  DESTINATION ${_dbg_prefix}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${${opm}_VER_DIR}
 	  )
   endif (${opm}_LIBRARY_TYPE STREQUAL "SHARED" AND ${opm}_TARGET AND ${opm}_DEBUG)

--- a/cmake/Modules/UseDebugSymbols.cmake
+++ b/cmake/Modules/UseDebugSymbols.cmake
@@ -106,7 +106,7 @@ function (strip_debug_symbols targets)
 		add_custom_command (TARGET ${target}
 		  POST_BUILD
 		  WORKING_DIRECTORY ${_dir}
-		  COMMAND ${DSYMUTIL} ARGS --flat --out=${_target_file}${_debug_ext} ${_target_file}
+		  COMMAND ${DSYMUTIL} ARGS --out=${_target_file}${_debug_ext} ${_target_file}
 		  COMMAND ${OBJCOPY} ARGS -S ${_target_file}
 		  VERBATIM
 		  )


### PR DESCRIPTION
gdb on MacOS X does not seem to be very fond of "flat" dSYM files, but it can read the bundle variant fine. Thus we change that to enable debugging across several tools.
