### PR TITLE
Fixes missing return value in non-void function of WellsManager.

### DIFF
--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -188,6 +188,11 @@ namespace WellsManagerDetail
         case Opm::CompletionDirection::DirectionEnum::Z:
             return permutation {{ idx_t(0), idx_t(1), idx_t(2) }};
         }
+        // All enum values should be handled above. Therefore
+        // we should never reach this one. Anyway for the sake
+        // of reduced warnings we throw an exception.
+        throw std::invalid_argument("unhandled enum value");
+
     }
 
     // Permute (diagonal) permeability components according to


### PR DESCRIPTION
gcc warned about the following

/home/mblatt/src/dune/opm/opm-core/opm/core/wells/WellsManager.cpp: In function ‘std::array<long unsigned int, 3ul> WellsManagerDetail::directionIndices(Opm::CompletionDirection::DirectionEnum)’:
/home/mblatt/src/dune/opm/opm-core/opm/core/wells/WellsManager.cpp:191: warning: control reaches end of non-void function

To calm it I introduced a default branch in the switch statement that throws.
This should of course never be reached.
