### PR TITLE
Add test data files needed for test_equil to the right cmake list.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -187,7 +187,9 @@ list (APPEND TEST_DATA_FILES
 	tests/capillary.DATA
 	tests/capillary_overlap.DATA
 	tests/deadfluids.DATA
+	tests/equil_livegas.DATA
 	tests/equil_liveoil.DATA
+	tests/equil_rsvd_and_rvvd.DATA
 	tests/wetgas.DATA
 	tests/testBlackoilState1.DATA
 	tests/testBlackoilState2.DATA


### PR DESCRIPTION
This was forgotten in the equil-code just merged, it did not prevent successful building, but gave errors with make test.
