### PR TITLE
PVT properties: allow them to be temperature dependent

### DIFF
--- a/opm/core/props/BlackoilPropertiesBasic.cpp
+++ b/opm/core/props/BlackoilPropertiesBasic.cpp
@@ -91,6 +91,7 @@ namespace Opm
 
     /// \param[in]  n      Number of data points.
     /// \param[in]  p      Array of n pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  z      Array of nP surface volume values.
     /// \param[in]  cells  Array of n cell indices to be associated with the p and z values.
     /// \param[out] mu     Array of nP viscosity values, array must be valid before calling.
@@ -98,6 +99,7 @@ namespace Opm
     ///                    array must be valid before calling.
     void BlackoilPropertiesBasic::viscosity(const int n,
                                             const double* p,
+                                            const double* T,
                                             const double* z,
                                             const int* /*cells*/,
                                             double* mu,
@@ -106,12 +108,13 @@ namespace Opm
         if (dmudp) {
             OPM_THROW(std::runtime_error, "BlackoilPropertiesBasic::viscosity()  --  derivatives of viscosity not yet implemented.");
         } else {
-            pvt_.mu(n, p, z, mu);
+            pvt_.mu(n, p, T, z, mu);
         }
     }
 
     /// \param[in]  n      Number of data points.
     /// \param[in]  p      Array of n pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  z      Array of nP surface volume values.
     /// \param[in]  cells  Array of n cell indices to be associated with the p and z values.
     /// \param[out] A      Array of nP^2 values, array must be valid before calling.
