### PR TITLE
Fix option name to match name in use in conditional.

### DIFF
--- a/cmake/Modules/UseWarnings.cmake
+++ b/cmake/Modules/UseWarnings.cmake
@@ -13,7 +13,7 @@ if (CXX_COMPAT_GCC)
   endif (_warn_flag)
 endif ()
 
-option(SILENCE_DUNE_WARNINGS "Disable warnings from DUNE?" OFF)
+option(SILENCE_EXTERNAL_WARNINGS "Disable some warnings from external packages (requires GCC 4.6 or newer)" OFF)
 if(SILENCE_EXTERNAL_WARNINGS AND CXX_COMPAT_GCC)
   file(WRITE ${CMAKE_BINARY_DIR}/disable_warning_pragmas.h "
 #pragma GCC diagnostic push


### PR DESCRIPTION
A mistake was made when renaming the option (not renaming it everywhere).

This did not create any trouble for me, perhaps since I did not use ccmake to set my options but give them in a cache preload file with the -C option to cmake. Anyone who tried to activate the option in ccmake would probably not see the wished-for effect, anyway.

Also added a doc string that specifies minimum gcc version.
