### PR TITLE
change the default of the "threephase_model" parameter from "simple" to ...

### DIFF
--- a/opm/core/props/BlackoilPropertiesFromDeck_impl.hpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck_impl.hpp
@@ -85,11 +85,11 @@ namespace Opm
             rock_.init(eclState, number_of_cells, global_cell, cart_dims);
         }
 
-        const int pvt_samples = param.getDefault("pvt_tab_size", 200);
+        const int pvt_samples = param.getDefault("pvt_tab_size", -1);
         pvt_.init(deck, pvt_samples);
 
         // Unfortunate lack of pointer smartness here...
-        const int sat_samples = param.getDefault("sat_tab_size", 200);
+        const int sat_samples = param.getDefault("sat_tab_size", -1);
         std::string threephase_model = param.getDefault<std::string>("threephase_model", "gwseg");
         if (deck->hasKeyword("ENDSCALE") && threephase_model != "gwseg") {
             OPM_THROW(std::runtime_error, "Sorry, end point scaling currently available for the 'gwseg' model only.");


### PR DESCRIPTION
..."gwseg"

Using "simple", the Norne deck aborts with an exception.

Note: SPE1 and SPE9 still seem to work fine with this but there might
be small differences so that the reference solutions of the Jenkins
server might need to be updated...
