### PR TITLE
Bump version numbers.

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -1,7 +1,7 @@
 Module: opm-core
 Description: Open Porous Media Initiative Core Library
 # if you change this, make sure to also change opm/core/version.h
-Version: 1.0
-Label: 2013.03
+Version: 1.1
+Label: 2013.10
 Maintainer: atgeirr@sintef.no
 Depends: dune-common (>= 2.2) dune-istl (>= 2.2)

--- a/opm/core/version.h
+++ b/opm/core/version.h
@@ -7,5 +7,5 @@ extern const char* const opm_core_version;
  * Current API level (for use with DUNE_VERSION_xxx):
  */
 #define OPM_CORE_VERSION_MAJOR    1
-#define OPM_CORE_VERSION_MINOR    0
+#define OPM_CORE_VERSION_MINOR    1
 #define OPM_CORE_VERSION_REVISION 0


### PR DESCRIPTION
Since there are a few new APIs and features, but no major changes, it seems proper to move from 1.0 to 1.1, even though strict backward compatibility cannot be expected.

Label bumped to 2013.10.
