### PR TITLE
Fix a few nits in "opm-core-prereqs.cmake"

### DIFF
--- a/cmake/Modules/opm-core-prereqs.cmake
+++ b/cmake/Modules/opm-core-prereqs.cmake
@@ -30,6 +30,6 @@ set (opm-core_DEPS
 	# DUNE dependency
 	"dune-common"
 	"dune-istl"
-	#Parser library
+	# Parser library for ECL-type simulation models
 	"opm-parser REQUIRED"
 	)


### PR DESCRIPTION
@andlaus suggested (https://github.com/OPM/opm-core/pull/503#discussion_r10197046) that the search for ERT be promoted ahead of "opm-parser" in opm-core's prerequisite file.  I agree, but chose instead to defer the search for "opm-parser" until after we've established the local state of ERT availability to mimic the order of other modules.

This change-set also explicitly states the role of opm-parser within the project.
