### PR TITLE
Makes KAMG and FastAMG solver available with dune-istl 2.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ include (CMakeLists_files.cmake)
 
 macro (config_hook)
 #	opm_need_version_of ("dune-common")
+  opm_need_version_of ("dune-istl")
 	list (APPEND ${project}_CONFIG_IMPL_VARS
 		HAVE_DUNE_ISTL
 		)

--- a/cmake/Modules/opm-core-prereqs.cmake
+++ b/cmake/Modules/opm-core-prereqs.cmake
@@ -3,9 +3,6 @@
 
 # defines that must be present in config.h for our headers
 set (opm-core_CONFIG_VAR
-  DUNE_ISTL_VERSION_MAJOR
-  DUNE_ISTL_VERSION_MINOR
-  DUNE_ISTL_VERSION_REVISION
 	HAVE_ERT
 	HAVE_SUITESPARSE_UMFPACK_H
 	)


### PR DESCRIPTION
Previously we relied on the define DUNE_HAS_FAST_AMG to detect
whether these preconditioners are available. This define is only
available in the 2.2 release with cmake support. Therfore we now
addtionally test whether we are using dune-istl 2.3 or newer.

With this PR the new solvers become available for dune-istl 2.3 and above!
