### PR TITLE
Made single-argument constructors explicit.

### DIFF
--- a/opm/core/grid/GridManager.hpp
+++ b/opm/core/grid/GridManager.hpp
@@ -44,10 +44,10 @@ namespace Opm
     {
     public:
         /// Construct a 3d corner-point grid or tensor grid from a deck.
-        GridManager(const Opm::EclipseGridParser& deck);
+        explicit GridManager(const Opm::EclipseGridParser& deck);
 
         /// Construct a 3d corner-point grid or tensor grid from a deck.
-        GridManager(Opm::DeckConstPtr newParserDeck);
+        explicit GridManager(Opm::DeckConstPtr newParserDeck);
 
         /// Construct a 2d cartesian grid with cells of unit size.
         GridManager(int nx, int ny);
@@ -65,7 +65,7 @@ namespace Opm
         /// Construct a grid from an input file.
         /// The file format used is currently undocumented,
         /// and is therefore only suited for internal use.
-        GridManager(const std::string& input_filename);
+        explicit GridManager(const std::string& input_filename);
 
         /// Destructor.
         ~GridManager();

--- a/opm/core/wells/WellsManager.hpp
+++ b/opm/core/wells/WellsManager.hpp
@@ -66,7 +66,7 @@ namespace Opm
         /// manage control switching does not exist.
         ///
         /// @param[in] W Existing wells object.
-        WellsManager(struct Wells* W);
+        explicit WellsManager(struct Wells* W);
 
         /// Construct from input deck and grid.
         /// The permeability argument may be zero if the input contain


### PR DESCRIPTION
Avoids unintended implicit conversions.

There may be more cases of this error around, I have not done an exhaustive search.
