### PR TITLE
Install header-only pkgconfig file to generic lib/

### DIFF
--- a/cmake/Modules/OpmProject.cmake
+++ b/cmake/Modules/OpmProject.cmake
@@ -136,10 +136,17 @@ function (opm_cmake_config name)
 	${CMAKE_INSTALL_PREFIX}/include${${name}_VER_DIR}
 	)
 
-  # put this in the right system location; assume that we have binaries
+  # put this in the right system location; if we have binaries then it
+  # should go in the arch-specific lib/ directory, otherwise use the
+  # common/noarch lib/ directory (these targets come from UseMultiArch)
+  if (${name}_TARGET)
+	set (_pkg_dir ${CMAKE_INSTALL_LIBDIR})
+  else ()
+	set (_pkg_dir ${LIBDIR_MULTIARCH_UNAWARE})
+  endif ()
   install (
 	FILES ${PROJECT_BINARY_DIR}/${${name}_NAME}-install.pc
-	DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig${${name}_VER_DIR}/
+	DESTINATION ${CMAKE_INSTALL_PREFIX}/${_pkg_dir}/pkgconfig${${name}_VER_DIR}/
 	RENAME ${${name}_NAME}.pc
 	)
 endfunction (opm_cmake_config name)


### PR DESCRIPTION
The previous version assumed that we had libraries, and thus always installs the .pc file in the multi-arch library directory. However, we now have modules which does not have a library, but whose header files still need to be located. Since the lib/ directory is usually in the pkgconfig search path, it is natural to put them there.
