### PR TITLE
Increase precision from CornerpointChopper::writeGrdecl

### DIFF
--- a/opm/core/io/eclipse/CornerpointChopper.hpp
+++ b/opm/core/io/eclipse/CornerpointChopper.hpp
@@ -309,6 +309,9 @@ namespace Opm
             out << "SPECGRID\n" << new_dims_[0] << ' ' << new_dims_[1] << ' ' << new_dims_[2]
                 << " 1 F\n/\n\n";
 
+            out.precision(15);
+            out.setf(std::ios::scientific);
+
             outputField(out, new_COORD_, "COORD", /* nl = */ 3);
             outputField(out, new_ZCORN_, "ZCORN", /* nl = */ 4);
             outputField(out, new_ACTNUM_, "ACTNUM");


### PR DESCRIPTION
This change-set increases the precision of floating-point vector output from method `writeGrdecl()` of class `CornerpointChopper`.  Previously, we used the default precision (typically five or six decimal places) in the on-disk representation of the model samples generated by method `chop()`.  This, however, produced noticeable discrepancies in the results between models that were upscaled directly using one of the `upscale_*` utilities in module opm-upscaling and models that were chopped, written to disk and then upscaled in a separate pass.  Using more precision in the output vectors attenuates that round-off error effect.
