### PR TITLE
The water/gas press. are calculated only if woc/goc is within the reservoar 

### DIFF
--- a/opm/core/simulator/initStateEquil_impl.hpp
+++ b/opm/core/simulator/initStateEquil_impl.hpp
@@ -401,7 +401,7 @@ namespace Opm
                 const double woc = reg.zwoc();
                 // Compute Oil pressure at WOC,
                 // if WOC is within the reservoir.
-                if ( ( woc > span[0] ) & ( woc < span[1] ) ){
+                if ( ( woc > span[0] ) && ( woc < span[1] ) ){
                     if      (z0 > woc) { po_woc = opress[0](woc); } // WOC above datum
                     else if (z0 < woc) { po_woc = opress[1](woc); } // WOC below datum
                     else               { po_woc = p0;             } // WOC *at*  datum
@@ -410,7 +410,7 @@ namespace Opm
                 const double goc = reg.zgoc();
                 // Compute Oil pressure at GOC,
                 // if GOC is within the reservoir.
-                if ( ( goc > span[0] ) & ( goc < span[1] ) ){
+                if ( ( goc > span[0] ) && ( goc < span[1] ) ){
                     if      (z0 > goc) { po_goc = opress[0](goc); } // GOC above datum
                     else if (z0 < goc) { po_goc = opress[1](goc); } // GOC below datum
                     else               { po_goc = p0;             } // GOC *at*  datum
@@ -487,17 +487,11 @@ namespace Opm
                 // po_woc is -inf and the water pressure
                 // is set to -inf.
                 if ( po_woc > 0 ){
-
                     PhasePressure::water(G, reg, span, grav, po_woc,
                                          cells, press[ wix ]);
                 } else {
-                    std::vector<double>::size_type local_index = 0;
-                    for (typename CellRange::const_iterator ci = cells.begin(); ci != cells.end(); ++ci, ++local_index) {
-                        const int cell = *ci;
-                        press[wix][cell] = po_woc;
-                    }
+                    press[wix].assign(cells.size(),po_woc);
                 }
-
 
             }
 
@@ -508,15 +502,10 @@ namespace Opm
                 // po_woc is -inf and the water pressure
                 // is set to -inf.
                 if (po_goc > 0){
-
                     PhasePressure::gas(G, reg, span, grav, po_goc,
                                        cells, press[ gix ]);
                 } else {
-                    std::vector<double>::size_type local_index = 0;
-                    for (typename CellRange::const_iterator ci = cells.begin(); ci != cells.end(); ++ci, ++local_index) {
-                        const int cell = *ci;
-                        press[gix][cell] = po_goc;
-                    }
+                    press[gix].assign(cells.size(),po_goc);
                 }
 
             }


### PR DESCRIPTION
The water/gas pressure used for the calculation of the phase saturation and the rs values is set to -inf when woc/goc is above or below the reservoir. With this fix in the initialization OPM reproduces Eclipse results for SPE9. 
