### PR TITLE
OpmFind.cmake: prevent multiple calls to the same module in the same run

### DIFF
--- a/cmake/Modules/OpmFind.cmake
+++ b/cmake/Modules/OpmFind.cmake
@@ -137,7 +137,7 @@ macro (find_and_append_package_to prefix name)
 	# using config mode is better than using module (aka. find) mode
 	# because then the package has already done all its probes and
 	# stored them in the config file for us
-	if (NOT DEFINED ${name}_FOUND)
+	if (NOT DEFINED ${name}_FOUND AND NOT DEFINED ${NAME}_FOUND)
 	  if (${name}_DIR)
 		message (STATUS "Finding package ${name} using config mode")
 		find_package (${name} ${ARGN} NO_MODULE PATHS ${${name}_DIR} NO_DEFAULT_PATH)
@@ -146,8 +146,11 @@ macro (find_and_append_package_to prefix name)
 		find_package (${name} ${ARGN})
 	  endif ()
 	endif ()
-	if (NOT ${name}_FOUND)
-	  set (${name}_FOUND "0")
+	if (NOT DEFINED ${name}_FOUND)
+	  set (${name}_FOUND "${${NAME}_FOUND}")
+	endif ()
+	if (NOT DEFINED ${NAME}_FOUND)
+	  set (${NAME}_FOUND "${${name}_FOUND}")
 	endif ()
   endif ()
 


### PR DESCRIPTION
this prevents to check for the same software package more than once in the same cmake run and should thus speed things up a bit and make the terminal output a bit cleaner. For this, I assumed that the ${name}_FOUND cmake variable does not get cached and that if a package is found or not found the first time, the module produces the same result for all consecutive calls. It looks like all modules in opm-core exhibit these properties...
