### PR TITLE
fix typo: it's PVCDO, not PVDCO

### DIFF
--- a/opm/core/props/pvt/BlackoilPvtProperties.cpp
+++ b/opm/core/props/pvt/BlackoilPvtProperties.cpp
@@ -33,7 +33,7 @@
 #include <opm/core/utility/linearInterpolation.hpp>
 
 #include <opm/parser/eclipse/Utility/PvtwTable.hpp>
-#include <opm/parser/eclipse/Utility/PvdcoTable.hpp>
+#include <opm/parser/eclipse/Utility/PvcdoTable.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
 namespace Opm
@@ -168,7 +168,7 @@ namespace Opm
 
                 props_[phase_usage_.phase_pos[Liquid]].reset(new SinglePvtLiveOil(pvtoTable));
             } else if (newParserDeck->hasKeyword("PVCDO")) {
-                Opm::PvdcoTable pvcdoTable(newParserDeck->getKeyword("PVCDO"));
+                Opm::PvcdoTable pvcdoTable(newParserDeck->getKeyword("PVCDO"));
 
                 props_[phase_usage_.phase_pos[Liquid]].reset(new SinglePvtConstCompr(pvcdoTable));
             } else {

--- a/opm/core/props/pvt/SinglePvtConstCompr.hpp
+++ b/opm/core/props/pvt/SinglePvtConstCompr.hpp
@@ -24,7 +24,7 @@
 #include <opm/core/utility/ErrorMacros.hpp>
 
 #include <opm/parser/eclipse/Utility/PvtwTable.hpp>
-#include <opm/parser/eclipse/Utility/PvdcoTable.hpp>
+#include <opm/parser/eclipse/Utility/PvcdoTable.hpp>
 
 #include <vector>
 #include <algorithm>
@@ -71,7 +71,7 @@ namespace Opm
             visc_comp_ = pvtwTable.getViscosibilityColumn()[0];
         }
 
-        SinglePvtConstCompr(const Opm::PvdcoTable &pvdcoTable)
+        SinglePvtConstCompr(const Opm::PvcdoTable &pvdcoTable)
         {
             if (pvdcoTable.numRows() != 1)
                 OPM_THROW(std::runtime_error,


### PR DESCRIPTION
(since the parser did not have a definition for this keyword until
_very_ recently, I severly doubt that these code paths have been used
recently...)

This one depends on OPM/opm-parser#179
