### PR TITLE
ERT: link to the pthreads library

### DIFF
--- a/cmake/Modules/FindERT.cmake
+++ b/cmake/Modules/FindERT.cmake
@@ -182,6 +182,13 @@ if (UNIX)
   list (APPEND ERT_LIBRARIES ${MATH_LIBRARY})
 endif (UNIX)
 
+# if shared libraries are disabled on linux, explcitly linking to the
+# pthreads library is required by ERT
+find_package(Threads ${ERT_QUIET})
+if (CMAKE_THREAD_LIBS_INIT)
+  list (APPEND ERT_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+endif()
+
 # Platform specific library where dlopen with friends lives
 list (APPEND ERT_LIBRARIES ${CMAKE_DL_LIBS})
 


### PR DESCRIPTION
this is required to make the opm-core build succeed if ERT was build
with -DBUILD_SHARED_LIBS=OFF . (without it, I get errors like

```
/home/and/src/ert/devel/libert_util/src/thread_pool_posix.c:328: error: undefined reference to 'pthread_create'
```
