### PR TITLE
Introduce Support for Horizontal Completions and Net-To-Gross Ratios

### DIFF
--- a/opm/core/wells/WellsManager.hpp
+++ b/opm/core/wells/WellsManager.hpp
@@ -27,6 +27,8 @@
 #include <opm/core/wells/WellsGroup.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/GroupTree.hpp>
 
+#include <opm/core/utility/CompressedPropertyAccess.hpp>
+
 struct Wells;
 struct UnstructuredGrid;
 
@@ -155,7 +157,8 @@ namespace Opm
         static void setupCompressedToCartesian(const int* global_cell, int number_of_cells, std::map<int,int>& cartesian_to_compressed );
         void setupWellControls(std::vector<WellConstPtr>& wells, size_t timeStep,
                                std::vector<std::string>& well_names, const PhaseUsage& phaseUsage);
-        template<class C2F, class CC, class FC>
+
+        template<class C2F, class CC, class FC, class NTG>
         void createWellsFromSpecs( std::vector<WellConstPtr>& wells, size_t timeStep,
                                    const C2F& cell_to_faces, 
                                    const int* cart_dims,
@@ -167,7 +170,8 @@ namespace Opm
                                    std::map<std::string, int> & well_names_to_index,
                                    const PhaseUsage& phaseUsage,
                                    const std::map<int,int>& cartesian_to_compressed,
-                                   const double* permeability);
+                                   const double* permeability,
+                                   const NTG& ntg);
 
         void addChildGroups(GroupTreeNodeConstPtr parentNode, ScheduleConstPtr schedule, size_t timeStep, const PhaseUsage& phaseUsage);
         void setupGuideRates(std::vector<WellConstPtr>& wells, const size_t timeStep, std::vector<WellData>& well_data, std::map<std::string, int>& well_names_to_index);


### PR DESCRIPTION
This change-set generalises the calculation of the Peaceman index of a completion to account for horizontal completions and effects of net-to-gross ("NTG") ratios.  The change is contained in the implementation of the `WellsManager`, so all clients get these features without code change.

At this time the NTG factor is incorporated unconditionally if present in the input represented by `WellsManager`'s `eclipseState` constructor parameter.  We may want to make that policy configurable for clients.  The change-set uses features of OPM/opm-parser#295 and cannot be merged until that is available in opm-parser's master branch lest the build break.

This change-set supersedes earlier efforts and therefore closes #622, closes OPM/opm-autodiff#174, and closes OPM/opm-polymer#66.
