### PR TITLE
initStateFromDeck: reverse the priorities of the PRESSURE and EQUIL keywords

### DIFF
--- a/opm/core/simulator/initState_impl.hpp
+++ b/opm/core/simulator/initState_impl.hpp
@@ -488,6 +488,11 @@ namespace Opm
                   "found " << pu.num_phases << " phases in deck.");
         }
         state.init(grid, num_phases);
+        if (newParserDeck->hasKeyword("EQUIL") && newParserDeck->hasKeyword("PRESSURE")) {
+            OPM_THROW(std::runtime_error, "initStateFromDeck(): The deck must either specify the initial "
+                      "condition using the PRESSURE _or_ the EQUIL keyword (currently it has both)");
+        }
+
         if (newParserDeck->hasKeyword("EQUIL")) {
             if (num_phases != 2) {
                 OPM_THROW(std::runtime_error, "initStateFromDeck(): EQUIL-based init currently handling only two-phase scenarios.");
@@ -583,6 +588,10 @@ namespace Opm
         if (num_phases != pu.num_phases) {
             OPM_THROW(std::runtime_error, "initStateFromDeck():  user specified property object with " << num_phases << " phases, "
                   "found " << pu.num_phases << " phases in deck.");
+        }
+        if (deck.hasField("EQUIL") && deck.hasField("PRESSURE")) {
+            OPM_THROW(std::runtime_error, "initStateFromDeck(): The deck must either specify the initial "
+                      "condition using the PRESSURE _or_ the EQUIL keyword (currently it has both)");
         }
         state.init(grid, num_phases);
         if (deck.hasField("EQUIL")) {


### PR DESCRIPTION
i.e., if PRESSURE and EQUIL are both present, we now use the first
instead of the second one for initialization. This is convenient for
the Norne dataset as the init data can be simply included from the
main file. Also, one can argue that if both keywords are present, the
user knows what he does and probably has an external tool to generate
the init data. (Though it can be debated if we should print a scary
warning in that case...)

the code paths for the old EclipseGridParser have not been touched...
