### PR TITLE
Disable "test_equil" test

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -169,7 +169,7 @@ list (APPEND TEST_SOURCE_FILES
 	tests/test_param.cpp
 	tests/test_blackoilfluid.cpp
 	tests/test_shadow.cpp
-	tests/test_equil.cpp
+	#tests/test_equil.cpp  # 2014-07-08 Disabled due to breaking CI system
 	tests/test_regionmapping.cpp
 	tests/test_units.cpp
 	tests/test_blackoilstate.cpp


### PR DESCRIPTION
This test breaks the Continuous Integration system (Jenkins).  While we investigate the underlying causes it is better to restore the build to pristine order.
