### PR TITLE
Fix permeability assignment

### DIFF
--- a/opm/core/props/rock/RockFromDeck.cpp
+++ b/opm/core/props/rock/RockFromDeck.cpp
@@ -121,8 +121,10 @@ namespace Opm
                         // K(i,j) = (*tensor[kmap[kix]])[glob];
                         permeability_[off + (i + dim*j)] = (*tensor[kmap[kix]])[glob];
                     }
+
                     // K(i,i) = std::max(K(i,i), perm_threshold);
-                    permeability_[off + 3*i + i] = std::max(permeability_[off + 3*i + i], perm_threshold);
+                    double& kii = permeability_[off + i*(dim + 1)];
+                    kii = std::max(kii, perm_threshold);
                 }
 
                 permfield_valid_[c] = std::vector<unsigned char>::value_type(1);


### PR DESCRIPTION
I was reviewing the `RockFromDeck::assignPermeability()` method as a fallout from work to introduce horizontal completions and net-to-gross effects in the Peaceman index calculation (cf., PRs OPM/opm-core#622 and OPM/opm-autodiff#174).  There is an inconsistency in the assignment of permeability component values in the contiguous array `RockFromDeck::permeability_`.

The loop nest

``` C++
int kix = 0;
for (int i = 0; i < dim; ++i) {
    for (int j = 0; j < dim; ++j, ++kix) {
        permeability_[off + kix] = K(i,j);
    }
}
```

implies row-major ordering (column index cycling the most rapidly) of the tensor in a cell within the `permeability_` container.  On the other hand, the higher-level interfaces rely on `permeability_` having column-major ordering (row index cycling the most rapidly).  Fortunately, the surrounding code enforces symmetric tensors so the resulting numerical values are the same in both orderings.  In the original [`ReservoirPropertyCommon`](https://github.com/OPM/opm-porsol/blob/master/opm/porsol/common/ReservoirPropertyCommon_impl.hpp) code from which this was ported in commit 8e627bf, the component ordering was implicitly handled by the [`FullMatrix`](https://github.com/OPM/opm-porsol/blob/master/opm/porsol/common/Matrix.hpp) facility but that property was lost in the porting.  This change-set restores the intended assignment.

While here, we also make two other localised changes in the interest of maintainability.  In particular, removing an obsolete and misleading comment and simplifying a thresholding operation on the diagonal tensor components.
