### PR TITLE
Correct a number of minor issues in capillary pressure scaling code

### DIFF
--- a/opm/core/props/satfunc/SaturationPropsFromDeck_impl.hpp
+++ b/opm/core/props/satfunc/SaturationPropsFromDeck_impl.hpp
@@ -420,7 +420,7 @@ namespace Opm
     template <class SatFuncSet>
     void SaturationPropsFromDeck<SatFuncSet>::swatInitScaling(const int cell,
                                                               const double pcow,
-                                                              double & swat)
+                                                              double& swat)
     {
         if (phase_usage_.phase_used[BlackoilPhases::Aqua]) {
             const double pc_low_threshold = 1.0e-8;


### PR DESCRIPTION
This change-set fixes a correctness issue (use of variable-length arrays) and removes two inconsistencies from the implementation of function

``` C++
SaturationPropsFromDeck<SatFuncSet>::swatInitScaling()
```
