### PR TITLE
Allow direct interpolation of props with new parser.

### DIFF
--- a/opm/core/props/pvt/BlackoilPvtProperties.cpp
+++ b/opm/core/props/pvt/BlackoilPvtProperties.cpp
@@ -157,8 +157,11 @@ namespace Opm
         if (phase_usage_.phase_used[Liquid]) {
             if (newParserDeck->hasKeyword("PVDO")) {
                 Opm::PvdoTable pvdoTable(newParserDeck->getKeyword("PVDO"), region_number_);
-
-                props_[phase_usage_.phase_pos[Liquid]].reset(new SinglePvtDeadSpline(pvdoTable, samples));
+                if (samples > 0) {
+                    props_[phase_usage_.phase_pos[Liquid]].reset(new SinglePvtDeadSpline(pvdoTable, samples));
+                } else {
+                    props_[phase_usage_.phase_pos[Liquid]].reset(new SinglePvtDead(pvdoTable));
+                }
             } else if (newParserDeck->hasKeyword("PVTO")) {
                 Opm::PvtoTable pvtoTable(newParserDeck->getKeyword("PVTO"), /*tableIdx=*/0);
 
@@ -175,8 +178,11 @@ namespace Opm
         if (phase_usage_.phase_used[Vapour]) {
             if (newParserDeck->hasKeyword("PVDG")) {
                 Opm::PvdgTable pvdgTable(newParserDeck->getKeyword("PVDG"), region_number_);
-
-                props_[phase_usage_.phase_pos[Vapour]].reset(new SinglePvtDeadSpline(pvdgTable, samples));
+                if (samples > 0) {
+                    props_[phase_usage_.phase_pos[Vapour]].reset(new SinglePvtDeadSpline(pvdgTable, samples));
+                } else {
+                    props_[phase_usage_.phase_pos[Vapour]].reset(new SinglePvtDead(pvdgTable));
+                }
             } else if (newParserDeck->hasKeyword("PVTG")) {
                 Opm::PvtgTable pvtgTable(newParserDeck->getKeyword("PVTG"), /*tableIdx=*/0);
 

--- a/opm/core/props/pvt/SinglePvtDead.cpp
+++ b/opm/core/props/pvt/SinglePvtDead.cpp
@@ -86,6 +86,30 @@ namespace Opm
 //            << "\n\nvisc\n\n" << viscosity_ << std::endl;
     }
 
+    /// Constructor
+    SinglePvtDead::SinglePvtDead(const Opm::PvdgTable& pvdgTable)
+    {
+        // Copy data
+        const std::vector<double>& press = pvdgTable.getPressureColumn();
+        const std::vector<double>& b = pvdgTable.getFormationFactorColumn();
+        const std::vector<double>& visc = pvdgTable.getViscosityColumn();
+
+        const int sz = b.size();
+        std::vector<double> bInv(sz);
+        for (int i = 0; i < sz; ++i) {
+            bInv[i] = 1.0 / b[i];
+        }
+        b_ = NonuniformTableLinear<double>(press, bInv);
+        viscosity_ = NonuniformTableLinear<double>(press, visc);
+
+        // Dumping the created tables.
+//         static int count = 0;
+//         std::ofstream os((std::string("dump-") + boost::lexical_cast<std::string>(count++)).c_str());
+//         os.precision(15);
+//         os << "1/B\n\n" << one_over_B_
+//            << "\n\nvisc\n\n" << viscosity_ << std::endl;
+    }
+
     // Destructor
     SinglePvtDead::~SinglePvtDead()
     {

--- a/opm/core/props/pvt/SinglePvtDead.hpp
+++ b/opm/core/props/pvt/SinglePvtDead.hpp
@@ -25,6 +25,7 @@
 #include <opm/core/utility/NonuniformTableLinear.hpp>
 
 #include <opm/parser/eclipse/Utility/PvdoTable.hpp>
+#include <opm/parser/eclipse/Utility/PvdgTable.hpp>
 
 #include <vector>
 
@@ -43,7 +44,8 @@ namespace Opm
     public:
         typedef std::vector<std::vector<std::vector<double> > > table_t;
         SinglePvtDead(const table_t& pvd_table);
-        SinglePvtDead(const Opm::PvdoTable &pvdoTable);
+        SinglePvtDead(const Opm::PvdoTable& pvdoTable);
+        SinglePvtDead(const Opm::PvdgTable& pvdgTable);
         virtual ~SinglePvtDead();
 
         /// Viscosity as a function of p and z.


### PR DESCRIPTION
After transitioning to use the new parser, the SinglePvtDead class was never used even when the 'samples' argument used to control usage was zero or negative. The resulting construction of SinglePvtDeadSpline objects was then failing.

This change adds a new constructor to SinglePvtDead, and restores the ability to control spline usage with the samples argument.

Note that the three constructors for the class are very similar, resulting from copying and pasting. This PR does not refactor this.
