### PR TITLE
FindQuadmath: add -fext-numeric-literals if the compiler supports it

### DIFF
--- a/cmake/Modules/FindQuadmath.cmake
+++ b/cmake/Modules/FindQuadmath.cmake
@@ -9,6 +9,12 @@
 include(CheckCSourceCompiles)
 include(CheckCXXSourceCompiles)
 include(CMakePushCheckState)
+include(CheckCXXCompilerFlag)
+
+check_cxx_compiler_flag("-Werror -fext-numeric-literals" HAVE_EXTENDED_NUMERIC_LITERALS)
+if (HAVE_EXTENDED_NUMERIC_LITERALS)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fext-numeric-literals")
+endif()
 
 cmake_push_check_state()
 list(APPEND CMAKE_REQUIRED_LIBRARIES "quadmath")


### PR DESCRIPTION
this is required for GCC >= 4.8 to support the 'Q' suffix for floating
point literals (which are used in the quadmath.h header)

In order to prevent compilers which eat the flag but do not support it
from complaining constantly, it is tested for with "-Werror" enabled...

note that merging this PR is not strictly required because so far FindQuadmath.cmake is only used by eWoms (where it is already included), but it would be good include it into opm-core anyway to this module canonical with regard to the build system...
