### PR TITLE
Guard against erroneous use of initBlackoilSurfvol().

### DIFF
--- a/opm/core/simulator/initState_impl.hpp
+++ b/opm/core/simulator/initState_impl.hpp
@@ -617,7 +617,7 @@ namespace Opm
                              State& state)
     {
         if (props.numPhases() != 3) {
-            OPM_THROW(std::runtime_error, "initBlackoilSurfvol() can for now only be used with 3 phases.");
+            OPM_THROW(std::runtime_error, "initBlackoilSurfvol() is only supported in three-phase simulations.");
         }
 
         const std::vector<double>& rs = state.gasoilratio();


### PR DESCRIPTION
The code introduced in #386 requires 3 phases, so we guard against trying to call function with only 2.
