### PR TITLE
fix test for HAVE_QUAD on some instances of ubuntu 13.10

### DIFF
--- a/cmake/Modules/FindQuadmath.cmake
+++ b/cmake/Modules/FindQuadmath.cmake
@@ -12,11 +12,12 @@ include(CMakePushCheckState)
 
 cmake_push_check_state()
 list(APPEND CMAKE_REQUIRED_LIBRARIES "quadmath")
-CHECK_C_SOURCE_COMPILES("
+CHECK_CXX_SOURCE_COMPILES("
 #include <quadmath.h>
 
 int main(void){
     __float128 foo = sqrtq(123.456);
+    foo = FLT128_MIN;
 }" HAVE_QUAD)
 cmake_pop_check_state()
 


### PR DESCRIPTION
I haven't figured out why exactly this happens, but on one of my computers
which is now running kubuntu 13.10, g++ says the following if one tries to use
quadruple precision math:

/home/erne/src/ewoms/ewoms/common/quad.hh: In static member function ‘static quad std::numeric_limits<__float128>::min()’:
/home/erne/src/ewoms/ewoms/common/quad.hh:52:14: error: unable to find numeric literal operator ‘operator"" Q’
     { return FLT128_MIN; }

since this happens only on this machine and only with the C++ compiler (but
not the C compiler), i suppose that this is either an upgrade issue
with kubuntu or an issue with ubuntu's gcc stack. Strangely enough,
my other kubuntu 13.10 machine does not have a problem with that...

In any case, also testing for assignability of constants and using the
C++ compiler for the quadmath test won't hurt...
