### PR TITLE
Changed open / close behaviour of well_controls

### DIFF
--- a/opm/core/pressure/tpfa/cfs_tpfa_residual.c
+++ b/opm/core/pressure/tpfa/cfs_tpfa_residual.c
@@ -869,7 +869,7 @@ assemble_completion_to_well(int i, int w, int c, int nc, int np,
     W    = wells->W;
     ctrl = W->ctrls[ w ];
 
-    if (well_controls_get_current(ctrl) < 0) {
+    if (well_controls_well_is_shut( ctrl )) {
         /* Interpreting a negative current control index to mean a shut well */
         welleq_coeff_shut(np, h, &res, &w2c, &w2w);
     }
@@ -933,7 +933,7 @@ assemble_well_contrib(struct cfs_tpfa_res_wells   *wells ,
 
     for (w = i = 0; w < W->number_of_wells; w++) {
         pw = wpress[ w ];
-        is_open = (well_controls_get_current(W->ctrls[w]) >= 0);
+        is_open = well_controls_well_is_open(W->ctrls[w]);
 
         for (; i < W->well_connpos[w + 1]; i++, pmobp += np) {
 

--- a/opm/core/pressure/tpfa/ifs_tpfa.c
+++ b/opm/core/pressure/tpfa/ifs_tpfa.c
@@ -363,7 +363,7 @@ assemble_well_contrib(int                   nc ,
     for (w = 0; w < W->number_of_wells; w++) {
         ctrls = W->ctrls[ w ];
 
-        if (well_controls_get_current(ctrls) < 0) {
+        if (well_controls_well_is_shut(ctrls) ) {
 
             /* Treat this well as a shut well, isolated from the domain. */
 

--- a/opm/core/simulator/SimulatorIncompTwophase.cpp
+++ b/opm/core/simulator/SimulatorIncompTwophase.cpp
@@ -310,7 +310,7 @@ namespace Opm
         const int nw = wells->number_of_wells;
         for (int w = 0; w < nw; ++w) {
             const WellControls* wc = wells->ctrls[w];
-            if (well_controls_get_current(wc) >= 0) {
+            if (well_controls_well_is_open( wc )) {
                 if (well_controls_get_current_type(wc) == BHP) {
                     return false;
                 }

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -51,8 +51,7 @@ namespace Opm
                     // above or below (depending on if the well is an
                     // injector or producer) pressure in first perforation
                     // cell.
-                    if ((well_controls_get_current(ctrl) < 0) || // SHUT
-                        (well_controls_get_current_type(ctrl) != BHP)) {
+                    if (well_controls_well_is_shut(ctrl) || (well_controls_get_current_type(ctrl) != BHP)) {
                         const int first_cell = wells->well_cells[wells->well_connpos[w]];
                         const double safety_factor = (wells->type[w] == INJECTOR) ? 1.01 : 0.99;
                         bhp_[w] = safety_factor*state.pressure()[first_cell];
@@ -61,8 +60,7 @@ namespace Opm
                     }
 
                     // Initialize well rates to match controls if type is SURFACE_RATE
-                    if ((well_controls_get_current(ctrl) >= 0) && // open well
-                        (well_controls_get_current_type(ctrl) == SURFACE_RATE)) {
+                    if (well_controls_well_is_open( ctrl ) || (well_controls_get_current_type(ctrl) == SURFACE_RATE)) {
                         const double rate_target = well_controls_get_current_target(ctrl);
                         const double * distr = well_controls_get_current_distr( ctrl );
                         for (int p = 0; p < np; ++p) {

--- a/opm/core/well_controls.h
+++ b/opm/core/well_controls.h
@@ -55,8 +55,18 @@ well_controls_get_current( const struct WellControls * ctrl);
 void
 well_controls_set_current( struct WellControls * ctrl, int current);
 
-void
-well_controls_invert_current( struct WellControls * ctrl );
+
+bool 
+well_controls_well_is_shut(const struct WellControls * ctrl);
+
+bool 
+well_controls_well_is_open(const struct WellControls * ctrl);
+
+void 
+well_controls_open_well( struct WellControls * ctrl);
+
+void 
+well_controls_shut_well( struct WellControls * ctrl);
 
 int
 well_controls_add_new(enum WellControlType type , double target , const double * distr , struct WellControls * ctrl);

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -747,9 +747,7 @@ namespace Opm
     void WellNode::shutWell()
     {
         if (shut_well_) {
-            // We set the tilde of the current control
-            // set_current_control(self_index_, -1, wells_);
-            well_controls_invert_current(wells_->ctrls[self_index_]);
+            well_controls_shut_well( wells_->ctrls[self_index_]);
         }
         else {
             const double target = 0.0;
@@ -767,7 +765,7 @@ namespace Opm
                 well_controls_iset_target( wells_->ctrls[self_index_] , group_control_index_ , target);
                 well_controls_iset_distr(wells_->ctrls[self_index_] , group_control_index_ , distr);
             }
-            well_controls_invert_current(wells_->ctrls[self_index_]);
+            well_controls_open_well( wells_->ctrls[self_index_]);
         }
     }
 

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -869,17 +869,9 @@ namespace Opm
                 }
                 const int index = it->second;
                 if (line.openshutflag_ == "SHUT") {
-                    int cur_ctrl = well_controls_get_current(w_->ctrls[index]);
-                    if (cur_ctrl >= 0) {
-                        well_controls_invert_current(w_->ctrls[index]);
-                    }
-                    assert(well_controls_get_current(w_->ctrls[index]) < 0);
+                    well_controls_shut_well( w_->ctrls[index] );
                 } else if (line.openshutflag_ == "OPEN") {
-                    int cur_ctrl = well_controls_get_current(w_->ctrls[index]);
-                    if (cur_ctrl < 0) {
-                        well_controls_invert_current(w_->ctrls[index]);
-                    }
-                    assert(well_controls_get_current(w_->ctrls[index]) >= 0);
+                    well_controls_open_well( w_->ctrls[index] );
                 } else {
                     OPM_THROW(std::runtime_error, "Unknown Open/close keyword: \"" << line.openshutflag_<< "\". Allowed values: OPEN, SHUT.");
                 }

--- a/opm/core/wells/well_controls.c
+++ b/opm/core/wells/well_controls.c
@@ -98,6 +98,8 @@ struct WellControls
      */
     int current;
 
+    bool well_is_open;
+
     /* 
        The capacity allocated.
     */
@@ -130,7 +132,7 @@ well_controls_create(void)
     ctrl = malloc(1 * sizeof *ctrl);
 
     if (ctrl != NULL) {
-        /* Initialise empty control set */
+        /* Initialise empty control set; the well is created open. */
         ctrl->num               = 0;
         ctrl->number_of_phases  = 0;
         ctrl->type              = NULL;
@@ -138,6 +140,7 @@ well_controls_create(void)
         ctrl->distr             = NULL;
         ctrl->current           = -1;
         ctrl->cpty              = 0;         
+        ctrl->well_is_open      = true;  
     }
 
     return ctrl;
@@ -192,10 +195,22 @@ well_controls_set_current( struct WellControls * ctrl, int current) {
     ctrl->current = current;
 }
 
-void 
-well_controls_invert_current( struct WellControls * ctrl ) {
-    ctrl->current = ~ctrl->current;
+bool well_controls_well_is_shut(const struct WellControls * ctrl) {
+    return !ctrl->well_is_open;
 }
+
+bool well_controls_well_is_open(const struct WellControls * ctrl) {
+    return ctrl->well_is_open;
+}
+
+void well_controls_open_well( struct WellControls * ctrl) {
+    ctrl->well_is_open = true;
+}
+
+void well_controls_shut_well( struct WellControls * ctrl) {
+    ctrl->well_is_open = false;
+}
+
 
 
 enum WellControlType 

--- a/tests/test_wellcontrols.cpp
+++ b/tests/test_wellcontrols.cpp
@@ -45,11 +45,6 @@ BOOST_AUTO_TEST_CASE(Construction)
     well_controls_set_current( ctrls , 2 );
     BOOST_CHECK_EQUAL( 2 , well_controls_get_current( ctrls ));
     
-    well_controls_invert_current( ctrls );
-    BOOST_CHECK( well_controls_get_current( ctrls ) < 0 );
-    well_controls_invert_current( ctrls );
-    BOOST_CHECK_EQUAL( 2 , well_controls_get_current( ctrls ));
-
     {
         enum WellControlType type1 = BHP;
         enum WellControlType type2 = SURFACE_RATE;
@@ -102,4 +97,22 @@ BOOST_AUTO_TEST_CASE(Construction)
     well_controls_destroy( ctrls );
 }
 
+
+BOOST_AUTO_TEST_CASE(OpenClose)
+{
+    struct WellControls * ctrls = well_controls_create();
+
+    BOOST_CHECK_EQUAL( true , well_controls_well_is_open(ctrls) );
+    BOOST_CHECK_EQUAL( false , well_controls_well_is_shut(ctrls) );
+
+    well_controls_open_well( ctrls );
+    BOOST_CHECK_EQUAL( true   , well_controls_well_is_open(ctrls) );
+    BOOST_CHECK_EQUAL( false  , well_controls_well_is_shut(ctrls) );
+
+    well_controls_shut_well( ctrls );
+    BOOST_CHECK_EQUAL( false   , well_controls_well_is_open(ctrls) );
+    BOOST_CHECK_EQUAL( true    , well_controls_well_is_shut(ctrls) );
+    
+    well_controls_destroy( ctrls );
+}
 


### PR DESCRIPTION
The structure well_controls has an array of available controls and a current index which points into the array of available controls. The current index is also used to indicate whether a well is open or not:

```
current >= 0 Well is open
current < 0   Well is closed
```

This approach fails in the situation where there are no available controls. Unfortunately that is a quite typical situation:

```
WCONHIST
    'W1' 'OPEN'  0  .... /
/

WCONPROD
    'W1' 'SHUT'   /
/
```

Here the numerical oil rate is first set to zero with the WCONHIST keyword; while the well is still open. Then with the WCONPROD keyword the well is shut. In the final WCONPROD keyword all control values are defaulted, i.e. there are no available controls.

In this PR a boolean flag `well_is_open` is introduced in well_controls structure, and the current index is not modified when the well is opened/shut.
