### PR TITLE
EclipseWriter: add new parser

### DIFF
--- a/opm/core/io/eclipse/EclipseWriter.hpp
+++ b/opm/core/io/eclipse/EclipseWriter.hpp
@@ -24,6 +24,8 @@
 #include <opm/core/io/OutputWriter.hpp>
 #include <opm/core/props/BlackoilPhases.hpp>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
 #include <string>
 #include <vector>
 #include <memory>  // std::unique_ptr
@@ -61,6 +63,14 @@ public:
                   std::shared_ptr <const EclipseGridParser> parser,
                   std::shared_ptr <const UnstructuredGrid> grid);
 
+    /*!
+     * \brief Sets the common attributes required to write eclipse
+     *        binary files using ERT.
+     */
+    EclipseWriter(const parameter::ParameterGroup& params,
+                  Opm::DeckConstPtr newParserDeck,
+                  std::shared_ptr <const UnstructuredGrid> grid);
+
     /**
      * We need a destructor in the compilation unit to avoid the
      * EclipseSummary being a complete type here.
@@ -88,6 +98,7 @@ public:
 
 private:
     std::shared_ptr <const EclipseGridParser> parser_;
+    Opm::DeckConstPtr newParserDeck_;
     std::shared_ptr <const UnstructuredGrid> grid_;
     bool enableOutput_;
     int outputInterval_;


### PR DESCRIPTION
This finishes the quest to make EclipseWriter fit for the Norne deck. Note that the patches in this series are self contained and could equally well be splitted into two separate PRs. (Which I will do if you like the first patch, but not the second...)
