### PR TITLE
Removed cpos = ~cpos constructions for closing a well

### DIFF
--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -664,12 +664,11 @@ namespace Opm
                         }
                         InjectionControl::Mode mode = InjectionControl::mode(wci_line.control_mode_);
                         int cpos = control_pos[mode];
-                        if (cpos == -1 && mode != InjectionControl::GRUP) {
-                            OPM_THROW(std::runtime_error, "Control for " << wci_line.control_mode_ << " not specified in well " << well_names[wix]);
-                        }
                         // We need to check if the well is shut or not
                         if (wci_line.open_shut_flag_ == "SHUT") {
                             well_controls_shut_well( w_->ctrls[wix]);
+                        } else if (cpos == -1 && mode != InjectionControl::GRUP) {
+                            OPM_THROW(std::runtime_error, "Control for " << wci_line.control_mode_ << " not specified in well " << well_names[wix]);
                         }
                         set_current_control(wix, cpos, w_);
 
@@ -1329,12 +1328,10 @@ namespace Opm
 
                 ProductionControl::Mode mode = ProductionControl::mode(well->getProducerControlMode(timeStep));
                 int cpos = control_pos[mode];
-                if (cpos == -1 && mode != ProductionControl::GRUP) {
-                    OPM_THROW(std::runtime_error, "Control mode type " << mode << " not present in well " << well_names[well_index]);
-                }
-                // If it's shut, we complement the cpos
                 if (well->getStatus(timeStep) == WellCommon::SHUT) {
                     well_controls_shut_well( w_->ctrls[well_index] );
+                } else if (cpos == -1 && mode != ProductionControl::GRUP) {
+                    OPM_THROW(std::runtime_error, "Control mode type " << mode << " not present in well " << well_names[well_index]);
                 }
                 set_current_control(well_index, cpos, w_);
             }


### PR DESCRIPTION
This is a fallout from https://github.com/OPM/opm-core/pull/507

Closing wells was performed by:

``` C++
cpos = ~cpos;
set_current_control( );
```

This fails hard when a well has been shut and has no valid controls. With this PR the `well_controls_shut_well()` is used. As an extension of the same theme the second commit introduces a change in the WellsManager: it will check that a well is open before throwing on an invalid control.

With these two commits the opm-core/WellsManager can load the "complete" NORNE Schedule file - with the following caveats:
1. Many wells have control mode RESV in the WCONHIST keyword; as discussed previously we really do not know how to handle that in a sane manner. I have manually applied s/RESV/ORAT/g throughout the NORNE SCHEDULE file.
2. We do not currently handle the 'STOP' well status, there was only one active 'STOP' status in the whole file, I changed that to 'SHUT'.

A small summary application is coming in a separate PR when this is merged.
