### PR TITLE
add the missing TABDIMS keyword to the live oil and wet gas unit test data files

### DIFF
--- a/tests/liveoil.DATA
+++ b/tests/liveoil.DATA
@@ -1,3 +1,8 @@
+TABDIMS
+-- use the defaults of TABDIMS but the keyword must be present in the deck
+-- for it to be usable
+/
+
 OIL
 GAS
 WATER

--- a/tests/wetgas.DATA
+++ b/tests/wetgas.DATA
@@ -1,3 +1,8 @@
+TABDIMS
+-- use the defaults of TABDIMS but the keyword must be present in the deck
+-- for it to be usable
+/
+
 WATER
 OIL
 GAS


### PR DESCRIPTION
these are required for the new parser. (without them, these files
would be invalid AFAICT, but I'm not an Eclipse file format expert...)
