### PR TITLE
Portability fix: 'uint' is nonstandard.

### DIFF
--- a/opm/core/utility/PropertySystem.hpp
+++ b/opm/core/utility/PropertySystem.hpp
@@ -798,7 +798,7 @@ template<typename... Args>
 class RevertedTuple
 {
 private:
-    template<uint N, typename... All>
+    template<unsigned int N, typename... All>
     struct RevertedTupleOuter
     {
         template<typename Head, typename... Tail>


### PR DESCRIPTION
Always use `unsigned int` instead. `uint` gives compile failure on Mac OS X.
