### PR TITLE
Re-add the bhp reports to the summary output.

### DIFF
--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -1187,7 +1187,6 @@ struct EclipseWellBhp : public EclipseWellReport {
     virtual double update (const SimulatorTimer& /*timer*/,
                            const WellState& wellState)
     {
-        std::cout << "bhp(wellState) = " << bhp(wellState) << std::endl;
         return bhp(wellState);
     }
 };


### PR DESCRIPTION
It was lost in the shuffling bewteen branches when working on the new parser.
