### PR TITLE
Complete cf7f07b PR #530 to support FastAMG with dune-istl 2.3

### DIFF
--- a/opm/core/linalg/LinearSolverIstl.cpp
+++ b/opm/core/linalg/LinearSolverIstl.cpp
@@ -40,6 +40,10 @@
 #include <dune/istl/paamg/amg.hh>
 #include <dune/istl/paamg/kamg.hh>
 
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 3)
+#include <dune/istl/paamg/fastamg.hh>
+#endif
+
 #include <stdexcept>
 #include <iostream>
 


### PR DESCRIPTION
This fixes further occurences of DUNE_HAS_FASTAMG that were
missed in pull request #530.

Previously we relied on the define DUNE_HAS_FAST_AMG to detect
whether these preconditioners are available. This define is only
available in the 2.2 release with cmake support. Therfore we now
addtionally test whether we are using dune-istl 2.3 or newer.
