### PR TITLE
Glue in support for the grid property modifier keywords

### DIFF
--- a/examples/compute_initial_state.cpp
+++ b/examples/compute_initial_state.cpp
@@ -86,10 +86,11 @@ try
     const std::string deck_filename = param.get<std::string>("deck_filename");
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::DeckConstPtr deck = parser->parseFile(deck_filename);
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck));
     const double grav = param.getDefault("gravity", unit::gravity);
     GridManager gm(deck);
     const UnstructuredGrid& grid = *gm.c_grid();
-    BlackoilPropertiesFromDeck props(deck, grid, param);
+    BlackoilPropertiesFromDeck props(deck, eclipseState, grid, param);
     warnIfUnusedParams(param);
 
     // Initialisation.

--- a/examples/compute_tof.cpp
+++ b/examples/compute_tof.cpp
@@ -121,7 +121,7 @@ try
         // Grid init
         grid.reset(new GridManager(deck));
         // Rock and fluid init
-        props.reset(new IncompPropertiesFromDeck(deck, *grid->c_grid()));
+        props.reset(new IncompPropertiesFromDeck(deck, eclipseState, *grid->c_grid()));
         // Wells init.
         wells.reset(new Opm::WellsManager(eclipseState , 0 , *grid->c_grid(), props->permeability()));
         // Gravity.

--- a/examples/sim_2p_comp_reorder.cpp
+++ b/examples/sim_2p_comp_reorder.cpp
@@ -99,12 +99,12 @@ try
     if (use_deck) {
         std::string deck_filename = param.get<std::string>("deck_filename");
         deck = parser->parseFile(deck_filename);
-
         eclipseState.reset(new EclipseState(deck));
+
         // Grid init
         grid.reset(new GridManager(deck));
         // Rock and fluid init
-        props.reset(new BlackoilPropertiesFromDeck(deck, *grid->c_grid(), param));
+        props.reset(new BlackoilPropertiesFromDeck(deck, eclipseState, *grid->c_grid(), param));
         // check_well_controls = param.getDefault("check_well_controls", false);
         // max_well_control_iterations = param.getDefault("max_well_control_iterations", 10);
         // Rock compressibility.

--- a/examples/sim_2p_incomp.cpp
+++ b/examples/sim_2p_incomp.cpp
@@ -113,11 +113,12 @@ try
 
         std::string deck_filename = param.get<std::string>("deck_filename");
         deck = parser->parseFile(deck_filename);
+        EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck));
         eclipseState.reset( new EclipseState(deck));
         // Grid init
         grid.reset(new GridManager(deck));
         // Rock and fluid init
-        props.reset(new IncompPropertiesFromDeck(deck, *grid->c_grid()));
+        props.reset(new IncompPropertiesFromDeck(deck, eclipseState, *grid->c_grid()));
         // check_well_controls = param.getDefault("check_well_controls", false);
         // max_well_control_iterations = param.getDefault("max_well_control_iterations", 10);
         // Rock compressibility.

--- a/examples/wells_example.cpp
+++ b/examples/wells_example.cpp
@@ -36,15 +36,15 @@ try
     // Read input file
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck = parser->parseFile(file_name);
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck));
     std::cout << "Done!" << std::endl;
 
     // Setup grid
     GridManager grid(deck);
 
     // Define rock and fluid properties
-    IncompPropertiesFromDeck incomp_properties(deck, *grid.c_grid());
+    IncompPropertiesFromDeck incomp_properties(deck, eclipseState, *grid.c_grid());
     RockCompressibility rock_comp(deck);
-    EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck));
 
     // Finally handle the wells
     WellsManager wells(eclipseState , 0 , *grid.c_grid(), incomp_properties.permeability());

