### PR TITLE
[cleanup] Removes a superfluous if-check of the well state.

### DIFF
--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -623,9 +623,6 @@ namespace Opm
                     if (cpos == -1 && mode != WellsManagerDetail::ProductionControl::GRUP) {
                         OPM_THROW(std::runtime_error, "Control mode type " << mode << " not present in well " << well_names[well_index]);
                     }
-                    if (cpos == -1 && mode != WellsManagerDetail::ProductionControl::GRUP) {
-                        OPM_THROW(std::runtime_error, "Control mode type " << mode << " not present in well " << well_names[well_index]);
-                    }
                     else {
                         set_current_control(well_index, cpos, w_);
                     }


### PR DESCRIPTION
There were to identical if statements and the second one was followed
by an else branch. While in this case (if statement just throws) it is not
a bug, this commit cleans up one of the if statements.
