### PR TITLE
Bugfix: avoid using TimeMap without deck.

### DIFF
--- a/examples/sim_2p_incomp.cpp
+++ b/examples/sim_2p_incomp.cpp
@@ -237,7 +237,7 @@ try
         rep = simulator.run(simtimer, state, well_state);
     } else {
         // With a deck, we may have more epochs etc.
-        Opm::TimeMapPtr timeMap(new Opm::TimeMap(deck));
+        Opm::TimeMapConstPtr timeMap = eclipseState->getSchedule()->getTimeMap();
 
         std::cout << "\n\n================    Starting main simulation loop     ===============\n"
                   << "                        (number of report steps: "


### PR DESCRIPTION
This made the simulator crash when there is no deck involved.
