### PR TITLE
Search in build/ sub-dir if only suite root is given

### DIFF
--- a/cmake/Modules/OpmPackage.cmake
+++ b/cmake/Modules/OpmPackage.cmake
@@ -149,10 +149,18 @@ macro (find_opm_package module deps header lib defs prog conf)
 	  ${${module}_DIR}
 	  ${${module}_ROOT}
 	  ${${MODULE}_ROOT}
-	  ${${module}_DIR}/..
-	  ${${module}_ROOT}/..
-	  ${${MODULE}_ROOT}/..
 	  )
+	# only add parent directories for those variants that are actually set
+	# (otherwise, we'll inadvertedly add the root directory (=all))
+	if (${module}_DIR)
+	  list (APPEND _guess ${${module}_DIR}/..)
+	endif (${module}_DIR)
+	if (${module}_ROOT)
+	  list (APPEND _guess ${${module}_ROOT}/..)
+	endif (${module}_ROOT)
+	if (${MODULE}_ROOT)
+	  list (APPEND _guess ${${MODULE}_ROOT}/..)
+	endif (${MODULE}_ROOT)
 	# don't search the system paths! that would be dangerous; if there
 	# is a problem in our own specified directory, we don't necessarily
 	# want an old version that is left in one of the system paths!


### PR DESCRIPTION
If the package suite was given (e.g. DUNE_ROOT=/blum), then the code set up the root for each individual package automatically (e.g. DUNE_COMMON_ROOT=/blum/dune-common), but the path which was then
activated did not get the local build sub-directory (e.g. if we are building opm-autodiff in /frub/opm-autodiff/build, then the local build directory is "build/"), and thus this was not appended to the library search path. The result was that the source was found (because the root pointed to a valid source tree), but the library was not (because it is "hidden" in the subdirectory).

This patch is created as a result of issue opm/opm-autodiff#59. Please hold the merge until @qilicun can confirm that it works properly in that setup.
