### PR TITLE
Provide eclipse state to saturation property init.

### DIFF
--- a/opm/core/props/BlackoilPropertiesFromDeck_impl.hpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck_impl.hpp
@@ -57,7 +57,7 @@ namespace Opm
         SaturationPropsFromDeck<SatFuncSimpleNonuniform>* ptr
             = new SaturationPropsFromDeck<SatFuncSimpleNonuniform>();
         satprops_.reset(ptr);
-        ptr->init(deck, number_of_cells, global_cell, begin_cell_centroids, dimension,
+        ptr->init(deck, eclState, number_of_cells, global_cell, begin_cell_centroids, dimension,
                   /*numSamples=*/0);
 
         if (pvt_.numPhases() != satprops_->numPhases()) {
@@ -99,19 +99,19 @@ namespace Opm
                 SaturationPropsFromDeck<SatFuncStone2Uniform>* ptr
                     = new SaturationPropsFromDeck<SatFuncStone2Uniform>();
                 satprops_.reset(ptr);
-                ptr->init(deck, number_of_cells, global_cell, begin_cell_centroids,
+                ptr->init(deck, eclState, number_of_cells, global_cell, begin_cell_centroids,
                           dimension, sat_samples);
             } else if (threephase_model == "simple") {
                 SaturationPropsFromDeck<SatFuncSimpleUniform>* ptr
                     = new SaturationPropsFromDeck<SatFuncSimpleUniform>();
                 satprops_.reset(ptr);
-                ptr->init(deck, number_of_cells, global_cell, begin_cell_centroids,
+                ptr->init(deck, eclState, number_of_cells, global_cell, begin_cell_centroids,
                           dimension, sat_samples);
             } else if (threephase_model == "gwseg") {
                 SaturationPropsFromDeck<SatFuncGwsegUniform>* ptr
                     = new SaturationPropsFromDeck<SatFuncGwsegUniform>();
                 satprops_.reset(ptr);
-                ptr->init(deck, number_of_cells, global_cell, begin_cell_centroids,
+                ptr->init(deck, eclState, number_of_cells, global_cell, begin_cell_centroids,
                           dimension, sat_samples);
             } else {
                 OPM_THROW(std::runtime_error, "Unknown threephase_model: " << threephase_model);
@@ -121,19 +121,19 @@ namespace Opm
                 SaturationPropsFromDeck<SatFuncStone2Nonuniform>* ptr
                     = new SaturationPropsFromDeck<SatFuncStone2Nonuniform>();
                 satprops_.reset(ptr);
-                ptr->init(deck, number_of_cells, global_cell, begin_cell_centroids,
+                ptr->init(deck, eclState, number_of_cells, global_cell, begin_cell_centroids,
                           dimension, sat_samples);
             } else if (threephase_model == "simple") {
                 SaturationPropsFromDeck<SatFuncSimpleNonuniform>* ptr
                     = new SaturationPropsFromDeck<SatFuncSimpleNonuniform>();
                 satprops_.reset(ptr);
-                ptr->init(deck, number_of_cells, global_cell, begin_cell_centroids,
+                ptr->init(deck, eclState, number_of_cells, global_cell, begin_cell_centroids,
                           dimension, sat_samples);
             } else if (threephase_model == "gwseg") {
                 SaturationPropsFromDeck<SatFuncGwsegNonuniform>* ptr
                     = new SaturationPropsFromDeck<SatFuncGwsegNonuniform>();
                 satprops_.reset(ptr);
-                ptr->init(deck, number_of_cells, global_cell, begin_cell_centroids,
+                ptr->init(deck, eclState, number_of_cells, global_cell, begin_cell_centroids,
                           dimension, sat_samples);
             } else {
                 OPM_THROW(std::runtime_error, "Unknown threephase_model: " << threephase_model);

--- a/opm/core/props/IncompPropertiesFromDeck.cpp
+++ b/opm/core/props/IncompPropertiesFromDeck.cpp
@@ -32,7 +32,7 @@ namespace Opm
     {
         rock_.init(eclState, grid.number_of_cells, grid.global_cell, grid.cartdims);
         pvt_.init(deck);
-        satprops_.init(deck, grid, 200);
+        satprops_.init(deck, eclState, grid, 200);
         if (pvt_.numPhases() != satprops_.numPhases()) {
             OPM_THROW(std::runtime_error, "IncompPropertiesFromDeck::IncompPropertiesFromDeck() - Inconsistent number of phases in pvt data ("
                   << pvt_.numPhases() << ") and saturation-dependent function data (" << satprops_.numPhases() << ").");

--- a/opm/core/props/satfunc/SaturationPropsFromDeck.hpp
+++ b/opm/core/props/satfunc/SaturationPropsFromDeck.hpp
@@ -28,6 +28,7 @@
 #include <opm/core/props/satfunc/SatFuncGwseg.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
 #include <vector>
 
@@ -59,6 +60,7 @@ namespace Opm
         /// \param[in]  samples  Number of uniform sample points for saturation tables.
         /// NOTE: samples will only be used with the SatFuncSetUniform template argument.
         void init(Opm::DeckConstPtr deck,
+                  Opm::EclipseStateConstPtr eclState,
                   const UnstructuredGrid& grid,
                   const int samples);
 
@@ -77,6 +79,7 @@ namespace Opm
         /// NOTE: samples will only be used with the SatFuncSetUniform template argument.
         template<class T>
         void init(Opm::DeckConstPtr deck,
+                  Opm::EclipseStateConstPtr eclState,
                   int number_of_cells,
                   const int* global_cell,
                   const T& begin_cell_centroids,

--- a/opm/core/props/satfunc/SaturationPropsFromDeck_impl.hpp
+++ b/opm/core/props/satfunc/SaturationPropsFromDeck_impl.hpp
@@ -50,10 +50,11 @@ namespace Opm
     /// Initialize from deck.
     template <class SatFuncSet>
     void SaturationPropsFromDeck<SatFuncSet>::init(Opm::DeckConstPtr deck,
+                                                   Opm::EclipseStateConstPtr eclState,
                                                    const UnstructuredGrid& grid,
                                                    const int samples)
     {
-        this->init(deck, grid.number_of_cells,
+        this->init(deck, eclState, grid.number_of_cells,
                    grid.global_cell, grid.cell_centroids,
                    grid.dimensions, samples);
     }
@@ -62,6 +63,7 @@ namespace Opm
     template <class SatFuncSet>
     template<class T>
     void SaturationPropsFromDeck<SatFuncSet>::init(Opm::DeckConstPtr deck,
+                                                   Opm::EclipseStateConstPtr eclState,
                                                    int number_of_cells,
                                                    const int* global_cell,
                                                    const T& begin_cell_centroids,


### PR DESCRIPTION
Prepare for initialization of SWL-family  from eclipse state.  Must be merged together with corresponding PR for opm-autodiff.  
