### PR TITLE
Fix SimulatorTimer-related bug in EclipseWriter.

### DIFF
--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -790,6 +790,11 @@ struct EclipseWellTotal : public EclipseWellReport {
 
     virtual double update (const SimulatorTimer& timer,
                              const WellState& wellState) {
+        if (timer.currentStepNum() == 0) {
+            // We are at the initial state.
+            // No step has been taken yet.
+            return 0.0;
+        }
         // TODO: Is the rate average for the timestep, or is in
         // instantaneous (in which case trapezoidal or Simpson integration
         // would probably be better)


### PR DESCRIPTION
Since writeTimeStep() now (after a recent PR in opm-autodiff) gets called also before the first timestep is done, the EclipseWellTotal::update() method was in error, always calling SimulatorTimer::stepLengthTaken(). That method cannot be called if the
timer's currentStepNum() is 0, so that is checked for and intercepted.

The total rate in that case is of course zero.
