### PR TITLE
use extended regular expressions in the test for std::regex

### DIFF
--- a/cmake/Modules/FindCXX11Features.cmake
+++ b/cmake/Modules/FindCXX11Features.cmake
@@ -133,7 +133,7 @@ CHECK_CXX_SOURCE_RUNS("
     #include <regex>
     int main(void)
     {
-      std::regex r(\"AB.*|BC+\");
+      std::regex r(\"AB.*|BC+\", std::regex::extended);
       if (!std::regex_match(\"AB\", r))
            return 1;
       if (!std::regex_match(\"ABC\", r))


### PR DESCRIPTION
for some compilers (e.g., GCC < 4.9) the default is buggy and
opm-parser thus uses extended expressions...

thanks to [at]bska for digging this up!
