### PR TITLE
Use empty constructor to construct empty shared_ptr.

### DIFF
--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -1538,7 +1538,7 @@ EclipseWriter::EclipseWriter (
         std::shared_ptr <const EclipseGridParser> parser,
         std::shared_ptr <const UnstructuredGrid> grid)
     : parser_ (parser)
-    , newParserDeck_(0)
+    , newParserDeck_()
     , grid_ (grid)
     , uses_ (phaseUsageFromDeck (*parser))
 {
@@ -1592,7 +1592,7 @@ EclipseWriter::EclipseWriter (
         const ParameterGroup& params,
         Opm::DeckConstPtr newParserDeck,
         std::shared_ptr <const UnstructuredGrid> grid)
-    : parser_ (0)
+    : parser_ ()
     , newParserDeck_(newParserDeck)
     , grid_ (grid)
     , uses_ (phaseUsageFromDeck (newParserDeck))


### PR DESCRIPTION
At least for g++-4.4. shared_ptr does not have a constructor
taking an integer and therefore compilation fails. Therefore we
resort statements to construct empty pointers, like

```
parser_(0)
```

to using the empty constructor:

```
parser_()
```

This patch closes #533
