### PR TITLE
Document modules and structures in the build system

### DIFF
--- a/cmake/OPM-CMake.md
+++ b/cmake/OPM-CMake.md
@@ -10,7 +10,7 @@ sets up declarative lists of prerequisites and content and rely on convention
 and pre-made modules to do the build. Its goal is to replace but be
 compatible with the old autotools-based system.
 
-## Notation
+## Terminology
 
 In the build system to following abstract locations are referred to:
 


### PR DESCRIPTION
This changeset gives a brief description of each of the modules that comprises the build system, and the suffices that is used to form a virtual structure of variables for each project. It is written in MarkDown; best viewed through the GitHub interface.
