### PR TITLE
Corrects required version and make Eigen3 download work.

### DIFF
--- a/cmake/Modules/opm-autodiff-prereqs.cmake
+++ b/cmake/Modules/opm-autodiff-prereqs.cmake
@@ -19,5 +19,5 @@ set (opm-autodiff_DEPS
 	dune-istl REQUIRED;
 	opm-core REQUIRED"
 	# Eigen
-	"Eigen3 3.1 REQUIRED"
+	"Eigen3 3.1.2 "
 	)


### PR DESCRIPTION
this is just the core version of OPM/opm-autodiff#77 . If you'd like to avoid a horrible mess, please open a PR for core _before_ merging the original PR next time.