@@ -121,7 +124,8 @@ namespace Opm
     ///                    array must be valid before calling. The matrices are output
     ///                    in Fortran order.
     void BlackoilPropertiesBasic::matrix(const int n,
-                                         const double* /*p*/,
+                                         const double* p,
+                                         const double* T,
                                          const double* /*z*/,
                                          const int* /*cells*/,
                                          double* A,
@@ -130,7 +134,7 @@ namespace Opm
         const int np = numPhases();
         assert(np <= 2);
         double B[2]; // Must be enough since component classes do not handle more than 2.
-        pvt_.B(1, 0, 0, B);
+        pvt_.B(1, p, T, 0, B);
         // Compute A matrix
 // #pragma omp parallel for
         for (int i = 0; i < n; ++i) {

--- a/opm/core/props/BlackoilPropertiesBasic.hpp
+++ b/opm/core/props/BlackoilPropertiesBasic.hpp
@@ -83,6 +83,7 @@ namespace Opm
 
         /// \param[in]  n      Number of data points.
         /// \param[in]  p      Array of n pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  z      Array of nP surface volume values.
         /// \param[in]  cells  Array of n cell indices to be associated with the p and z values.
         /// \param[out] mu     Array of nP viscosity values, array must be valid before calling.
@@ -90,6 +91,7 @@ namespace Opm
         ///                    array must be valid before calling.
         virtual void viscosity(const int n,
                                const double* p,
+                               const double* T,
                                const double* z,
                                const int* cells,
                                double* mu,
@@ -97,6 +99,7 @@ namespace Opm
 
         /// \param[in]  n      Number of data points.
         /// \param[in]  p      Array of n pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  z      Array of nP surface volume values.
         /// \param[in]  cells  Array of n cell indices to be associated with the p and z values.
         /// \param[out] A      Array of nP^2 values, array must be valid before calling.
@@ -107,6 +110,7 @@ namespace Opm
         ///                    in Fortran order.
         virtual void matrix(const int n,
                             const double* p,
+                            const double* T,
                             const double* z,
                             const int* cells,
                             double* A,

--- a/opm/core/props/BlackoilPropertiesFromDeck.cpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck.cpp
@@ -90,6 +90,7 @@ namespace Opm
 
     /// \param[in]  n      Number of data points.
     /// \param[in]  p      Array of n pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  z      Array of nP surface volume values.
     /// \param[in]  cells  Array of n cell indices to be associated with the p and z values.
     /// \param[out] mu     Array of nP viscosity values, array must be valid before calling.
@@ -97,6 +98,7 @@ namespace Opm
     ///                    array must be valid before calling.
     void BlackoilPropertiesFromDeck::viscosity(const int n,
                                                const double* p,
+                                               const double* T,
                                                const double* z,
                                                const int* cells,
                                                double* mu,
@@ -111,12 +113,13 @@ namespace Opm
             for (int i = 0; i < n; ++ i)
                 pvtTableIdx[i] = cellPvtTableIdx[cells[i]];
 
-            pvt_.mu(n, &pvtTableIdx[0], p, z, mu);
+            pvt_.mu(n, &pvtTableIdx[0], p, T, z, mu);
         }
     }
 
     /// \param[in]  n      Number of data points.
     /// \param[in]  p      Array of n pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  z      Array of nP surface volume values.
     /// \param[in]  cells  Array of n cell indices to be associated with the p and z values.
     /// \param[out] A      Array of nP^2 values, array must be valid before calling.
@@ -127,6 +130,7 @@ namespace Opm
     ///                    in Fortran order.
     void BlackoilPropertiesFromDeck::matrix(const int n,
                                             const double* p,
+                                            const double* T,
                                             const double* z,
                                             const int* cells,
                                             double* A,
@@ -144,10 +148,10 @@ namespace Opm
         if (dAdp) {
             dB_.resize(n*np);
             dR_.resize(n*np);
-            pvt_.dBdp(n, &pvtTableIdx[0], p, z, &B_[0], &dB_[0]);
+            pvt_.dBdp(n, &pvtTableIdx[0], p, T, z, &B_[0], &dB_[0]);
             pvt_.dRdp(n, &pvtTableIdx[0], p, z, &R_[0], &dR_[0]);
         } else {
-            pvt_.B(n, &pvtTableIdx[0], p, z, &B_[0]);
+            pvt_.B(n, &pvtTableIdx[0], p, T, z, &B_[0]);
             pvt_.R(n, &pvtTableIdx[0], p, z, &R_[0]);
         }
         const int* phase_pos = pvt_.phasePosition();

--- a/opm/core/props/BlackoilPropertiesFromDeck.hpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck.hpp
@@ -125,6 +125,7 @@ namespace Opm
 
         /// \param[in]  n      Number of data points.
         /// \param[in]  p      Array of n pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  z      Array of nP surface volume values.
         /// \param[in]  cells  Array of n cell indices to be associated with the p and z values.
         /// \param[out] mu     Array of nP viscosity values, array must be valid before calling.
@@ -132,6 +133,7 @@ namespace Opm
         ///                    array must be valid before calling.
         virtual void viscosity(const int n,
                                const double* p,
+                               const double* T,
                                const double* z,
                                const int* cells,
                                double* mu,
@@ -139,6 +141,7 @@ namespace Opm
 
         /// \param[in]  n      Number of data points.
         /// \param[in]  p      Array of n pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  z      Array of nP surface volume values.
         /// \param[in]  cells  Array of n cell indices to be associated with the p and z values.
         /// \param[out] A      Array of nP^2 values, array must be valid before calling.
@@ -149,6 +152,7 @@ namespace Opm
         ///                    in Fortran order.
         virtual void matrix(const int n,
                             const double* p,
+                            const double* T,
                             const double* z,
                             const int* cells,
                             double* A,

--- a/opm/core/props/BlackoilPropertiesInterface.hpp
+++ b/opm/core/props/BlackoilPropertiesInterface.hpp
@@ -70,6 +70,7 @@ namespace Opm
 
         /// \param[in]  n      Number of data points.
         /// \param[in]  p      Array of n pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  z      Array of nP surface volume values.
         /// \param[in]  cells  Array of n cell indices to be associated with the p and z values.
         /// \param[out] mu     Array of nP viscosity values, array must be valid before calling.
@@ -77,6 +78,7 @@ namespace Opm
         ///                    array must be valid before calling.
         virtual void viscosity(const int n,
                                const double* p,
+                               const double* T,
                                const double* z,
                                const int* cells,
                                double* mu,
@@ -84,6 +86,7 @@ namespace Opm
 
         /// \param[in]  n      Number of data points.
         /// \param[in]  p      Array of n pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  z      Array of nP surface volume values.
         /// \param[in]  cells  Array of n cell indices to be associated with the p and z values.
         /// \param[out] A      Array of nP^2 values, array must be valid before calling.
@@ -94,6 +97,7 @@ namespace Opm
         ///                    in Fortran order.
         virtual void matrix(const int n,
                             const double* p,
+                            const double* T,
                             const double* z,
                             const int* cells,
                             double* A,

--- a/opm/core/props/IncompPropertiesBasic.cpp
+++ b/opm/core/props/IncompPropertiesBasic.cpp
@@ -44,7 +44,7 @@ namespace Opm
                   << pvt_.numPhases() << ") and saturation-dependent function data (" << satprops_.numPhases() << ").");
         }
         viscosity_.resize(pvt_.numPhases());
-        pvt_.mu(1, 0, 0, &viscosity_[0]);
+        pvt_.mu(1, 0, 0, 0, &viscosity_[0]);
     }
 
     IncompPropertiesBasic::IncompPropertiesBasic(const int num_phases,
@@ -64,7 +64,7 @@ namespace Opm
                   << pvt_.numPhases() << ") and saturation-dependent function data (" << satprops_.numPhases() << ").");
         }
         viscosity_.resize(pvt_.numPhases());
-        pvt_.mu(1, 0, 0, &viscosity_[0]);
+        pvt_.mu(1, 0, 0, 0, &viscosity_[0]);
     }
 
     IncompPropertiesBasic::~IncompPropertiesBasic()

--- a/opm/core/props/pvt/BlackoilPvtProperties.cpp
+++ b/opm/core/props/pvt/BlackoilPvtProperties.cpp
@@ -161,12 +161,13 @@ namespace Opm
     void BlackoilPvtProperties::mu(const int n,
                                    const int* pvtTableIdx,
                                    const double* p,
+                                   const double* T,
                                    const double* z,
                                    double* output_mu) const
     {
         data1_.resize(n);
         for (int phase = 0; phase < phase_usage_.num_phases; ++phase) {
-            props_[phase]->mu(n, pvtTableIdx, p, z, &data1_[0]);
+            props_[phase]->mu(n, pvtTableIdx, p, T, z, &data1_[0]);
 // #pragma omp parallel for
             for (int i = 0; i < n; ++i) {
                 output_mu[phase_usage_.num_phases*i + phase] = data1_[i];
@@ -177,12 +178,13 @@ namespace Opm
     void BlackoilPvtProperties::B(const int n,
                                   const int* pvtTableIdx,
                                   const double* p,
+                                  const double* T,
                                   const double* z,
                                   double* output_B) const
     {
         data1_.resize(n);
         for (int phase = 0; phase < phase_usage_.num_phases; ++phase) {
-            props_[phase]->B(n, pvtTableIdx, p, z, &data1_[0]);
+            props_[phase]->B(n, pvtTableIdx, p, T, z, &data1_[0]);
 // #pragma omp parallel for
             for (int i = 0; i < n; ++i) {
                 output_B[phase_usage_.num_phases*i + phase] = data1_[i];
@@ -193,6 +195,7 @@ namespace Opm
     void BlackoilPvtProperties::dBdp(const int n,
                                      const int* pvtTableIdx,
                                      const double* p,
+                                     const double* T,
                                      const double* z,
                                      double* output_B,
                                      double* output_dBdp) const
@@ -200,7 +203,7 @@ namespace Opm
         data1_.resize(n);
         data2_.resize(n);
         for (int phase = 0; phase < phase_usage_.num_phases; ++phase) {
-            props_[phase]->dBdp(n, pvtTableIdx, p, z, &data1_[0], &data2_[0]);
+            props_[phase]->dBdp(n, pvtTableIdx, p, T, z, &data1_[0], &data2_[0]);
 // #pragma omp parallel for
             for (int i = 0; i < n; ++i) {
                 output_B[phase_usage_.num_phases*i + phase] = data1_[i];

--- a/opm/core/props/pvt/BlackoilPvtProperties.hpp
+++ b/opm/core/props/pvt/BlackoilPvtProperties.hpp
@@ -77,24 +77,27 @@ namespace Opm
         /// \return  Array of size numPhases().
         const double* surfaceDensities(int regionIdx = 0) const;
 
-        /// Viscosity as a function of p and z.
+        /// Viscosity as a function of p, T and z.
         void mu(const int n,
                 const int *pvtTableIdx,
                 const double* p,
+                const double* T,
                 const double* z,
                 double* output_mu) const;
 
-        /// Formation volume factor as a function of p and z.
+        /// Formation volume factor as a function of p, T and z.
         void B(const int n,
                const int *pvtTableIdx,
                const double* p,
+               const double* T,
                const double* z,
                double* output_B) const;
 
-        /// Formation volume factor and p-derivative as functions of p and z.
+        /// Formation volume factor and p-derivative as functions of p, T and z.
         void dBdp(const int n,
                   const int *pvtTableIdx,
                   const double* p,
+                  const double* T,
                   const double* z,
                   double* output_B,
                   double* output_dBdp) const;

--- a/opm/core/props/pvt/PvtConstCompr.hpp
+++ b/opm/core/props/pvt/PvtConstCompr.hpp
@@ -109,6 +109,7 @@ namespace Opm
         virtual void mu(const int n,
                         const int* pvtRegionIdx,
                         const double* p,
+                        const double* /*T*/,
                         const double* /*z*/,
                         double* output_mu) const
         {
@@ -124,6 +125,7 @@ namespace Opm
         virtual void mu(const int n,
                         const int* pvtRegionIdx,
                         const double* p,
+                        const double* /*T*/,
                         const double* /*r*/,
                         double* output_mu,
                         double* output_dmudp,
@@ -144,6 +146,7 @@ namespace Opm
         virtual void mu(const int n,
                         const int* pvtRegionIdx,
                         const double* p,
+                        const double* /*T*/,
                         const double* /*r*/,
                         const PhasePresence* /*cond*/,
                         double* output_mu,
@@ -165,6 +168,7 @@ namespace Opm
         virtual void B(const int n,
                        const int* pvtRegionIdx,
                        const double* p,
+                       const double* /*T*/,
                        const double* /*z*/,
                        double* output_B) const
         {
@@ -180,6 +184,7 @@ namespace Opm
         virtual void dBdp(const int n,
                           const int* pvtRegionIdx,
                           const double* p,
+                          const double* /*T*/,
                           const double* /*z*/,
                           double* output_B,
                           double* output_dBdp) const
@@ -197,6 +202,7 @@ namespace Opm
         virtual void b(const int n,
                        const int* pvtRegionIdx,
                        const double* p,
+                       const double* /*T*/,
                        const double* /*r*/,
                        double* output_b,
                        double* output_dbdp,
@@ -220,6 +226,7 @@ namespace Opm
         virtual void b(const int n,
                        const int* pvtRegionIdx,
                        const double* p,
+                       const double* /*T*/,
                        const double* /*r*/,
                        const PhasePresence* /*cond*/,
                        double* output_b,

--- a/opm/core/props/pvt/PvtDead.cpp
+++ b/opm/core/props/pvt/PvtDead.cpp
@@ -112,7 +112,8 @@ namespace Opm
 
     void PvtDead::mu(const int n,
                      const int* pvtTableIdx,
-                           const double* p,
+                     const double* p,
+                     const double* /*T*/,
                            const double* /*z*/,
                            double* output_mu) const
     {
@@ -127,7 +128,8 @@ namespace Opm
 
     void PvtDead::mu(const int n,
                      const int* pvtTableIdx,
-                               const double* p,
+                     const double* p,
+                     const double* /*T*/,
                                const double* /*r*/,
                                double* output_mu,
                                double* output_dmudp,
@@ -148,7 +150,8 @@ namespace Opm
 
     void PvtDead::mu(const int n,
                      const int* pvtTableIdx,
-                               const double* p,
+                     const double* p,
+                     const double* /*T*/,
                                const double* /*r*/,
                                const PhasePresence* /*cond*/,
                                double* output_mu,
@@ -171,7 +174,8 @@ namespace Opm
 
     void PvtDead::B(const int n,
                     const int* pvtTableIdx,
-                          const double* p,
+                    const double* p,
+                    const double* /*T*/,
                           const double* /*z*/,
                           double* output_B) const
     {
@@ -185,12 +189,13 @@ namespace Opm
 
     void PvtDead::dBdp(const int n,
                        const int* pvtTableIdx,
-                             const double* p,
+                       const double* p,
+                       const double* T,
                              const double* /*z*/,
                              double* output_B,
                              double* output_dBdp) const
     {
-        B(n, pvtTableIdx, p, 0, output_B);
+        B(n, pvtTableIdx, p, T, 0, output_B);
 // #pragma omp parallel for
         for (int i = 0; i < n; ++i) {
             int regionIdx = getTableIndex_(pvtTableIdx, i);
@@ -201,7 +206,8 @@ namespace Opm
 
     void PvtDead::b(const int n,
                     const int* pvtTableIdx,
-                              const double* p,
+                    const double* p,
+                    const double* /*T*/,
                               const double* /*r*/,
                               double* output_b,
                               double* output_dbdp,
@@ -222,7 +228,8 @@ namespace Opm
 
     void PvtDead::b(const int n,
                     const int* pvtTableIdx,
-                              const double* p,
+                    const double* p,
+                    const double* /*T*/,
                               const double* /*r*/,
                               const PhasePresence* /*cond*/,
                               double* output_b,

--- a/opm/core/props/pvt/PvtDead.hpp
+++ b/opm/core/props/pvt/PvtDead.hpp
@@ -50,64 +50,71 @@ namespace Opm
         void initFromGas(const std::vector<Opm::PvdgTable>& pvdgTables);
         virtual ~PvtDead();
 
-        /// Viscosity as a function of p and z.
+        /// Viscosity as a function of p, T and z.
         virtual void mu(const int n,
                         const int* pvtTableIdx,
                         const double* p,
+                        const double* T,
                         const double* z,
                         double* output_mu) const;
 
-        /// Viscosity and its derivatives as a function of p and r.
+        /// Viscosity and its p and r derivatives as a function of p, T and r.
         /// The fluid is considered saturated if r >= rsSat(p).
         virtual void mu(const int n,
                         const int* pvtTableIdx,
                         const double* p,
+                        const double* T,
                         const double* r,
                         double* output_mu,
                         double* output_dmudp,
                         double* output_dmudr) const;
 
-        /// Viscosity as a function of p and r.
+        /// Viscosity as a function of p, T and r.
         /// State condition determined by 'cond'.
         virtual void mu(const int n,
                         const int* pvtTableIdx,
                         const double* p,
+                        const double* T,
                         const double* r,
                         const PhasePresence* cond,
                         double* output_mu,
                         double* output_dmudp,
                         double* output_dmudr) const;
 
-        /// Formation volume factor as a function of p and z.
+        /// Formation volume factor as a function of p, T and z.
         virtual void B(const int n,
                        const int* pvtTableIdx,
                        const double* p,
+                       const double* T,
                        const double* z,
                        double* output_B) const;
 
-        /// Formation volume factor and p-derivative as functions of p and z.
+        /// Formation volume factor and p-derivative as functions of p, T and z.
         virtual void dBdp(const int n,
                           const int* pvtTableIdx,
                           const double* p,
+                          const double* T,
                           const double* z,
                           double* output_B,
                           double* output_dBdp) const;
 
-        /// The inverse of the formation volume factor b = 1 / B, and its derivatives as a function of p and r.
+        /// The inverse of the formation volume factor b = 1 / B, and its p and r derivatives as a function of p, T and r.
         /// The fluid is considered saturated if r >= rsSat(p).
         virtual void b(const int n,
                        const int* pvtTableIdx,
                        const double* p,
+                       const double* T,
                        const double* r,
                        double* output_b,
                        double* output_dbdp,
                        double* output_dbdr) const;
 
-        /// The inverse of the formation volume factor b = 1 / B, and its derivatives as a function of p and r.
+        /// The inverse of the formation volume factor b = 1 / B, and its p and r derivatives as a function of p, T and r.
         /// State condition determined by 'cond'.
         virtual void b(const int n,
                        const int* pvtTableIdx,
                        const double* p,
+                       const double* T,
                        const double* r,
                        const PhasePresence* cond,
                        double* output_b,

--- a/opm/core/props/pvt/PvtDeadSpline.cpp
+++ b/opm/core/props/pvt/PvtDeadSpline.cpp
@@ -105,7 +105,8 @@ namespace Opm
 
     void PvtDeadSpline::mu(const int n,
                            const int* pvtTableIdx,
-                                 const double* p,
+                           const double* p,
+                           const double* /*T*/,
                                  const double* /*z*/,
                                  double* output_mu) const
     {
@@ -119,6 +120,7 @@ namespace Opm
     void PvtDeadSpline::mu(const int n,
                            const int* pvtTableIdx,
                            const double* p,
+                           const double* /*T*/,
                            const double* /*r*/,
                            double* output_mu,
                            double* output_dmudp,
@@ -136,6 +138,7 @@ namespace Opm
     void PvtDeadSpline::mu(const int n,
                            const int* pvtTableIdx,
                            const double* p,
+                           const double* /*T*/,
                            const double* /*r*/,
                            const PhasePresence* /*cond*/,
                            double* output_mu,
@@ -154,7 +157,8 @@ namespace Opm
 
     void PvtDeadSpline::B(const int n,
                           const int* pvtTableIdx,
-                                const double* p,
+                          const double* p,
+                          const double* /*T*/,
                                 const double* /*z*/,
                                 double* output_B) const
     {
@@ -168,11 +172,12 @@ namespace Opm
     void PvtDeadSpline::dBdp(const int n,
                              const int* pvtTableIdx,
                              const double* p,
+                             const double* T,
                              const double* /*z*/,
                              double* output_B,
                              double* output_dBdp) const
     {
-        B(n, pvtTableIdx, p, 0, output_B);
+        B(n, pvtTableIdx, p, T, 0, output_B);
 // #pragma omp parallel for
         for (int i = 0; i < n; ++i) {
             int regionIdx = getTableIndex_(pvtTableIdx, i);
@@ -183,7 +188,8 @@ namespace Opm
 
     void PvtDeadSpline::b(const int n,
                           const int* pvtTableIdx,
-                              const double* p,
+                          const double* p,
+                          const double* T,
                               const double* /*r*/,
                               double* output_b,
                               double* output_dbdp,
@@ -201,6 +207,7 @@ namespace Opm
     void PvtDeadSpline::b(const int n,
                           const int* pvtTableIdx,
                           const double* p,
+                          const double* T,
                           const double* /*r*/,
                           const PhasePresence* /*cond*/,
                           double* output_b,

--- a/opm/core/props/pvt/PvtDeadSpline.hpp
+++ b/opm/core/props/pvt/PvtDeadSpline.hpp
@@ -49,64 +49,71 @@ namespace Opm
 
         virtual ~PvtDeadSpline();
 
-        /// Viscosity as a function of p and z.
+        /// Viscosity as a function of p, T and z.
         virtual void mu(const int n,
                         const int* pvtTableIdx,
                         const double* p,
+                        const double* T,
                         const double* z,
                         double* output_mu) const;
 
-        /// Viscosity and its derivatives as a function of p and r.
+        /// Viscosity and its p and r derivatives as a function of p, T and r.
         /// The fluid is considered saturated if r >= rsSat(p).
         virtual void mu(const int n,
                         const int* pvtTableIdx,
                         const double* p,
+                        const double* T,
                         const double* r,
                         double* output_mu,
                         double* output_dmudp,
                         double* output_dmudr) const;
 
-        /// Viscosity as a function of p and r.
+        /// Viscosity as a function of p, T and r.
         /// State condition determined by 'cond'.
         virtual void mu(const int n,
                         const int* pvtTableIdx,
                         const double* p,
+                        const double* T,
                         const double* r,
                         const PhasePresence* cond,
                         double* output_mu,
                         double* output_dmudp,
                         double* output_dmudr) const;
 
-        /// Formation volume factor as a function of p and z.
+        /// Formation volume factor as a function of p, T and z.
         virtual void B(const int n,
                        const int* pvtTableIdx,
                        const double* p,
+                       const double* T,
                        const double* z,
                        double* output_B) const;
 
-        /// Formation volume factor and p-derivative as functions of p and z.
+        /// Formation volume factor and p-derivative as functions of p, T and z.
         virtual void dBdp(const int n,
                           const int* pvtTableIdx,
                           const double* p,
+                          const double* T,
                           const double* z,
                           double* output_B,
                           double* output_dBdp) const;
 
-        /// The inverse of the formation volume factor b = 1 / B, and its derivatives as a function of p and r.
+        /// The inverse of the formation volume factor b = 1 / B, and its p and r derivatives as a function of p, T and r.
         /// The fluid is considered saturated if r >= rsSat(p).
         virtual void b(const int n,
                        const int* pvtTableIdx,
                        const double* p,
+                       const double* T,
                        const double* r,
                        double* output_b,
                        double* output_dbdp,
                        double* output_dbdr) const;
 
-        /// The inverse of the formation volume factor b = 1 / B, and its derivatives as a function of p and r.
+        /// The inverse of the formation volume factor b = 1 / B, and its p and r derivatives as a function of p, T and r.
         /// State condition determined by 'cond'.
         virtual void b(const int n,
                        const int* pvtTableIdx,
                        const double* p,
+                       const double* T,
                        const double* r,
                        const PhasePresence* cond,
                        double* output_b,

--- a/opm/core/props/pvt/PvtInterface.hpp
+++ b/opm/core/props/pvt/PvtInterface.hpp
@@ -42,8 +42,8 @@ namespace Opm
         ///                          arbitrary two-phase and three-phase situations.
         void setPhaseConfiguration(const int num_phases, const int* phase_pos);
 
-        /// The PVT properties can either be given as a function of pressure (p) and surface volume (z)
-        /// or pressure (p) and gas resolution factor (r).
+        /// The PVT properties can either be given as a function of pressure (p), temperature (T) and surface volume (z)
+        /// or pressure (p), temperature (T) and gas resolution factor (r).
         /// For all the virtual methods, the following apply:
         /// - pvtRegionIdx is an array of size n and represents the
         ///   index of the PVT table which should be used to calculate
@@ -54,38 +54,42 @@ namespace Opm
         /// - Output arrays shall be of size n, and must be valid before
         ///   calling the method.
 
-        /// Viscosity as a function of p and z.
+        /// Viscosity as a function of p, T and z.
         virtual void mu(const int n,
                         const int* pvtRegionIdx,
                         const double* p,
+                        const double* T,
                         const double* z,
                         double* output_mu) const = 0;
 
-        /// Viscosity as a function of p and r.
+        /// Viscosity as a function of p, T and r.
         /// The fluid is considered saturated if r >= rsSat(p).
         virtual void mu(const int n,
                         const int* pvtRegionIdx,
-                              const double* p,
+                        const double* p,
+                        const double* T,
                               const double* r,
                               double* output_mu,
                               double* output_dmudp,
                               double* output_dmudr) const = 0;
 
-        /// Viscosity as a function of p and r.
+        /// Viscosity as a function of p, T and r.
         /// State condition determined by 'cond'.
         virtual void mu(const int n,
                         const int* pvtRegionIdx,
-                              const double* p,
+                        const double* p,
+                        const double* T,
                               const double* r,
                               const PhasePresence* cond,
                               double* output_mu,
                               double* output_dmudp,
                               double* output_dmudr) const = 0;
 
-        /// Formation volume factor as a function of p and z.
+        /// Formation volume factor as a function of p, T and z.
         virtual void B(const int n,
                        const int* pvtRegionIdx,
                        const double* p,
+                       const double* T,
                        const double* z,
                        double* output_B) const = 0;
 
@@ -93,25 +97,28 @@ namespace Opm
         virtual void dBdp(const int n,
                           const int* pvtRegionIdx,
                           const double* p,
+                          const double* T,
                           const double* z,
                           double* output_B,
                           double* output_dBdp) const = 0;
 
-        /// The inverse of the volume factor b = 1 / B as a function of p and r.
+        /// The inverse of the volume factor b = 1 / B as a function of p, T and r.
         /// The fluid is considered saturated if r >= rsSat(p).
         virtual void b(const int n,
                        const int* pvtRegionIdx,
-                          const double* p,
+                       const double* p,
+                       const double* T,
                           const double* r,
                           double* output_b,
                           double* output_dbdp,
                           double* output_dpdr) const = 0;
 
-        /// The inverse of the volume factor b = 1 / B as a function of p and r.
+        /// The inverse of the volume factor b = 1 / B as a function of p, T and r.
         /// State condition determined by 'cond'.
         virtual void b(const int n,
                        const int* pvtRegionIdx,
-                          const double* p,
+                       const double* p,
+                       const double* T,
                           const double* r,
                           const PhasePresence* cond,
                           double* output_b,

--- a/opm/core/props/pvt/PvtLiveGas.cpp
+++ b/opm/core/props/pvt/PvtLiveGas.cpp
@@ -104,6 +104,7 @@ namespace Opm
     void PvtLiveGas::mu(const int n,
                         const int* pvtRegionIdx,
                         const double* p,
+                        const double* /*T*/,
                         const double* z,
                         double* output_mu) const
     {
@@ -116,10 +117,11 @@ namespace Opm
         }
     }
 
-    /// Viscosity and its derivatives as a function of p and r.
+    /// Viscosity and its p and r derivatives as a function of p, T and r.
     void PvtLiveGas::mu(const int /*n*/,
                         const int* /*pvtRegionIdx*/,
-                              const double* /*p*/,
+                        const double* /*p*/,
+                        const double* /*T*/,
                               const double* /*r*/,
                               double* /*output_mu*/,
                               double* /*output_dmudp*/,
@@ -128,10 +130,11 @@ namespace Opm
         OPM_THROW(std::runtime_error, "The new fluid interface not yet implemented");
     }
 
-    /// Viscosity and its derivatives as a function of p and r.
+    /// Viscosity and its p and r derivatives as a function of p, T and r.
     void PvtLiveGas::mu(const int n,
                         const int* pvtRegionIdx,
-                               const double* p,
+                        const double* p,
+                        const double* /*T*/,
                                const double* r,
                                const PhasePresence* cond,
                                double* output_mu,
@@ -164,10 +167,11 @@ namespace Opm
     }
 
 
-    /// Formation volume factor as a function of p and z.
+    /// Formation volume factor as a function of p, T and z.
     void PvtLiveGas::B(const int n,
                        const int* pvtRegionIdx,
-                             const double* p,
+                       const double* p,
+                       const double* /*T*/,
                              const double* z,
                              double* output_B) const
     {
@@ -181,8 +185,9 @@ namespace Opm
 
     /// Formation volume factor and p-derivative as functions of p and z.
     void PvtLiveGas::dBdp(const int n,
-                       const int* pvtRegionIdx,
-                                const double* p,
+                          const int* pvtRegionIdx,
+                          const double* p,
+                          const double* /*T*/,
                                 const double* z,
                                 double* output_B,
                                 double* output_dBdp) const
@@ -193,10 +198,11 @@ namespace Opm
         }
     }
 
-    /// The inverse of the formation volume factor b = 1 / B, and its derivatives as a function of p and r.
+    /// The inverse of the formation volume factor b = 1 / B, and its p and r derivatives as a function of p, T and r.
     void PvtLiveGas::b(const int /*n*/,
                        const int* /*pvtRegionIdx*/,
-                             const double* /*p*/,
+                       const double* /*p*/,
+                       const double* /*T*/,
                              const double* /*r*/,
                              double* /*output_b*/,
                              double* /*output_dbdp*/,
@@ -206,10 +212,11 @@ namespace Opm
         OPM_THROW(std::runtime_error, "The new fluid interface not yet implemented");
     }
 
-    /// The inverse of the formation volume factor b = 1 / B, and its derivatives as a function of p and r.
+    /// The inverse of the formation volume factor b = 1 / B, and its p and r derivatives as a function of p, T and r.
     void PvtLiveGas::b(const int n,
                        const int* pvtRegionIdx,
-                          const double* p,
+                       const double* p,
+                       const double* /*T*/,
                           const double* r,
                           const PhasePresence* cond,
                           double* output_b,

--- a/opm/core/props/pvt/PvtLiveGas.hpp
+++ b/opm/core/props/pvt/PvtLiveGas.hpp
@@ -29,8 +29,8 @@
 namespace Opm
 {
     /// Class for miscible wet gas (with vaporized oil in vapour phase).
-    /// The PVT properties can either be given as a function of pressure (p) and surface volume (z)
-    /// or pressure (p) and gas resolution factor (r).
+    /// The PVT properties can either be given as a function of pressure (p), temperature (T) and surface volume (z)
+    /// or pressure (p), temperature (T) and gas resolution factor (r).
     /// For all the virtual methods, the following apply: p, r and z
     /// are expected to be of size n, size n and n*num_phases, respectively.
     /// Output arrays shall be of size n, and must be valid before
@@ -41,64 +41,71 @@ namespace Opm
         PvtLiveGas(const std::vector<Opm::PvtgTable>& pvtgTables);
         virtual ~PvtLiveGas();
 
-        /// Viscosity as a function of p and z.
+        /// Viscosity as a function of p, T and z.
         virtual void mu(const int n,
                         const int* pvtRegionIdx,
                         const double* p,
+                        const double* T,
                         const double* z,
                         double* output_mu) const;
 
-        /// Viscosity and its derivatives as a function of p and r.
+        /// Viscosity and its p and r derivatives as a function of p, T and r.
         /// The fluid is considered saturated if r >= rsSat(p).
         virtual void mu(const int n,
                         const int* pvtRegionIdx,
                         const double* p,
+                        const double* T,
                         const double* r,
                         double* output_mu,
                         double* output_dmudp,
                         double* output_dmudr) const;
 
-        /// Viscosity as a function of p and r.
+        /// Viscosity as a function of p, T and r.
         /// State condition determined by 'cond'.
         virtual void mu(const int n,
                         const int* pvtRegionIdx,
                         const double* p,
+                        const double* T,
                         const double* r,
                         const PhasePresence* cond,
                         double* output_mu,
                         double* output_dmudp,
                         double* output_dmudr) const;
 
-        /// Formation volume factor as a function of p and z.
+        /// Formation volume factor as a function of p, T and z.
         virtual void B(const int n,
                        const int* pvtRegionIdx,
                        const double* p,
+                       const double* T,
                        const double* z,
                        double* output_B) const;
 
-        /// Formation volume factor and p-derivative as functions of p and z.
+        /// Formation volume factor and p-derivative as functions of p, T and z.
         virtual void dBdp(const int n,
                           const int* pvtRegionIdx,
                           const double* p,
+                          const double* T,
                           const double* z,
                           double* output_B,
                           double* output_dBdp) const;
 
-        /// The inverse of the formation volume factor b = 1 / B, and its derivatives as a function of p and r.
+        /// The inverse of the formation volume factor b = 1 / B, and its p and r derivatives as a function of p, T and r.
         /// The fluid is considered saturated if r >= rsSat(p).
         virtual void b(const int n,
                        const int* pvtRegionIdx,
                        const double* p,
+                       const double* T,
                        const double* r,
                        double* output_b,
                        double* output_dbdp,
                        double* output_dbdr) const;
 
-        /// The inverse of the formation volume factor b = 1 / B, and its derivatives as a function of p and r.
+        /// The inverse of the formation volume factor b = 1 / B, and its p and r derivatives as a function of p, T and r.
         /// State condition determined by 'cond'.
         virtual void b(const int n,
                        const int* pvtRegionIdx,
                        const double* p,
+                       const double* T,
                        const double* r,
                        const PhasePresence* cond,
                        double* output_b,
@@ -107,7 +114,7 @@ namespace Opm
 
 
 
-        /// Solution gas/oil ratio and its derivatives at saturated conditions as a function of p.
+        /// Solution gas/oil ratio and its derivatives at saturated conditions as a function of p, T.
         virtual void rsSat(const int n,
                            const int* pvtRegionIdx,
                           const double* p,

--- a/opm/core/props/pvt/PvtLiveOil.cpp
+++ b/opm/core/props/pvt/PvtLiveOil.cpp
@@ -132,10 +132,11 @@ namespace Opm
     }
 
 
-    /// Viscosity as a function of p and z.
+    /// Viscosity as a function of p, T and z.
     void PvtLiveOil::mu(const int n,
                         const int* pvtTableIdx,
-                              const double* p,
+                        const double* p,
+                        const double* /*T*/,
                               const double* z,
                               double* output_mu) const
     {
@@ -150,10 +151,11 @@ namespace Opm
         }
     }
 
-    /// Viscosity and its derivatives as a function of p and r.
+    /// Viscosity and its p and r derivatives as a function of p, T and r.
     void PvtLiveOil::mu(const int n,
                         const int* pvtTableIdx,
-                               const double* p,
+                        const double* p,
+                        const double* /*T*/,
                                const double* r,
                                double* output_mu,
                                double* output_dmudp,
@@ -184,10 +186,11 @@ namespace Opm
                 }
     }
 
-    /// Viscosity and its derivatives as a function of p and r.
+    /// Viscosity and its p and r derivatives as a function of p, T and r.
     void PvtLiveOil::mu(const int n,
                         const int* pvtTableIdx,
-                               const double* p,
+                        const double* p,
+                        const double* /*T*/,
                                const double* r,
                                const PhasePresence* cond,
                                double* output_mu,
@@ -221,10 +224,11 @@ namespace Opm
     }
 
 
-    /// Formation volume factor as a function of p and z.
+    /// Formation volume factor as a function of p, T and z.
     void PvtLiveOil::B(const int n,
                        const int* pvtTableIdx,
-                             const double* p,
+                       const double* p,
+                       const double* /*T*/,
                              const double* z,
                              double* output_B) const
     {
@@ -238,10 +242,11 @@ namespace Opm
     }
 
 
-    /// Formation volume factor and p-derivative as functions of p and z.
+    /// Formation volume factor and p-derivative as functions of p, T and z.
     void PvtLiveOil::dBdp(const int n,
-                        const int* pvtTableIdx,
-                                const double* p,
+                          const int* pvtTableIdx,
+                          const double* p,
+                          const double* /*T*/,
                                 const double* z,
                                 double* output_B,
                                 double* output_dBdp) const
@@ -255,8 +260,9 @@ namespace Opm
     }
 
     void PvtLiveOil::b(const int n,
-                        const int* pvtTableIdx,
-                          const double* p,
+                       const int* pvtTableIdx,
+                       const double* p,
+                       const double* /*T*/,
                           const double* r,
                           double* output_b,
                           double* output_dbdp,
@@ -275,8 +281,9 @@ namespace Opm
     }
 
     void PvtLiveOil::b(const int n,
-                        const int* pvtTableIdx,
-                          const double* p,
+                       const int* pvtTableIdx,
+                       const double* p,
+                       const double* /*T*/,
                           const double* r,
                           const PhasePresence* cond,
                           double* output_b,

--- a/opm/core/props/pvt/PvtLiveOil.hpp
+++ b/opm/core/props/pvt/PvtLiveOil.hpp
@@ -30,8 +30,8 @@
 namespace Opm
 {
     /// Class for miscible live oil (with dissolved gas in liquid phase).
-    /// The PVT properties can either be given as a function of pressure (p) and surface volume (z)
-    /// or pressure (p) and gas resolution factor (r).
+    /// The PVT properties can either be given as a function of pressure (p), temperature (T) and surface volume (z)
+    /// or pressure (p), temperature (T) and gas resolution factor (r).
     /// For all the virtual methods, the following apply: p, r and z
     /// are expected to be of size n, size n and n*num_phases, respectively.
     /// Output arrays shall be of size n, and must be valid before
@@ -42,64 +42,71 @@ namespace Opm
         PvtLiveOil(const std::vector<Opm::PvtoTable>& pvtoTables);
         virtual ~PvtLiveOil();
 
-        /// Viscosity as a function of p and z.
+        /// Viscosity as a function of p, T and z.
         virtual void mu(const int n,
                         const int* pvtTableIdx,
                         const double* p,
+                        const double* T,
                         const double* z,
                         double* output_mu) const;
 
-        /// Viscosity and its derivatives as a function of p and r.
+        /// Viscosity and its p and r derivatives as a function of p, T and r.
         /// The fluid is considered saturated if r >= rsSat(p).
         virtual void mu(const int n,
                         const int* pvtTableIdx,
                         const double* p,
+                        const double* T,
                         const double* r,
                         double* output_mu,
                         double* output_dmudp,
                         double* output_dmudr) const;
 
-        /// Viscosity as a function of p and r.
+        /// Viscosity as a function of p, T and r.
         /// State condition determined by 'cond'.
         virtual void mu(const int n,
                         const int* pvtTableIdx,
                         const double* p,
+                        const double* T,
                         const double* r,
                         const PhasePresence* cond,
                         double* output_mu,
                         double* output_dmudp,
                         double* output_dmudr) const;
 
-        /// Formation volume factor as a function of p and z.
+        /// Formation volume factor as a function of p, T and z.
         virtual void B(const int n,
                        const int* pvtTableIdx,
                        const double* p,
+                       const double* T,
                        const double* z,
                        double* output_B) const;
 
-        /// Formation volume factor and p-derivative as functions of p and z.
+        /// Formation volume factor and p-derivative as functions of p, T and z.
         virtual void dBdp(const int n,
                           const int* pvtTableIdx,
                           const double* p,
+                          const double* T,
                           const double* z,
                           double* output_B,
                           double* output_dBdp) const;
 
-        /// The inverse of the formation volume factor b = 1 / B, and its derivatives as a function of p and r.
+        /// The inverse of the formation volume factor b = 1 / B, and its derivatives as a function of p, T and r.
         /// The fluid is considered saturated if r >= rsSat(p).
         virtual void b(const int n,
                        const int* pvtTableIdx,
                        const double* p,
+                       const double* T,
                        const double* r,
                        double* output_b,
                        double* output_dbdp,
                        double* output_dbdr) const;
 
-        /// The inverse of the formation volume factor b = 1 / B, and its derivatives as a function of p and r.
+        /// The inverse of the formation volume factor b = 1 / B, and its derivatives as a function of p, T and r.
         /// State condition determined by 'cond'.
         virtual void b(const int n,
                        const int* pvtTableIdx,
                        const double* p,
+                       const double* T,
                        const double* r,
                        const PhasePresence* cond,
                        double* output_b,

--- a/opm/core/props/pvt/PvtPropertiesBasic.cpp
+++ b/opm/core/props/pvt/PvtPropertiesBasic.cpp
@@ -113,6 +113,7 @@ namespace Opm
 
     void PvtPropertiesBasic::mu(const int n,
                                 const double* /*p*/,
+                                const double* /*T*/,
                                 const double* /*z*/,
                                 double* output_mu) const
     {
@@ -127,6 +128,7 @@ namespace Opm
 
     void PvtPropertiesBasic::B(const int n,
                                const double* /*p*/,
+                               const double* /*T*/,
                                const double* /*z*/,
                                double* output_B) const
     {
@@ -141,6 +143,7 @@ namespace Opm
 
     void PvtPropertiesBasic::dBdp(const int n,
                                   const double* /*p*/,
+                                  const double* /*T*/,
                                   const double* /*z*/,
                                   double* output_B,
                                   double* output_dBdp) const

--- a/opm/core/props/pvt/PvtPropertiesBasic.hpp
+++ b/opm/core/props/pvt/PvtPropertiesBasic.hpp
@@ -29,7 +29,7 @@ namespace Opm
 
     /// Class collecting simple pvt properties for 1-3 phases.
     /// All phases are incompressible and have constant viscosities.
-    /// For all the methods, the following apply: p and z are unused.
+    /// For all the methods, the following apply: p, T and z are unused.
     /// Output arrays shall be of size n*numPhases(), and must be valid
     /// before calling the method.
     /// NOTE: This class is intentionally similar to BlackoilPvtProperties.
@@ -62,21 +62,24 @@ namespace Opm
         /// \return  Array of size numPhases().
         const double* surfaceDensities() const;
 
-        /// Viscosity as a function of p and z.
+        /// Viscosity as a function of p, T and z.
         void mu(const int n,
                 const double* p,
+                const double* T,
                 const double* z,
                 double* output_mu) const;
 
-        /// Formation volume factor as a function of p and z.
+        /// Formation volume factor as a function of p, T and z.
         void B(const int n,
                const double* p,
+               const double* T,
                const double* z,
                double* output_B) const;
 
-        /// Formation volume factor and p-derivative as functions of p and z.
+        /// Formation volume factor and p-derivative as functions of p, T and z.
         void dBdp(const int n,
                   const double* p,
+                  const double* T,
                   const double* z,
                   double* output_B,
                   double* output_dBdp) const;

--- a/opm/core/simulator/SimulatorCompressibleTwophase.cpp
+++ b/opm/core/simulator/SimulatorCompressibleTwophase.cpp
@@ -358,7 +358,7 @@ namespace Opm
             // Solve pressure equation.
             if (check_well_controls_) {
                 computeFractionalFlow(props_, allcells_,
-                                      state.pressure(), state.surfacevol(), state.saturation(),
+                                      state.pressure(), state.temperature(), state.surfacevol(), state.saturation(),
                                       fractional_flows);
                 wells_manager_.applyExplicitReinjectionControls(well_resflows_phase, well_resflows_phase);
             }
@@ -445,7 +445,7 @@ namespace Opm
             double injected[2] = { 0.0 };
             double produced[2] = { 0.0 };
             for (int tr_substep = 0; tr_substep < num_transport_substeps_; ++tr_substep) {
-                tsolver_.solve(&state.faceflux()[0], &state.pressure()[0],
+                tsolver_.solve(&state.faceflux()[0], &state.pressure()[0], &state.temperature()[0],
                                &initial_porevol[0], &porevol[0], &transport_src[0], stepsize,
                                state.saturation(), state.surfacevol());
                 double substep_injected[2] = { 0.0 };

--- a/opm/core/simulator/SimulatorState.cpp
+++ b/opm/core/simulator/SimulatorState.cpp
@@ -12,6 +12,7 @@ SimulatorState::equals (const SimulatorState& other,
 
     // if we use &=, then all the tests will be run regardless
     equal = equal && vectorApproxEqual( pressure() , other.pressure() , epsilon);
+    equal = equal && vectorApproxEqual( temperature() , other.temperature() , epsilon);
     equal = equal && vectorApproxEqual( facepressure() , other.facepressure() , epsilon);
     equal = equal && vectorApproxEqual( faceflux() , other.faceflux() , epsilon);
     equal = equal && vectorApproxEqual( saturation() , other.saturation() , epsilon);
@@ -48,6 +49,7 @@ SimulatorState::init(int number_of_cells, int number_of_faces, int num_phases)
 {
     num_phases_ = num_phases;
     press_.resize(number_of_cells, 0.0);
+    temp_.resize(number_of_cells, 273.15 + 20);
     fpress_.resize(number_of_faces, 0.0);
     flux_.resize(number_of_faces, 0.0);
     sat_.resize(num_phases_ * number_of_cells, 0.0);

--- a/opm/core/simulator/SimulatorState.hpp
+++ b/opm/core/simulator/SimulatorState.hpp
@@ -38,11 +38,13 @@ namespace Opm
         int numPhases() const { return num_phases_; }
 
         std::vector<double>& pressure    () { return press_ ; }
+        std::vector<double>& temperature () { return temp_  ; }
         std::vector<double>& facepressure() { return fpress_; }
         std::vector<double>& faceflux    () { return flux_  ; }
         std::vector<double>& saturation  () { return sat_   ; }
 
         const std::vector<double>& pressure    () const { return press_ ; }
+        const std::vector<double>& temperature () const { return temp_  ; }
         const std::vector<double>& facepressure() const { return fpress_; }
         const std::vector<double>& faceflux    () const { return flux_  ; }
         const std::vector<double>& saturation  () const { return sat_   ; }
@@ -56,6 +58,7 @@ namespace Opm
     private:
         int num_phases_;
         std::vector<double> press_ ;
+        std::vector<double> temp_  ;
         std::vector<double> fpress_;
         std::vector<double> flux_  ;
         std::vector<double> sat_   ;

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -44,6 +44,7 @@ namespace Opm
                 const int nw = wells->number_of_wells;
                 const int np = wells->number_of_phases;
                 bhp_.resize(nw);
+                temperature_.resize(nw, 273.15 + 20); // standard temperature for now
                 wellrates_.resize(nw * np, 0.0);
                 for (int w = 0; w < nw; ++w) {
                     assert((wells->type[w] == INJECTOR) || (wells->type[w] == PRODUCER));
@@ -110,6 +111,10 @@ namespace Opm
         std::vector<double>& bhp() { return bhp_; }
         const std::vector<double>& bhp() const { return bhp_; }
 
+        /// One temperature per well.
+        std::vector<double>& temperature() { return temperature_; }
+        const std::vector<double>& temperature() const { return temperature_; }
+
         /// One rate per well and phase.
         std::vector<double>& wellRates() { return wellrates_; }
         const std::vector<double>& wellRates() const { return wellrates_; }
@@ -124,6 +129,7 @@ namespace Opm
 
     private:
         std::vector<double> bhp_;
+        std::vector<double> temperature_;
         std::vector<double> wellrates_;
         std::vector<double> perfrates_;
         std::vector<double> perfpress_;

--- a/opm/core/transport/reorder/TransportSolverCompressibleTwophaseReorder.cpp
+++ b/opm/core/transport/reorder/TransportSolverCompressibleTwophaseReorder.cpp
@@ -80,6 +80,7 @@ namespace Opm
 
     void TransportSolverCompressibleTwophaseReorder::solve(const double* darcyflux,
                                                    const double* pressure,
+                                                   const double* temperature,
                                                    const double* porevolume0,
                                                    const double* porevolume,
                                                    const double* source,
@@ -95,8 +96,8 @@ namespace Opm
         dt_ = dt;
         toWaterSat(saturation, saturation_);
 
-        props_.viscosity(props_.numCells(), pressure, NULL, &allcells_[0], &visc_[0], NULL);
-        props_.matrix(props_.numCells(), pressure, NULL, &allcells_[0], &A_[0], NULL);
+        props_.viscosity(props_.numCells(), pressure, temperature, NULL, &allcells_[0], &visc_[0], NULL);
+        props_.matrix(props_.numCells(), pressure, temperature, NULL, &allcells_[0], &A_[0], NULL);
 
         // Check immiscibility requirement (only done for first cell).
         if (A_[1] != 0.0 || A_[2] != 0.0) {

--- a/opm/core/transport/reorder/TransportSolverCompressibleTwophaseReorder.hpp
+++ b/opm/core/transport/reorder/TransportSolverCompressibleTwophaseReorder.hpp
@@ -48,6 +48,7 @@ namespace Opm
         /// Solve for saturation at next timestep.
         /// \param[in] darcyflux         Array of signed face fluxes.
         /// \param[in] pressure          Array of cell pressures
+        /// \param[in] temperature       Array of cell temperatures
         /// \param[in] surfacevol0       Array of surface volumes at start of timestep
         /// \param[in] porevolume0       Array of pore volumes at start of timestep.
         /// \param[in] porevolume        Array of pore volumes at end of timestep.
@@ -57,6 +58,7 @@ namespace Opm
         /// \param[in, out] surfacevol   Surface volume densities for each phase.
         void solve(const double* darcyflux,
                    const double* pressure,
+                   const double* temperature,
                    const double* porevolume0,
                    const double* porevolume,
                    const double* source,

--- a/opm/core/utility/miscUtilities.cpp
+++ b/opm/core/utility/miscUtilities.cpp
@@ -636,7 +636,7 @@ namespace Opm
                     double mob[max_np];
                     props.relperm(1, &s[np*cell], &cell, mob, 0);
                     double visc[max_np];
-                    props.viscosity(1, &p[cell], &z[np*cell], &cell, visc, 0);
+                    props.viscosity(1, &p[cell], 0, &z[np*cell], &cell, visc, 0);
                     double tmob = 0;
                     for(int i = 0; i < np; ++i) {
                         mob[i] /= visc[i];

--- a/opm/core/utility/miscUtilitiesBlackoil.hpp
+++ b/opm/core/utility/miscUtilitiesBlackoil.hpp
@@ -92,12 +92,14 @@ namespace Opm
     /// @param[in]  props     rock and fluid properties
     /// @param[in]  cells     cells with which the saturation values are associated
     /// @param[in]  p         pressure (one value per cell)
+    /// @param[in]  T         temperature (one value per cell)
     /// @param[in]  z         surface-volume values (for all P phases)
     /// @param[in]  s         saturation values (for all phases)
     /// @param[out] pmobc     phase mobilities (for all phases).
     void computePhaseMobilities(const Opm::BlackoilPropertiesInterface& props,
                                 const std::vector<int>&                 cells,
                                 const std::vector<double>&              p,
+                                const std::vector<double>&              T,
                                 const std::vector<double>&              z,
                                 const std::vector<double>&              s,
                                 std::vector<double>&                    pmobc);
@@ -107,12 +109,14 @@ namespace Opm
     /// @param[in]  props            rock and fluid properties
     /// @param[in]  cells            cells with which the saturation values are associated
     /// @param[in]  p                pressure (one value per cell)
+    /// @param[in]  T                temperature(one value per cell)
     /// @param[in]  z                surface-volume values (for all P phases)
     /// @param[in]  s                saturation values (for all phases)
     /// @param[out] fractional_flow  the fractional flow for each phase for each cell.
     void computeFractionalFlow(const Opm::BlackoilPropertiesInterface& props,
                                const std::vector<int>& cells,
                                const std::vector<double>& p,
+                               const std::vector<double>& T,
                                const std::vector<double>& z,
                                const std::vector<double>& s,
                                std::vector<double>& fractional_flows);

--- a/tests/test_blackoilfluid.cpp
+++ b/tests/test_blackoilfluid.cpp
@@ -102,7 +102,7 @@ std::vector<std::shared_ptr<PvtInterface> > getProps(Opm::DeckConstPtr deck, Opm
     return props_;
 }
 
-void testmu(const double reltol, int n, int np, const std::vector<int> &pvtTableIdx, std::vector<double> p, std::vector<double> r,std::vector<double> z,
+void testmu(const double reltol, int n, int np, const std::vector<int> &pvtTableIdx, std::vector<double> p, std::vector<double> T, std::vector<double> r,std::vector<double> z,
             std::vector<std::shared_ptr<PvtInterface> > props_, std::vector<Opm::PhasePresence> condition)
 {
     std::vector<double> mu(n);
@@ -116,8 +116,8 @@ void testmu(const double reltol, int n, int np, const std::vector<int> &pvtTable
 
     // test mu
     for (int phase = 0; phase < np; ++phase) {
-        props_[phase]->mu(n, &pvtTableIdx[0], &p[0], &r[0], &condition[0], &mu_new[0], &dmudp[0], &dmudr[0]);
-        props_[phase]->mu(n, &pvtTableIdx[0], &p[0], &z[0], &mu[0]);
+        props_[phase]->mu(n, &pvtTableIdx[0], &p[0], &T[0], &r[0], &condition[0], &mu_new[0], &dmudp[0], &dmudr[0]);
+        props_[phase]->mu(n, &pvtTableIdx[0], &p[0], &T[0], &z[0], &mu[0]);
         dmudp_diff = (mu_new[1]-mu_new[0])/(p[1]-p[0]);
         dmudr_diff = (mu_new[2]-mu_new[0])/(r[2]-r[0]);
         dmudp_diff_u = (mu_new[4]-mu_new[3])/(p[4]-p[3]);
@@ -138,7 +138,7 @@ void testmu(const double reltol, int n, int np, const std::vector<int> &pvtTable
     }
 }
 
-void testb(const double reltol, int n, int np, const std::vector<int> &pvtTableIdx, std::vector<double> p, std::vector<double> r,std::vector<double> z,
+void testb(const double reltol, int n, int np, const std::vector<int> &pvtTableIdx, std::vector<double> p, std::vector<double> T, std::vector<double> r,std::vector<double> z,
             std::vector<std::shared_ptr<PvtInterface> > props_, std::vector<Opm::PhasePresence> condition)
 {
     // test b
@@ -155,8 +155,8 @@ void testb(const double reltol, int n, int np, const std::vector<int> &pvtTableI
     double dbdr_diff_u;
 
     for (int phase = 0; phase < np; ++phase) {
-        props_[phase]->b(n, &pvtTableIdx[0], &p[0], &r[0], &condition[0], &b[0], &dbdp[0], &dbdr[0]);
-        props_[phase]->dBdp(n, &pvtTableIdx[0], &p[0], &z[0], &B[0], &dBdp[0]);
+        props_[phase]->b(n, &pvtTableIdx[0], &p[0], &T[0], &r[0], &condition[0], &b[0], &dbdp[0], &dbdr[0]);
+        props_[phase]->dBdp(n, &pvtTableIdx[0], &p[0], &T[0], &z[0], &B[0], &dBdp[0]);
         dbdp_diff = (b[1]-b[0])/(p[1]-p[0]);
         dbdr_diff = (b[2]-b[0])/(r[2]-r[0]);
         dbdp_diff_u = (b[4]-b[3])/(p[4]-p[3]);
@@ -253,6 +253,7 @@ BOOST_AUTO_TEST_CASE(test_liveoil)
     const double reltolpermu = 1e-1;
 
     std::vector<double> p(n);
+    std::vector<double> T(n, 273.15 + 20);
     std::vector<double> r(n);
     std::vector<PhasePresence> condition(n);
     std::vector<double> z(n * np);
@@ -292,9 +293,9 @@ BOOST_AUTO_TEST_CASE(test_liveoil)
 
     }
 
-    testmu(reltolpermu, n, np, pvtRegionIdx, p, r,z, props_, condition);
+    testmu(reltolpermu, n, np, pvtRegionIdx, p, T, r,z, props_, condition);
 
-    testb(reltolper,n,np,pvtRegionIdx,p,r,z,props_,condition);
+    testb(reltolper,n,np,pvtRegionIdx,p,T,r,z,props_,condition);
 
     testrsSat(reltolper,n,np,pvtRegionIdx,p,props_);
 
@@ -332,6 +333,7 @@ BOOST_AUTO_TEST_CASE(test_wetgas)
     const double reltolpermu = 1e-1;
 
     std::vector<double> p(n);
+    std::vector<double> T(n, 273.15+20);
     std::vector<double> r(n);
     std::vector<PhasePresence> condition(n);
     std::vector<double> z(n * np);
@@ -371,9 +373,9 @@ BOOST_AUTO_TEST_CASE(test_wetgas)
 
     }
 
-    testmu(reltolpermu, n, np, pvtRegionIdx, p, r,z, props_, condition);
+    testmu(reltolpermu, n, np, pvtRegionIdx, p,T, r,z, props_, condition);
 
-    testb(reltolper,n,np,pvtRegionIdx,p,r,z,props_,condition);
+    testb(reltolper,n,np,pvtRegionIdx,p,T,r,z,props_,condition);
 
     testrsSat(reltolper,n,np,pvtRegionIdx,p,props_);
 


### PR DESCRIPTION
Note that this patch does not introduce any real temperature
dependence but only changes the APIs for the viscosity and for the
density related methods. Also note, that I also don't like the fact that
this requires so many changes to so many files, but with the current
design of the property classes I cannot see a way to avoid this...

the testing don is a bit limited so far: it compiles on clang 3.5, gcc 4.9 and gcc 4.4, and all ctests pass (whatever the latter means). If you have more tests, please run them before merging.

Finally, opm-autodiff and opm-polymer require a few changes which must be merged synchronously with this one...
