### PR TITLE
remove unused typedef to avoid compiler warning and keep code clean.

### DIFF
--- a/opm/core/simulator/initStateEquil.hpp
+++ b/opm/core/simulator/initStateEquil.hpp
@@ -386,8 +386,6 @@ namespace Opm
                                  const UnstructuredGrid&           G    ,
                                  const double grav)
                 {
-                    typedef Miscibility::NoMixing NoMix;
-
                     for (typename RMap::RegionId
                              r = 0, nr = reg.numRegions();
                          r < nr; ++r)


### PR DESCRIPTION
this PR removes an unused typedef.
