### PR TITLE
add the boost::regex library as a prerequisite

### DIFF
--- a/cmake/Modules/Findopm-parser.cmake
+++ b/cmake/Modules/Findopm-parser.cmake
@@ -115,7 +115,7 @@ if (NOT CJSON_FOUND)
 endif ()
 
 # get the prerequisite Boost libraries
-find_package(Boost 1.44.0 COMPONENTS filesystem date_time system unit_test_framework ${OPM_PARSER_QUIET})
+find_package(Boost 1.44.0 COMPONENTS filesystem date_time system unit_test_framework regex ${OPM_PARSER_QUIET})
 
 if (CJSON_FOUND AND ERT_FOUND AND Boost_FOUND AND
     OPM_PARSER_LIBRARY AND OPM_JSON_LIBRARY AND OPM_PARSER_INCLUDE_DIR)


### PR DESCRIPTION
this is required for regex-matching keywords. Once GCC 4.9 is the
minimum compiler version to be supported, this can be dropped in favor
of std::regex ...

note that this patch should be propagated to all other modules before OPM/opm-parser#249 is merged. (in other words: ASAP.)
