### PR TITLE
Avoid release mode warnings.

### DIFF
--- a/opm/core/props/rock/RockFromDeck.cpp
+++ b/opm/core/props/rock/RockFromDeck.cpp
@@ -105,10 +105,9 @@ namespace Opm
                                           double perm_threshold)
     {
         const int dim              = 3;
-        const int num_global_cells = cartdims[0]*cartdims[1]*cartdims[2];
         const int nc = number_of_cells;
 
-        assert(num_global_cells > 0);
+        assert(cartdims[0]*cartdims[1]*cartdims[2] > 0);
 
         permeability_.assign(dim * dim * nc, 0.0);
 

--- a/opm/core/tof/TofReorder.cpp
+++ b/opm/core/tof/TofReorder.cpp
@@ -285,8 +285,7 @@ namespace Opm
                 // Combine locally computed (for each adjacent vertex) terms, with uniform weighting.
                 const int* face_nodes_beg = grid_.face_nodes + grid_.face_nodepos[f];
                 const int* face_nodes_end = grid_.face_nodes + grid_.face_nodepos[f + 1];
-                const int num_terms = face_nodes_end - face_nodes_beg;
-                assert(num_terms == 2 || grid_.dimensions != 2);
+                assert((face_nodes_end - face_nodes_beg) == 2 || grid_.dimensions != 2);
                 for (const int* fn_iter = face_nodes_beg; fn_iter < face_nodes_end; ++fn_iter) {
                     double loc_face_term = 0.0;
                     double loc_cell_term_factor = 0.0;


### PR DESCRIPTION
Variables only used in asserts have been removed, their content used directly in the assert() instead.

This removes two compiler warnings.
