### PR TITLE
Initializing do_hyst_ to false, this caused random segfaults in sim_fibo...

### DIFF
--- a/opm/core/props/satfunc/SaturationPropsFromDeck_impl.hpp
+++ b/opm/core/props/satfunc/SaturationPropsFromDeck_impl.hpp
@@ -100,8 +100,9 @@ namespace Opm
         }
 
         // Saturation table scaling
-        do_eps_ = false;
-        do_3pt_ = false;
+        do_hyst_ = false;
+        do_eps_  = false;
+        do_3pt_  = false;
         if (deck.hasField("ENDSCALE")) {
             //if (!phase_usage_.phase_used[Aqua] || !phase_usage_.phase_used[Liquid] || phase_usage_.phase_used[Vapour]) {
             //    OPM_THROW(std::runtime_error, "Currently endpoint-scaling limited to oil-water systems without gas.");


### PR DESCRIPTION
..._ad

Have struggled quite a bit with crashes in opm-autodiff the last days, but I think this was what caused it.
