### PR TITLE
EclipseWriter: don't convert the pressure field to active cells

### DIFF
--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -1405,7 +1405,6 @@ void EclipseWriter::writeSolution_(const SimulatorTimer& timer,
         // thinkable, but this is also not in the most performance
         // critical code path!
         std::vector<double> tmp = reservoirState.pressure();
-        restrictToActiveCells_(tmp, *grid_);
         convertUnit_(tmp, toBar);
 
         sol.add(EclipseKeyword<float>("PRESSURE", tmp));


### PR DESCRIPTION
because that array already is restricted to the active cells...

found using ASAN.
