### PR TITLE
[buildsystem] Disable search for Boost in parser detection

### DIFF
--- a/cmake/Modules/Findopm-parser.cmake
+++ b/cmake/Modules/Findopm-parser.cmake
@@ -109,10 +109,10 @@ if (NOT CJSON_FOUND)
   find_package(cjson ${opm-parser_FIND_REQUIRED} ${OPM_PARSER_QUIET})
 endif ()
 
-# get the prerequisite Boost libraries
-find_package(Boost 1.44.0
-  COMPONENTS filesystem date_time system unit_test_framework
-  ${opm-parser_FIND_REQUIRED} ${OPM_PARSER_QUIET})
+# # get the prerequisite Boost libraries
+# find_package(Boost 1.44.0
+#   COMPONENTS filesystem date_time system unit_test_framework
+#   ${opm-parser_FIND_REQUIRED} ${OPM_PARSER_QUIET})
 
 if (NOT CJSON_FOUND OR NOT ERT_FOUND OR NOT Boost_FOUND)
   set(opm-parser_FOUND "0")


### PR DESCRIPTION
This changeset disables the effect of commit e9a5e82.  There appears to be an unforeseen interaction between the calls to

``` cmake
Find_Package (Boost)
```

that are implied by module `opm-core-prereqs.cmake` and the one that's directly invoked in `Findopm-parser.cmake`.  Until the situation can be fully analysed and a complete solution implemented, this is a temporary measure to restore the build of opm-core and downstream OPM modules.
