### PR TITLE
fix typo in guard macro of fsh.h

### DIFF
--- a/opm/core/pressure/fsh.h
+++ b/opm/core/pressure/fsh.h
@@ -18,7 +18,7 @@
 */
 
 #ifndef OPM_FSH_HEADER_INCLUDED
-#define OPM_FHS_HEADER_INCLUDED
+#define OPM_FSH_HEADER_INCLUDED
 
 /**
  * \file


### PR DESCRIPTION
on CLang 3.4 svn this produced

```
/home/erne/src/opm-core/opm/core/pressure/fsh.h:20:9: warning: 'OPM_FSH_HEADER_INCLUDED' is used as a
      header guard here, followed by #define of a different macro [-Wheader-guard]
```

which is correct...
