### PR TITLE
Make linear interpolation default for saturation and some pvt properties.

### DIFF
--- a/opm/core/props/BlackoilPropertiesFromDeck.cpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck.cpp
@@ -31,11 +31,11 @@ namespace Opm
        if (init_rock){
             rock_.init(deck, grid);
         }
-        pvt_.init(deck, 200);
-        SaturationPropsFromDeck<SatFuncSimpleUniform>* ptr
-            = new SaturationPropsFromDeck<SatFuncSimpleUniform>();
+        pvt_.init(deck, 0);
+        SaturationPropsFromDeck<SatFuncSimpleNonuniform>* ptr
+            = new SaturationPropsFromDeck<SatFuncSimpleNonuniform>();
         satprops_.reset(ptr);
-        ptr->init(deck, grid, 200);
+        ptr->init(deck, grid, 0);
 
         if (pvt_.numPhases() != satprops_->numPhases()) {
             OPM_THROW(std::runtime_error, "BlackoilPropertiesFromDeck::BlackoilPropertiesFromDeck() - Inconsistent number of phases in pvt data ("
@@ -52,11 +52,11 @@ namespace Opm
             rock_.init(deck, grid);
         }
 
-        const int pvt_samples = param.getDefault("pvt_tab_size", 200);
+        const int pvt_samples = param.getDefault("pvt_tab_size", 0);
         pvt_.init(deck, pvt_samples);
 
         // Unfortunate lack of pointer smartness here...
-        const int sat_samples = param.getDefault("sat_tab_size", 200);
+        const int sat_samples = param.getDefault("sat_tab_size", 0);
         std::string threephase_model = param.getDefault<std::string>("threephase_model", "simple");
         if (deck.hasField("ENDSCALE") && threephase_model != "simple") {
             OPM_THROW(std::runtime_error, "Sorry, end point scaling currently available for the 'simple' model only.");


### PR DESCRIPTION
Saturation properties includes relative permeability and capillary pressure functions.

PVT properties include dead oil and dead gas tables.

The default has been to make a monotone spline from the given table values and use a fine, uniform sampling of that. With this change the default is to use the tables as-is. It is still possible to use the spline approach. For example in the class BlackoilPropertiesFromDeck one may pass nonzero values for the 'pvt_tab_size' and 'sat_tab_size' parameters, corresponding to how fine the spline will be sampled.

(Note that the commit message is a bit misleading, since it only mentions saturation properties.)
