### PR TITLE
dune.module: specify dependency on opm-parser

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -4,4 +4,4 @@ Description: Open Porous Media Initiative Core Library
 Version: 1.1
 Label: 2013.10
 Maintainer: atgeirr@sintef.no
-Depends: dune-common (>= 2.2) dune-istl (>= 2.2)
+Depends: dune-common (>= 2.2) dune-istl (>= 2.2) opm-parser


### PR DESCRIPTION
opm-parser is already required by cmake, but dunecontrol was unware of it up to now. this makes it possible to build the whole stack up to opm-core with dunecontrol and depends on OPM/opm-parser#67
