### PR TITLE
endpoint scaling: change default threephase_model to gwseg

### DIFF
--- a/opm/core/props/BlackoilPropertiesFromDeck.cpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck.cpp
@@ -139,9 +139,9 @@ namespace Opm
 
         // Unfortunate lack of pointer smartness here...
         const int sat_samples = param.getDefault("sat_tab_size", 0);
-        std::string threephase_model = param.getDefault<std::string>("threephase_model", "simple");
-        if (newParserDeck->hasKeyword("ENDSCALE") && threephase_model != "simple") {
-            OPM_THROW(std::runtime_error, "Sorry, end point scaling currently available for the 'simple' model only.");
+        std::string threephase_model = param.getDefault<std::string>("threephase_model", "gwseg");
+        if (newParserDeck->hasKeyword("ENDSCALE") && threephase_model != "gwseg") {
+            OPM_THROW(std::runtime_error, "Sorry, end point scaling currently available for the 'gwseg' model only.");
         }
         if (sat_samples > 1) {
             if (threephase_model == "stone2") {


### PR DESCRIPTION
and throw an exception if "simple" is encountered...

According to Ove, gwseg should be used, because "gwseg is the model
relevant to the norne case - i.e the model eclipse uses.

The fix for the simple model has to wait for a refac of the satfunc
complex."
