### PR TITLE
Output newline after last entry before "/" when outputting grid to file....

### DIFF
--- a/opm/core/io/eclipse/CornerpointChopper.hpp
+++ b/opm/core/io/eclipse/CornerpointChopper.hpp
@@ -358,6 +358,7 @@ namespace Opm
             for (int i = 0; i < num_extra_entries; ++i) {
                 os << "  " << field[num_full_rows*nel_per_row+i];
             }
+            if (num_extra_entries > 0) os << "\n";
             os << "/\n\n";
         }
 


### PR DESCRIPTION
... This makes gridfile more robust for later usage (e.g. for visualization in resinsight)
