### PR TITLE
Apply changes from commit a953ba8 to new parser code too.

### DIFF
--- a/opm/core/props/BlackoilPropertiesFromDeck.cpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck.cpp
@@ -49,7 +49,7 @@ namespace Opm
         if (init_rock){
            rock_.init(newParserDeck, grid);
         }
-        pvt_.init(newParserDeck, /*numSamples=*/200);
+        pvt_.init(newParserDeck, /*numSamples=*/0);
         SaturationPropsFromDeck<SatFuncSimpleUniform>* ptr
             = new SaturationPropsFromDeck<SatFuncSimpleNonuniform>();
         satprops_.reset(ptr);


### PR DESCRIPTION
The mentioned commit was applied before the merge of
opm-parser-integrate and therefore the changes did not carry over
to the code that uses the new parser. This code mimics the
changed behaviour for the new parser.

Closes issue #516
