### PR TITLE
Fix solver restart counter.

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping.hpp
@@ -38,6 +38,7 @@ namespace Opm {
         TimeStepControlType timeStepControl_; //!< time step control object
         const double initial_fraction_;       //!< fraction to take as a guess for initial time interval
         const double restart_factor_;         //!< factor to multiply time step with when solver fails to converge
+        const double growth_factor_;          //!< factor to multiply time step when solver recovered from failed convergence
         const int solver_restart_max_;        //!< how many restart of solver are allowed
         const bool solver_verbose_;           //!< solver verbosity 
         const bool timestep_verbose_;         //!< timestep verbosity 


### PR DESCRIPTION
This PR fixes a small issue with the solver restart counter not beeing reset after the solver converged again. Also, the time step does only grow moderately after a solver restart.

In addition I changed the caught exceptions to const reference as suggested by bska. 
