### PR TITLE
Eclipse summary output: always convert the simulation time to days

### DIFF
--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -762,7 +762,8 @@ private:
                                      false, /* formatted   */
                                      true,  /* unified     */
                                      ":",    /* join string */
-                                     timer.simulationTimeElapsed (),
+                                     Opm::unit::convert::to (timer.simulationTimeElapsed (),
+                                                             Opm::unit::day),
                                      dim[0],
                                      dim[1],
                                      dim[2]);


### PR DESCRIPTION
this seems to have been forgotten in one place...
