### PR TITLE
Fixes compilation of BlackoilPropertiesFromDeck.cpp.

### DIFF
--- a/opm/core/props/BlackoilPropertiesFromDeck.cpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck.cpp
@@ -50,7 +50,7 @@ namespace Opm
            rock_.init(newParserDeck, grid);
         }
         pvt_.init(newParserDeck, /*numSamples=*/0);
-        SaturationPropsFromDeck<SatFuncSimpleUniform>* ptr
+        SaturationPropsFromDeck<SatFuncSimpleNonuniform>* ptr
             = new SaturationPropsFromDeck<SatFuncSimpleNonuniform>();
         satprops_.reset(ptr);
         ptr->init(newParserDeck, grid, /*numSamples=*/0);


### PR DESCRIPTION
My patch 31c09aed was erroneous as it was trying to assing a
SaturationPropsFromDeck<SatFuncSimpleNonuniform> to a
SaturationPropsFromDeck<SatFuncSimpleUniform> in the constructor
taking the new parser. This patch fixes this.
