### PR TITLE
CornerPointChopper: Tidy code to output GRDECL format of subsample

### DIFF
--- a/opm/core/io/eclipse/CornerpointChopper.hpp
+++ b/opm/core/io/eclipse/CornerpointChopper.hpp
@@ -341,31 +341,6 @@ namespace Opm
             os << "/\n\n";
         }
 
-//            os << keyword << '\n';
-//            int sz = field.size();
-//            T last = std::numeric_limits<T>::max();
-//            int repeats = 0;
-//            for (int i = 0; i < sz; ++i) {
-//                T val = field[i];
-//                if (val == last) {
-//                    ++repeats;
-//                } else {
-//                    if (repeats == 1) {
-//                        os << last << '\n';
-//                    } else if (repeats > 1) {
-//                        os << repeats << '*' << last << '\n';
-//                    }
-//                    last = val;
-//                    repeats = 1;
-//                }
-//            }
-//            if (repeats == 1) {
-//                os << last << '\n';
-//            } else if (repeats > 1) {
-//                os << repeats << '*' << last << '\n';
-//            }
-//            os << "/\n\n";
-//        }
 
 
         template <typename T>


### PR DESCRIPTION
This change-set tidies the code used to implement method `writeGrdecl()`.  Specifically
- Use method `outputField()` to output the `COORD` and `ZCORN` arrays, thus eliminating repetition
- Simplify the implementation of `outputField()` to use straight-line code rather than a nested `for()` loop

While here, also remove a long-disabled code section for overall file readability.
