### PR TITLE
build system: prevent endless loop when using dunecontrol

### DIFF
--- a/cmake/Scripts/configure
+++ b/cmake/Scripts/configure
@@ -33,6 +33,7 @@ Optional Features:
   --enable-underscoring   assume Fortran routines have _ suffix [default=no]
   --enable-ninja          use Ninja build generator [default=no]
                           (automatically implies --enable-underscoring)
+  --config-cache          Reuse build configuration cache from a previous run
 
 Optional Packages:
   --with-alugrid=PATH     use the ALUGrid library from a specified location
@@ -138,6 +139,8 @@ boost_opts=
 # configuration that is passed on to CTest/CDash
 buildname=
 site=
+# if set, this prevents the previous CMake cache from being deleted
+config_cache=
 
 # default is to warn for unknown options, but this can be disabled
 option_check=yes
@@ -168,7 +171,10 @@ for OPT in "$@"; do
       OPTARG=${OPT#--}
       # OPTARG now contains everything after double dashes
       case "${OPTARG}" in
-        config-cache*)
+        config-cache)
+        cache-file=*)
+          # prevent the previous CMake cache from being deleted. The
+          # second option is only here for Dune/autotools compatibility
           config_cache="1"
           ;;
         src-dir=*)


### PR DESCRIPTION
Ha! found it:

this seems to be a bug in my cmake (i.e., 2.8.10.2): if the user sets the
CMAKE_CXX_COMPILER variable for a build directory where this variable
has already been set, one gets an endless loop. This stings especially
if using the dunecontrol compatibility layer as the compiler flags are
unconditionally set via the CXX_FLAGS environment variable in the
options file. Running duncontrol on a module twice will thus trigger the
infinite loop if some compiler flags are set by the user.

The solution is relatively simple: Delete the CMakeFiles directory
before calling cmake. for the dunecontrol compatibility mode, we do
this in the configure script. For details about the cmake bug, see
http://www.cmake.org/Bug/view.php?id=14119
