### PR TITLE
EclipseWriter: work around a GCC 4.4 smart_ptr bug

### DIFF
--- a/opm/core/io/OutputWriter.cpp
+++ b/opm/core/io/OutputWriter.cpp
@@ -48,7 +48,7 @@ private:
 /// Psuedo-constructor, can appear in template
 template <typename Format> unique_ptr <OutputWriter>
 create (const ParameterGroup& params,
-        std::shared_ptr <const EclipseGridParser> parser,
+        std::shared_ptr <EclipseGridParser> parser,
         std::shared_ptr <const UnstructuredGrid> grid) {
     return unique_ptr <OutputWriter> (new Format (params, parser, grid));
 }
@@ -61,7 +61,7 @@ create (const ParameterGroup& params,
 /// to the list below!
 typedef map <const char*, unique_ptr <OutputWriter> (*)(
         const ParameterGroup&,
-        std::shared_ptr <const EclipseGridParser>,
+        std::shared_ptr <EclipseGridParser>,
         std::shared_ptr <const UnstructuredGrid>)> map_t;
 map_t FORMATS = {
     { "output_ecl", &create <EclipseWriter> },
@@ -71,7 +71,7 @@ map_t FORMATS = {
 
 unique_ptr <OutputWriter>
 OutputWriter::create (const ParameterGroup& params,
-                      std::shared_ptr <const EclipseGridParser> parser,
+                      std::shared_ptr <EclipseGridParser> parser,
                       std::shared_ptr <const UnstructuredGrid> grid) {
     // allocate a list which will be filled with writers. this list
     // is initially empty (no output).

--- a/opm/core/io/OutputWriter.hpp
+++ b/opm/core/io/OutputWriter.hpp
@@ -108,7 +108,7 @@ public:
      */
     static std::unique_ptr <OutputWriter>
     create (const parameter::ParameterGroup& params,
-            std::shared_ptr <const EclipseGridParser> parser,
+            std::shared_ptr <EclipseGridParser> parser,
             std::shared_ptr <const UnstructuredGrid> grid);
 };
 

--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -1535,7 +1535,7 @@ void EclipseWriter::writeTimeStep(
 
 EclipseWriter::EclipseWriter (
         const ParameterGroup& params,
-        std::shared_ptr <const EclipseGridParser> parser,
+        std::shared_ptr <EclipseGridParser> parser,
         std::shared_ptr <const UnstructuredGrid> grid)
     : parser_ (parser)
     , newParserDeck_()

--- a/opm/core/io/eclipse/EclipseWriter.hpp
+++ b/opm/core/io/eclipse/EclipseWriter.hpp
@@ -60,7 +60,7 @@ public:
      * binary files using ERT.
      */
     EclipseWriter(const parameter::ParameterGroup& params,
-                  std::shared_ptr <const EclipseGridParser> parser,
+                  std::shared_ptr <EclipseGridParser> parser,
                   std::shared_ptr <const UnstructuredGrid> grid);
 
     /*!

--- a/opm/core/simulator/SimulatorOutput.cpp
+++ b/opm/core/simulator/SimulatorOutput.cpp
@@ -30,7 +30,7 @@ using namespace Opm;
 
 SimulatorOutputBase::SimulatorOutputBase (
         const parameter::ParameterGroup& params,
-        std::shared_ptr <const EclipseGridParser> parser,
+        std::shared_ptr <EclipseGridParser> parser,
         std::shared_ptr <const UnstructuredGrid> grid,
         std::shared_ptr <const SimulatorTimer> timer,
         std::shared_ptr <const SimulatorState> state,

--- a/opm/core/simulator/SimulatorOutput.hpp
+++ b/opm/core/simulator/SimulatorOutput.hpp
@@ -53,7 +53,7 @@ protected:
      * need to pick them up from the object members.
      */
     SimulatorOutputBase (const parameter::ParameterGroup& p,
-                         std::shared_ptr <const EclipseGridParser> parser,
+                         std::shared_ptr <EclipseGridParser> parser,
                          std::shared_ptr <const UnstructuredGrid> grid,
                          std::shared_ptr <const SimulatorTimer> timer,
                          std::shared_ptr <const SimulatorState> state,
@@ -139,7 +139,7 @@ private:
 template <typename Simulator>
 struct SimulatorOutput : public SimulatorOutputBase {
 	SimulatorOutput (const parameter::ParameterGroup& params,
-                     std::shared_ptr <const EclipseGridParser> parser,
+                     std::shared_ptr <EclipseGridParser> parser,
                      std::shared_ptr <const UnstructuredGrid> grid,
                      std::shared_ptr <const SimulatorTimer> timer,
                      std::shared_ptr <const SimulatorState> state,
@@ -161,7 +161,7 @@ struct SimulatorOutput : public SimulatorOutputBase {
      * the arguments passed exceeds the lifetime of this object.
      */
     SimulatorOutput (const parameter::ParameterGroup& params,
-                     const EclipseGridParser& parser,
+                     EclipseGridParser& parser,
                      const UnstructuredGrid& grid,
                      const SimulatorTimer& timer,
                      const SimulatorState& state,


### PR DESCRIPTION
maybe it is not a bug but the fact that GCC 4.4 uses a non-final c++-2011 spec. The problem is that GCC 4.4 does not implicitly convert `std::shared_ptr<$FOO>` to `std::shared_ptr<const $FOO>` which caused the recent Jenkins build errors at Statoil. Note that this problem only occurs with the output writer in conjunction with the old Eclipse parser, so OPM/opm-autodiff#105 also makes the problem disappear. The present patch addresses the root cause, though...
