### PR TITLE
Only add option for shared libraries once

### DIFF
--- a/cmake/Scripts/configure
+++ b/cmake/Scripts/configure
@@ -424,6 +424,8 @@ for OPT in "$@"; do
           esac
           test -n "${shared}" && \
           FEATURES="${FEATURES} -DBUILD_SHARED_LIBS:BOOL=${shared}"
+          # once we have added this, reset so we don't add again for next opt
+          shared=""
           ;;
         *)
           # remove everything *after* the equal sign


### PR DESCRIPTION
The way the test was done previously, it was added for _every_ option after `--enable-shared`, not only that one.

This is annoying, but not serious enough to warrant inclusion in release/2013.10 (unless there are other things that must be added as well)
