### PR TITLE
adapt to the renames of the table classes in opm-parser

### DIFF
--- a/opm/core/props/pvt/SinglePvtDeadSpline.cpp
+++ b/opm/core/props/pvt/SinglePvtDeadSpline.cpp
@@ -21,7 +21,7 @@
 #include <opm/core/props/pvt/SinglePvtDeadSpline.hpp>
 #include <opm/core/utility/buildUniformMonotoneTable.hpp>
 
-#include <opm/parser/eclipse/Utility/SimpleTable.hpp>
+#include <opm/parser/eclipse/Utility/SingleRecordTable.hpp>
 
 #include <algorithm>
 

--- a/opm/core/props/satfunc/SaturationPropsFromDeck_impl.hpp
+++ b/opm/core/props/satfunc/SaturationPropsFromDeck_impl.hpp
@@ -1075,7 +1075,7 @@ namespace Opm
                 depth_col.resize(num_tables);
                 col_names.resize(9);
                 for (int table_num=0; table_num<num_tables; ++table_num) {
-                    Opm::SimpleTable enptvd(newParserDeck->getKeyword("ENPTVD"), col_names, table_num);
+                    Opm::SingleRecordTable enptvd(newParserDeck->getKeyword("ENPTVD"), col_names, table_num);
                     depth_col[table_num] = enptvd.getColumn(0); // depth
                     param_col[table_num] = enptvd.getColumn(itab); // itab=[1-8]: swl swcr swu sgl sgcr sgu sowcr sogcr
                 }
@@ -1138,7 +1138,7 @@ namespace Opm
                 depth_col.resize(num_tables);
                 col_names.resize(8);
                 for (int table_num=0; table_num<num_tables; ++table_num) {
-                    Opm::SimpleTable enkrvd(newParserDeck->getKeyword("ENKRVD"), col_names, table_num);
+                    Opm::SingleRecordTable enkrvd(newParserDeck->getKeyword("ENKRVD"), col_names, table_num);
                     depth_col[table_num] = enkrvd.getColumn(0); // depth
                     param_col[table_num] = enkrvd.getColumn(itab); // itab=[1-7]: krw krg kro krwr krgr krorw krorg
                 }

--- a/opm/core/simulator/initStateEquil.hpp
+++ b/opm/core/simulator/initStateEquil.hpp
@@ -28,7 +28,7 @@
 #include <opm/core/utility/RegionMapping.hpp>
 #include <opm/core/utility/Units.hpp>
 #include <opm/parser/eclipse/Utility/EquilWrapper.hpp>
-#include <opm/parser/eclipse/Utility/SimpleTable.hpp>
+#include <opm/parser/eclipse/Utility/SingleRecordTable.hpp>
 
 #include <array>
 #include <cassert>
@@ -527,7 +527,7 @@ namespace Opm
                             if (rec[i].live_oil_table_index > 0) {
                                 if (newParserDeck->hasKeyword("RSVD") &&
                                     size_t(rec[i].live_oil_table_index) <= newParserDeck->getKeyword("RSVD")->size()) { 
-                                    Opm::SimpleTable rsvd(newParserDeck->getKeyword("RSVD"),std::vector<std::string>{"vd", "rs"},rec[i].live_oil_table_index-1);                                
+                                    Opm::SingleRecordTable rsvd(newParserDeck->getKeyword("RSVD"),std::vector<std::string>{"vd", "rs"},rec[i].live_oil_table_index-1);                                
                                     std::vector<double> vd(rsvd.getColumn("vd"));
                                     std::vector<double> rs(rsvd.getColumn("rs"));
                                     rs_func_.push_back(std::make_shared<Miscibility::RsVD>(props, cell, vd, rs));
@@ -558,7 +558,7 @@ namespace Opm
                             if (rec[i].wet_gas_table_index > 0) {
                                 if (newParserDeck->hasKeyword("RVVD") &&
                                     size_t(rec[i].wet_gas_table_index) <= newParserDeck->getKeyword("RVVD")->size()) { 
-                                    Opm::SimpleTable rvvd(newParserDeck->getKeyword("RVVD"),std::vector<std::string>{"vd", "rv"},rec[i].wet_gas_table_index-1);                                
+                                    Opm::SingleRecordTable rvvd(newParserDeck->getKeyword("RVVD"),std::vector<std::string>{"vd", "rv"},rec[i].wet_gas_table_index-1);                                
                                     std::vector<double> vd(rvvd.getColumn("vd"));
                                     std::vector<double> rv(rvvd.getColumn("rv"));
                                     rv_func_.push_back(std::make_shared<Miscibility::RvVD>(props, cell, vd, rv));


### PR DESCRIPTION
basically, "Opm::SimpleTable" becomes "Opm::SingleRecordTable".

This must be merged synchronously with the corresponding OPM/opm-parser#201...