--- a/opm/core/props/BlackoilPropertiesFromDeck.cpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck.cpp
@@ -24,19 +24,21 @@
 namespace Opm
 {
     BlackoilPropertiesFromDeck::BlackoilPropertiesFromDeck(Opm::DeckConstPtr deck,
+                                                           Opm::EclipseStateConstPtr eclState,
                                                            const UnstructuredGrid& grid,
                                                            bool init_rock)
     {
-        init(deck, grid.number_of_cells, grid.global_cell, grid.cartdims,
+        init(deck, eclState, grid.number_of_cells, grid.global_cell, grid.cartdims,
              grid.cell_centroids, grid.dimensions, init_rock);
     }
 
     BlackoilPropertiesFromDeck::BlackoilPropertiesFromDeck(Opm::DeckConstPtr deck,
+                                                           Opm::EclipseStateConstPtr eclState,
                                                            const UnstructuredGrid& grid,
                                                            const parameter::ParameterGroup& param,
                                                            bool init_rock)
     {
-        init(deck, grid.number_of_cells, grid.global_cell, grid.cartdims, grid.cell_centroids, 
+        init(deck, eclState, grid.number_of_cells, grid.global_cell, grid.cartdims, grid.cell_centroids, 
              grid.dimensions, param, init_rock);
     }
 

--- a/opm/core/props/BlackoilPropertiesFromDeck.hpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck.hpp
@@ -47,6 +47,7 @@ namespace Opm
         ///                      mapping from cell indices (typically from a processed grid)
         ///                      to logical cartesian indices consistent with the deck.
         BlackoilPropertiesFromDeck(Opm::DeckConstPtr deck,
+                                   Opm::EclipseStateConstPtr eclState,
                                    const UnstructuredGrid& grid, bool init_rock=true );
 
         /// Initialize from deck, grid and parameters.
@@ -61,6 +62,7 @@ namespace Opm
         ///                      For both size parameters, a 0 or negative value indicates that no spline fitting is to
         ///                      be done, and the input fluid data used directly for linear interpolation.
         BlackoilPropertiesFromDeck(Opm::DeckConstPtr deck,
+                                   Opm::EclipseStateConstPtr eclState,
                                    const UnstructuredGrid& grid,
                                    const parameter::ParameterGroup& param,
                                    bool init_rock=true);
@@ -68,6 +70,7 @@ namespace Opm
 
         template<class CentroidIterator>
         BlackoilPropertiesFromDeck(Opm::DeckConstPtr  deck,
+                                   Opm::EclipseStateConstPtr eclState,
                                    int number_of_cells,
                                    const int* global_cell,
                                    const int* cart_dims,
@@ -77,6 +80,7 @@ namespace Opm
 
         template<class CentroidIterator>
         BlackoilPropertiesFromDeck(Opm::DeckConstPtr  deck,
+                                   Opm::EclipseStateConstPtr eclState,
                                    int number_of_cells,
                                    const int* global_cell,
                                    const int* cart_dims,
@@ -222,6 +226,7 @@ namespace Opm
 
         template<class CentroidIterator>
         void init(Opm::DeckConstPtr deck,
+                  Opm::EclipseStateConstPtr eclState,
                   int number_of_cells,
                   const int* global_cell,
                   const int* cart_dims,
@@ -230,6 +235,7 @@ namespace Opm
                   bool init_rock);
         template<class CentroidIterator>
         void init(Opm::DeckConstPtr deck,
+                  Opm::EclipseStateConstPtr eclState,
                   int number_of_cells,
                   const int* global_cell,
                   const int* cart_dims,

--- a/opm/core/props/BlackoilPropertiesFromDeck_impl.hpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck_impl.hpp
@@ -2,6 +2,7 @@ namespace Opm
 {
     template<class CentroidIterator>
     BlackoilPropertiesFromDeck::BlackoilPropertiesFromDeck(Opm::DeckConstPtr deck,
+                                                           Opm::EclipseStateConstPtr eclState,
                                                            int number_of_cells,
                                                            const int* global_cell,
                                                            const int* cart_dims,
@@ -9,12 +10,13 @@ namespace Opm
                                                            int dimension,
                                                            bool init_rock)
     {
-        init(deck, number_of_cells, global_cell, cart_dims, begin_cell_centroids, dimension,
+        init(deck, eclState, number_of_cells, global_cell, cart_dims, begin_cell_centroids, dimension,
              init_rock);
     }
 
     template<class CentroidIterator>
     BlackoilPropertiesFromDeck::BlackoilPropertiesFromDeck(Opm::DeckConstPtr deck,
+                                                           Opm::EclipseStateConstPtr eclState,
                                                            int number_of_cells,
                                                            const int* global_cell,
                                                            const int* cart_dims,
@@ -24,6 +26,7 @@ namespace Opm
                                                            bool init_rock)
     {
         init(deck,
+             eclState,
              number_of_cells,
              global_cell,
              cart_dims,
@@ -35,6 +38,7 @@ namespace Opm
 
     template<class CentroidIterator>
     inline void BlackoilPropertiesFromDeck::init(Opm::DeckConstPtr deck,
+                                                 Opm::EclipseStateConstPtr eclState,
                                                  int number_of_cells,
                                                  const int* global_cell,
                                                  const int* cart_dims,
@@ -47,7 +51,7 @@ namespace Opm
         extractPvtTableIndex(cellPvtRegionIdx_, deck, number_of_cells, global_cell);
 
         if (init_rock){
-           rock_.init(deck, number_of_cells, global_cell, cart_dims);
+           rock_.init(eclState, number_of_cells, global_cell, cart_dims);
         }
         pvt_.init(deck, /*numSamples=*/0);
         SaturationPropsFromDeck<SatFuncSimpleNonuniform>* ptr
@@ -64,6 +68,7 @@ namespace Opm
 
     template<class CentroidIterator>
     inline void BlackoilPropertiesFromDeck::init(Opm::DeckConstPtr deck,
+                                                 Opm::EclipseStateConstPtr eclState,
                                                  int number_of_cells,
                                                  const int* global_cell,
                                                  const int* cart_dims,
@@ -77,7 +82,7 @@ namespace Opm
         extractPvtTableIndex(cellPvtRegionIdx_, deck, number_of_cells, global_cell);
 
         if(init_rock){
-            rock_.init(deck, number_of_cells, global_cell, cart_dims);
+            rock_.init(eclState, number_of_cells, global_cell, cart_dims);
         }
 
         const int pvt_samples = param.getDefault("pvt_tab_size", 200);

--- a/opm/core/props/IncompPropertiesFromDeck.cpp
+++ b/opm/core/props/IncompPropertiesFromDeck.cpp
@@ -27,9 +27,10 @@
 namespace Opm
 {
     IncompPropertiesFromDeck::IncompPropertiesFromDeck(Opm::DeckConstPtr deck,
+                                                       Opm::EclipseStateConstPtr eclState,
                                                        const UnstructuredGrid& grid)
     {
-        rock_.init(deck, grid.number_of_cells, grid.global_cell, grid.cartdims);
+        rock_.init(eclState, grid.number_of_cells, grid.global_cell, grid.cartdims);
         pvt_.init(deck);
         satprops_.init(deck, grid, 200);
         if (pvt_.numPhases() != satprops_.numPhases()) {

--- a/opm/core/props/IncompPropertiesFromDeck.hpp
+++ b/opm/core/props/IncompPropertiesFromDeck.hpp
@@ -21,6 +21,7 @@
 #define OPM_INCOMPPROPERTIESFROMDECK_HEADER_INCLUDED
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/core/props/IncompPropertiesInterface.hpp>
 #include <opm/core/props/rock/RockFromDeck.hpp>
 #include <opm/core/props/pvt/PvtPropertiesIncompFromDeck.hpp>
@@ -47,10 +48,12 @@ namespace Opm
     public:
         /// Initialize from deck and grid.
         /// \param  deck         Deck input parser
+        /// \param  eclState        The EclipseState (processed deck) produced by the opm-parser code
         /// \param  grid         Grid to which property object applies, needed for the
         ///                      mapping from cell indices (typically from a processed grid)
         ///                      to logical cartesian indices consistent with the deck.
         IncompPropertiesFromDeck(Opm::DeckConstPtr deck,
+                                 Opm::EclipseStateConstPtr eclState,
                                  const UnstructuredGrid& grid);
 
         /// Destructor.

--- a/opm/core/props/rock/RockFromDeck.hpp
+++ b/opm/core/props/rock/RockFromDeck.hpp
@@ -20,7 +20,7 @@
 #ifndef OPM_ROCKFROMDECK_HEADER_INCLUDED
 #define OPM_ROCKFROMDECK_HEADER_INCLUDED
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
 #include <vector>
 
@@ -36,12 +36,12 @@ namespace Opm
         RockFromDeck();
 
         /// Initialize from deck and cell mapping.
-        /// \param  deck            Deck produced by the opm-parser code
+        /// \param  eclState        The EclipseState (processed deck) produced by the opm-parser code
         /// \param  number_of_cells The number of cells in the grid.
         /// \param  global_cell     The mapping fom local to global cell indices.
         ///                         global_cell[i] is the corresponding global index of i.
         /// \param  cart_dims       The size of the underlying cartesian grid.
-        void init(Opm::DeckConstPtr deck,
+        void init(Opm::EclipseStateConstPtr eclState,
                   int number_of_cells, const int* global_cell,
                   const int* cart_dims);
 
@@ -72,10 +72,10 @@ namespace Opm
         }
 
     private:
-        void assignPorosity(Opm::DeckConstPtr deck,
+        void assignPorosity(Opm::EclipseStateConstPtr eclState,
                             int number_of_cells,
                             const int* global_cell);
-        void assignPermeability(Opm::DeckConstPtr deck,
+        void assignPermeability(Opm::EclipseStateConstPtr eclState,
                                 int number_of_cells,
                                 const int* global_cell,
                                 const int* cart_dims,

--- a/tests/capillary.DATA
+++ b/tests/capillary.DATA
@@ -1,6 +1,17 @@
+-- Most of the following sections are not actually needed by the test,
+-- but it is required by the Eclipse reference manual that they are
+-- present. Also, the higher level opm-parser classes
+-- (i.e. Opm::EclipseState et al.) assume that they are present.
+
+-------------------------------------
+RUNSPEC
+
 WATER
 OIL
 GAS
+
+DIMENS
+3 3 3 /
 
 TABDIMS
   1    1   40   20    1   20  /
@@ -8,6 +19,27 @@ TABDIMS
 EQLDIMS
 -- NTEQUL
      1 /
+
+-------------------------------------
+GRID
+
+-- Opm::EclipseState assumes that _some_ grid gets defined, so let's
+-- specify a fake one...
+
+DXV
+1 2 3 /
+
+DYV
+4 5 6 /
+
+DZV
+7 8 9 /
+
+DEPTHZ
+16*123.456 /
+
+-------------------------------------
+PROPS
 
 PVDO
 100 1.0 1.0
@@ -37,6 +69,13 @@ DENSITY
 700 1000 1
 /
 
+-------------------------------------
+SOLUTION
+
 EQUIL
 50 150 50 0.25 20 0.35 1* 1* 0
 /
+
+-------------------------------------
+SCHEDULE
+-- empty section

--- a/tests/deadfluids.DATA
+++ b/tests/deadfluids.DATA
@@ -1,6 +1,17 @@
+-- Most of the following sections are not actually needed by the test,
+-- but it is required by the Eclipse reference manual that they are
+-- present. Also, the higher level opm-parser classes
+-- (i.e. Opm::EclipseState et al.) assume that they are present.
+
+-------------------------------------
+RUNSPEC
+
 WATER
 OIL
 GAS
+
+DIMENS
+3 3 3 /
 
 TABDIMS
   1    1   40   20    1   20  /
@@ -8,6 +19,27 @@ TABDIMS
 EQLDIMS
 -- NTEQUL
      1 /
+
+-------------------------------------
+GRID
+
+-- Opm::EclipseState assumes that _some_ grid gets defined, so let's
+-- specify a fake one...
+
+DXV
+1 2 3 /
+
+DYV
+4 5 6 /
+
+DZV
+7 8 9 /
+
+DEPTHZ
+16*123.456 /
+
+-------------------------------------
+PROPS
 
 PVDO
 100 1.0 1.0
@@ -37,6 +69,13 @@ DENSITY
 700 1000 10
 /
 
+-------------------------------------
+SOLUTION
+
 EQUIL
 5 150 5 0 2 0 1* 1* 0
 /
+
+-------------------------------------
+SCHEDULE
+-- empty section

--- a/tests/test_equil.cpp
+++ b/tests/test_equil.cpp
@@ -336,7 +336,8 @@ BOOST_AUTO_TEST_CASE (DeckAllDead)
         grid(create_grid_cart3d(1, 1, 10), destroy_grid);
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::DeckConstPtr deck = parser->parseFile("deadfluids.DATA");
-    Opm::BlackoilPropertiesFromDeck props(deck, *grid, false);
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck));
+    Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, *grid, false);
     Opm::Equil::DeckDependent::InitialStateComputer comp(props, deck, *grid, 10.0);
     const auto& pressures = comp.press();
     BOOST_REQUIRE(pressures.size() == 3);
@@ -362,7 +363,8 @@ BOOST_AUTO_TEST_CASE (CapillaryInversion)
     const UnstructuredGrid& grid = *(gm.c_grid());
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::DeckConstPtr deck = parser->parseFile("capillary.DATA");
-    Opm::BlackoilPropertiesFromDeck props(deck, grid, false);
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck));
+    Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, false);
 
     // Test the capillary inversion for oil-water.
     const int cell = 0;
@@ -414,7 +416,8 @@ BOOST_AUTO_TEST_CASE (DeckWithCapillary)
     const UnstructuredGrid& grid = *(gm.c_grid());
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::DeckConstPtr deck = parser->parseFile("capillary.DATA");
-    Opm::BlackoilPropertiesFromDeck props(deck, grid, false);
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck));
+    Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, false);
 
     Opm::Equil::DeckDependent::InitialStateComputer comp(props, deck, grid, 10.0);
     const auto& pressures = comp.press();
@@ -453,7 +456,8 @@ BOOST_AUTO_TEST_CASE (DeckWithCapillaryOverlap)
     const UnstructuredGrid& grid = *(gm.c_grid());
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::DeckConstPtr deck = parser->parseFile("capillary_overlap.DATA");
-    Opm::BlackoilPropertiesFromDeck props(deck, grid, false);
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck));
+    Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, false);
 
     Opm::Equil::DeckDependent::InitialStateComputer comp(props, deck, grid, 9.80665);
     const auto& pressures = comp.press();
@@ -514,7 +518,8 @@ BOOST_AUTO_TEST_CASE (DeckWithLiveOil)
     const UnstructuredGrid& grid = *(gm.c_grid());
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::DeckConstPtr deck = parser->parseFile("equil_liveoil.DATA");
-    Opm::BlackoilPropertiesFromDeck props(deck, grid, false);
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck));
+    Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, false);
 
     Opm::Equil::DeckDependent::InitialStateComputer comp(props, deck, grid, 9.80665);
     const auto& pressures = comp.press();
@@ -592,7 +597,8 @@ BOOST_AUTO_TEST_CASE (DeckWithLiveGas)
     const UnstructuredGrid& grid = *(gm.c_grid());
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::DeckConstPtr deck = parser->parseFile("equil_livegas.DATA");
-    Opm::BlackoilPropertiesFromDeck props(deck, grid, false);
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck));
+    Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, false);
 
     Opm::Equil::DeckDependent::InitialStateComputer comp(props, deck, grid, 9.80665);
     const auto& pressures = comp.press();
@@ -673,7 +679,8 @@ BOOST_AUTO_TEST_CASE (DeckWithRSVDAndRVVD)
     const UnstructuredGrid& grid = *(gm.c_grid());
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::DeckConstPtr deck = parser->parseFile("equil_rsvd_and_rvvd.DATA");
-    Opm::BlackoilPropertiesFromDeck props(deck, grid, false);
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck));
+    Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, false);
 
     Opm::Equil::DeckDependent::InitialStateComputer comp(props, deck, grid, 9.80665);
     const auto& pressures = comp.press();


### PR DESCRIPTION
this basically means using Opm::EclipseState instead of the raw deck
for these keywords.

with this, property modifiers like ADD, MULT, COPY and friends are
supported for at least the PERM\* keywords. If additional keywords are
required these can be added relatively easily as well.

no ctest regressions have been observed with this patch on my machine.

note that in order to avoid build breakage, this patch needs to be merged synchronously with the respective opm-autodiff and opm-polymer PRs.

also note that the norne deck is broken until OPM/opm-parser#232 is merged. (which should not be too long away.) This _might_ have something to do with this PR but it is more likely that the breakage has already been introduced when EclipseState began to process property modifiers last week. I haven't bothered to check, though....
