### PR TITLE
Fix initialization

### DIFF
--- a/opm/core/simulator/initStateEquil_impl.hpp
+++ b/opm/core/simulator/initStateEquil_impl.hpp
@@ -559,6 +559,10 @@ namespace Opm
             const double zwoc = reg.zwoc ();
             const double zgoc = reg.zgoc ();
 
+            // make sure goc and woc is within the span for the phase pressure calculation
+            span[0] = std::min(span[0],zgoc);
+            span[1] = std::max(span[1],zwoc);
+
             if (! ((zgoc > z0) || (z0 > zwoc))) {
                 // Datum depth in oil zone  (zgoc <= z0 <= zwoc)
                 Details::equilibrateOWG(G, reg, grav, span, cells, press);


### PR DESCRIPTION
The first commit removes the work in #630 and #638 
The corner case when goc and woc is above and below the reservoir is instead fixed by increasing the span of the phase pressure calculation. This asserts more meaningful phase pressures at goc and woc. 

With this fix. Initialization matches Eclipse on SPE1,SPE3,SPE9 and Norne within reasonable accuracy.
