### PR TITLE
[buildsystem] Make dune-cornerpoint a suggestion.

### DIFF
--- a/cmake/Modules/Finddune-cornerpoint.cmake
+++ b/cmake/Modules/Finddune-cornerpoint.cmake
@@ -26,7 +26,7 @@ find_opm_package (
   "dunecornerpoint"
 
   # defines to be added to compilations
-  ""
+  "HAVE_DUNE_CORNERPOINT"
 
   # test program
 "#include <dune/grid/CpGrid.hpp>

--- a/cmake/Modules/opm-autodiff-prereqs.cmake
+++ b/cmake/Modules/opm-autodiff-prereqs.cmake
@@ -3,6 +3,7 @@
 
 # defines that must be present in config.h for our headers
 set (opm-autodiff_CONFIG_VAR
+  HAVE_DUNE_CORNERPOINT
 	)
 
 # dependencies
@@ -17,6 +18,7 @@ set (opm-autodiff_DEPS
 	# DUNE prerequisites
 	"dune-common REQUIRED;
 	dune-istl REQUIRED;
+        dune-cornerpoint;
 	opm-core REQUIRED"
 	# Eigen
 	"Eigen3 3.1.2 "


### PR DESCRIPTION
This change-set enables the opm-autodiff build system to recognise dune-cornerpoint support.

This is a synchronisation PR only.
