### PR TITLE
Do not include shut wells in the well name to index map

### DIFF
--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -787,8 +787,12 @@ void Summary::writeTimeStep(int reportStepIdx,
     const Opm::ScheduleConstPtr schedule = eclipseState_->getSchedule();
     const auto& timeStepWells = schedule->getWells(reportStepIdx);
     std::map<std::string, int> wellNameToIdxMap;
+    int openWellIdx = 0;
     for (size_t tsWellIdx = 0; tsWellIdx < timeStepWells.size(); ++tsWellIdx) {
-        wellNameToIdxMap[timeStepWells[tsWellIdx]->name()] = tsWellIdx;
+        if (timeStepWells[tsWellIdx]->getStatus(timer.currentStepNum()) != WellCommon::SHUT ) {
+            wellNameToIdxMap[timeStepWells[tsWellIdx]->name()] = openWellIdx;
+            openWellIdx++;
+        }
     }
 
     // internal view; do not move this code out of Summary!


### PR DESCRIPTION
The name to index map is used to make sure the correct wellstate values
are associated with the corresponding well. Shut wells should be
excluded from this mapping as no date is for shut wells are found in the
wellstates, instead 0 is used for the shut wells.

Tested on Norne. 
