### PR TITLE
effectiveExtent: Fix out-of-bounds indexing

### DIFF
--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -221,12 +221,11 @@ namespace WellsManagerDetail
         extent[2] *= ntg;
 
         const auto p = directionIndices(direction);
-        const std::array<double,3>::size_type d = extent.size();
 
         std::array<double,3>
-            D = {{ extent[ p[0]*(d + 1) ] ,
-                   extent[ p[1]*(d + 1) ] ,
-                   extent[ p[2]*(d + 1) ] }};
+            D = {{ extent[ p[0] ] ,
+                   extent[ p[1] ] ,
+                   extent[ p[2] ] }};
 
         return D;
     }


### PR DESCRIPTION
Commit 96cf137 introduced support for Peaceman index calculation that honoured general completion directions (`X`,`Y`,`Z`).  This was accomplished through a permutation index that reordered the permeability and geometric extent components according to a local coordinate system along the completion.

In a complete breakdown of logic, however, the d-component extent vector was indexed as though it were a d-by-d matrix.  This commit restores sanity to the processing.

Pointy hat: @bska.

This resolves OPM/opm-autodiff#194.
