### PR TITLE
adapt to the removal of the "strict parsing" concept

### DIFF
--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -136,7 +136,7 @@ std::shared_ptr<Opm::BlackoilState> createBlackOilState(Opm::EclipseGridConstPtr
 Opm::DeckConstPtr createDeck(const std::string& eclipse_data_filename) {
   Opm::ParserPtr parser(new Opm::Parser());
   Opm::ParserLogPtr parserLog(new Opm::ParserLog);
-  Opm::DeckConstPtr deck = parser->parseFile(eclipse_data_filename, true, parserLog);
+  Opm::DeckConstPtr deck = parser->parseFile(eclipse_data_filename, parserLog);
 
   return deck;
 }


### PR DESCRIPTION
this must be merged synchronously with OPM/opm-parser#347

also, for some reason I do not yet understand this code does not get compiled on my machine, but at least the jenkins server caught it... 
