### PR TITLE
CMAKE: check_cxx_source_compiles() in Findopm-parser to look for Deck.hpp

### DIFF
--- a/cmake/Modules/Findopm-parser.cmake
+++ b/cmake/Modules/Findopm-parser.cmake
@@ -135,7 +135,7 @@ if (NOT (OPM_PARSER_INCLUDE_DIR MATCHES "-NOTFOUND"
 
   check_cxx_source_compiles (
 "#include <cstdlib>
-#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 
 int main (void) {
    return EXIT_SUCCESS;


### PR DESCRIPTION
Sorry - sorry :-(

The current check_cxx_source_compiles() function looks for the header file Parser.hpp; that header file also requires cJSON - and the check fails for the wrong reason.

This should be distributed all over.
