### PR TITLE
effectiveRadius: Fix Numerator Formula

### DIFF
--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -241,7 +241,8 @@ namespace WellsManagerDetail
         const double D0_sq = D[0] * D[0];
         const double D1_sq = D[1] * D[1];
 
-        const double num = std::sqrt(K10*D0_sq + K01*D1_sq);
+        const double num = std::sqrt((std::sqrt(K10) * D0_sq) +
+                                     (std::sqrt(K01) * D1_sq));
         const double den = std::pow(K01, 0.25) + std::pow(K10, 0.25);
 
         // Note: Analytic constant 0.28 derived for infintely sized


### PR DESCRIPTION
We must take the square root of the permeability ratios, not use them as is.  This was lost in the refactorisation commit 96cf137.

Pointy hat: @bska.
