### PR TITLE
Support for multiple linear solver library containers

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -290,6 +290,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/linalg/SparseMatrix.hpp
 	opm/core/linalg/SparseMatrix_impl.hpp
 	opm/core/linalg/SparseMatrix_csr.hpp
+	opm/core/linalg/SparseMatrix_dune.hpp
 	opm/core/linalg/blas_lapack.h
 	opm/core/linalg/call_umfpack.h
 	opm/core/linalg/sparse_sys.h

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -163,6 +163,7 @@ list (APPEND TEST_SOURCE_FILES
 	tests/test_nonuniformtablelinear.cpp
 	tests/test_sparsevector.cpp
 	tests/test_sparsetable.cpp
+	tests/test_sparsematrix.cpp
 	tests/test_velocityinterpolation.cpp
 	tests/test_quadratures.cpp
 	tests/test_uniformtablelinear.cpp
@@ -286,6 +287,8 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/linalg/LinearSolverInterface.hpp
 	opm/core/linalg/LinearSolverIstl.hpp
 	opm/core/linalg/LinearSolverUmfpack.hpp
+	opm/core/linalg/SparseMatrix.hpp
+	opm/core/linalg/SparseMatrix_impl.hpp
 	opm/core/linalg/blas_lapack.h
 	opm/core/linalg/call_umfpack.h
 	opm/core/linalg/sparse_sys.h

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -289,6 +289,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/linalg/LinearSolverUmfpack.hpp
 	opm/core/linalg/SparseMatrix.hpp
 	opm/core/linalg/SparseMatrix_impl.hpp
+	opm/core/linalg/SparseMatrix_csr.hpp
 	opm/core/linalg/blas_lapack.h
 	opm/core/linalg/call_umfpack.h
 	opm/core/linalg/sparse_sys.h

--- a/opm/core/linalg/SparseMatrix.hpp
+++ b/opm/core/linalg/SparseMatrix.hpp
@@ -1,0 +1,338 @@
+#ifndef OPM_SPARSEMATRIX_HEADER
+#define OPM_SPARSEMATRIX_HEADER
+
+#include <memory>
+#include <vector>
+#include <map>
+
+/*
+ * An interface for sparse matrices, see the announcement:
+ * http://www.opm-project.org/pipermail/opm/2014-October/000664.html
+ *
+ * Motivation for this file and its contents:
+ * We would like to support multiple linear solver backends. A lot of these
+ * solvers uses their own data types, and in some cases code in the OPM project
+ * is very backend specific. In an attempt to resolve this I introduce a
+ * unified sparse matrix interface that ideally should be compatible with all
+ * solver libraries.
+ *
+ * It is designed in such a way that we can utilize "native types" (i.e. data
+ * structures provided by a specific solver library). This is achieved through
+ * template specialization and composition. This header file provides an
+ * interface you can assume are compatible with any underlying container for
+ * various linear solver libraries. It also provides a default implementation
+ * using our own CSR Matrix representation, using a simple C-compatible struct
+ * as actual storage. The default implementation is intended primarily as a
+ * safe fallback and a reference. For high performance code you should use the
+ * interface, but as relays to the native types your library provides.
+ *
+ * NOTICE: This is currently an experimental implementation and will likely
+ * break in future revisions.
+ *
+ * NOTICE: This implementations uses a LOT of non-trivial C++ tricks to
+ * accomplish its goals. I've tried to comment it whenever something might be
+ * unclear, but noone is perfect. Let me know if something is missing:
+ * mailto:jorgekva@stud.ntnu.no
+ *
+ * If you are extending this interface to a new backend, please also see the
+ * tests in tests/test_sparsematrix.cpp.
+ */
+
+namespace Opm {
+
+    namespace unmanaged {
+        /* the plain, C-compatible CSR matrix structure.
+         *
+         * rows_ gives the number of rows in the matrix, but rows + 1 places
+         * are allocated.
+         *
+         * each row's indices and values are given by the difference between
+         * row_ind_[ i + 1 ] and row_ind_[ i ]. This access is always safe
+         * because of the extra value set. The final value of row_ind_should
+         * always be equal to nonzeros_
+         */
+        template< typename Scalar = double >
+        struct CSR {
+            CSR() = default;
+            CSR( std::size_t rows, std::size_t nonzeros, Scalar* values, int*, int* );
+            std::size_t rows_;
+            std::size_t nonzeros_;
+            Scalar* values_;
+            int* col_ind_;
+            int* row_ind_;
+        };
+    }
+
+    template< typename Scalar = double >
+    struct CSR : public unmanaged::CSR< Scalar > {
+
+        /* iterators are templated on T in order to support const_iterators */
+        template< typename T, typename Derived >
+        class base_itr {
+            /* A CRTP mixin to implement trivial variations of common iterator
+             * operations. Assumes that the derived class implements
+             * ++operator, operator== and operator*
+             */
+            public:
+                base_itr() = default;
+
+                Derived operator++( int );
+                Derived operator--( int );
+                bool operator!=( const Derived& other ) const;
+                T* operator->();
+        };
+
+        template< typename T >
+        class col_itr : public base_itr< T, col_itr< T > > {
+            public:
+
+                /* forward iterator for the columns of a row. Reuses
+                 * base_itr for implementation of some operations, but is
+                 * pretty straight forward.
+                 */
+
+                col_itr() = default;
+                col_itr( Scalar* val, int* col, std::size_t ind );
+
+                col_itr& operator++();
+                col_itr& operator--();
+                bool operator==( const col_itr& ) const;
+
+                T& operator*();
+
+                std::size_t index() const;
+
+            private:
+                Scalar* values_;
+                int* col_ind_;
+                std::size_t index_;
+        };
+
+        template< typename T >
+        class row_ref {
+            /*
+             * References some row in the matrix. This is a proxy class to
+             * access some operations and create iterators for the matrix, e.g.
+             * operator[].
+             *
+             * It is also intented for use as a mixin in row_itr, but this is
+             * just a (nifty) implementation detail. It is not meant to be
+             * created directly from user code, but rather be (correctly)
+             * constructed through iterators or operator[].
+             */
+            public:
+                col_itr< T > begin();
+                col_itr< T > end();
+
+                row_ref() = default;
+
+                /* undefined behaviour if given matrix position is zero
+                 *
+                 * This does NOT guarantee constant-time lookup.
+                 */
+                T& operator[]( std::size_t );
+                const T& operator[]( std::size_t ) const;
+
+                std::size_t index() const;
+                std::size_t size() const;
+
+            protected:
+                /* this class is not meant to be constructed directly */
+                row_ref( Scalar* val, int* col, int* row, std::size_t index );
+
+                Scalar* values_;
+                int* col_ind_;
+                int* row_ind_;
+                std::size_t index_;
+        };
+
+        template< typename T >
+        class row_itr : private row_ref< T >, public base_itr< T, row_itr< T > > {
+            /* Bi-directional row iterator. Behaves as expected, but uses some
+             * C++ tricks:
+             *
+             * * CRTP mixin (base_itr) for a shorter implementation.
+             * * privately inherits from row_ref and (re)uses its fields for
+             * its data. Constructor is basically a forward call to that. This
+             * composition allows us to reuse its data fields (which would've
+             * been private anyways). 
+             *
+             * The real goal of the private implementation, however, was a
+             * zero-copy dereference of a row_ref. operator* an operator-> now
+             * simply returns a ref to -the instance itself-, now
+             * re-interpreted as a row_ref. This gives iterator access when
+             * used as a row_itr and  row_ref access when accessed as that.
+             * This, however, is just an implementation detail and not really
+             * visible from user code.
+             */
+            public:
+                row_itr() = default;
+                row_itr( Scalar* val, int* col, int* row, std::size_t index );
+
+                row_itr& operator++();
+                row_itr& operator--();
+                bool operator==( const row_itr& ) const;
+
+                row_ref< T >& operator*();
+                /* overrides base_itr::operator-> */
+                row_ref< T >* operator->();
+
+                /* for consistency with col_itr (and compability with Dune's
+                 * BCRSMatrix iterator, index() is also available as a
+                 * method on the iterator
+                 */
+                using row_ref< T >::index;
+        };
+
+        typedef Scalar type;
+        typedef Scalar scalar;
+
+        typedef std::size_t size_type;
+
+        typedef typename unmanaged::CSR< Scalar > unmanaged;
+
+        typedef Scalar& Reference;
+        typedef Scalar* Pointer;
+        typedef row_itr< Scalar > iterator;
+        typedef row_itr< const Scalar > const_iterator;
+
+        /* no copy or assignment construction, behave like a unique_ptr */
+        CSR( const CSR& ) = delete;
+        CSR& operator=( const CSR& ) = delete;
+        CSR& operator=( CSR&& ) = default;
+
+        CSR();
+        CSR( std::size_t rows, std::size_t nonzeros, Scalar* values, int*, int* );
+        CSR( CSR&& );
+        ~CSR();
+
+        /*
+         * mimics std::unique_ptr. get just returns an unmanaged copy of the
+         * object, whereas release releases (duh) ownership. If you call
+         * release, make sure to free the resources afterwards.
+         */
+        unmanaged get();
+        unmanaged release();
+    };
+
+    template< typename Storage = CSR< double > >
+    class SparseMatrix : private Storage {
+        public:
+            typedef typename Storage::Scalar scalar;
+            typedef scalar type;
+
+            typedef std::size_t size_type;
+
+            typedef typename Storage::unmanaged unmanaged;
+
+            typedef typename Storage::iterator iterator;
+            typedef typename Storage::const_iterator const_iterator;
+
+            typedef typename Storage::template row_ref< scalar > row_ref;
+            typedef typename Storage::template row_ref< const scalar > const_row_ref;
+
+        SparseMatrix() = default;
+        SparseMatrix( SparseMatrix&& ) = default;
+        SparseMatrix& operator=( SparseMatrix&& );
+
+        SparseMatrix( const SparseMatrix& ) = delete;
+        SparseMatrix& operator=( const SparseMatrix& ) = delete;
+
+        // This constructor takes -ownership- over the given data
+        // TODO: communicate this through interface. Take unique_ptr?
+        SparseMatrix( size_type rows, size_type nonzero,
+                scalar* values, int* col_ind, int* row_ind );
+
+        /*
+         * A test to see if the (x,y) coordinate is nonzero. log(n) complexity
+         * for CSR, typically does not give constant-time guarantees.
+         */
+        bool exists( size_type, size_type ) const;
+
+        /* bounds checked operator[][] (Not implemented yet) */
+        scalar& at( size_type, size_type );
+
+        row_ref operator[]( size_type );
+        const_row_ref operator[]( size_type ) const;
+
+        iterator begin();
+        iterator end();
+
+        const_iterator cbegin() const;
+        const_iterator cend() const;
+
+        size_type rows() const;
+        /*
+         * cols() does -not- actually guarantee returning the correct result,
+         * at least for CSR storage. The reason for this is that there could be
+         * columns all filled with zeros which aren't represented (and really
+         * not very useful) that are supposed to be there, but aren't. For most
+         * cases this should be irrelevant, and this estimate is ok.
+         *
+         * O(n) with the size of nonzeros.
+         */
+        size_type cols() const;
+        size_type nonzeros() const;
+
+        /*
+         * Get the underlying structure. Allows you to directly access the
+         * underlying object, at the cost of being unusable with other
+         * implementations. The obvious use case for this is algorithm
+         * development and testing, but it shouldn't be used unless absolutely
+         * necessary in production code.
+         */
+        Storage& unsafe();
+    };
+
+    struct CO {
+        CO( std::size_t r, std::size_t c ) : row_( r ), col_( c ) {}
+
+        bool operator==( const CO& o ) const {
+            return this->row_ == o.row_
+                && this->col_ == o.col_;
+        }
+
+        bool operator<( const CO& o ) const {
+            if( this->row_ > o.row_ ) return false;
+            return this->row_ < o.row_
+                || this->col_ < o.col_;
+        }
+
+        std::size_t row_;
+        std::size_t col_;
+    };
+
+    template< typename S, typename T > class SparseMatrixBuilder;
+
+    namespace {
+        template< typename Scalar, typename Storage, typename Return >
+        struct conv {
+            static SparseMatrix< Return >
+                convert( SparseMatrixBuilder< Scalar, Storage >* );
+        };
+    }
+
+    template< typename Scalar = double, typename Storage = std::map< CO, Scalar > >
+    class SparseMatrixBuilder : private Storage {
+        public:
+            SparseMatrixBuilder() = default;
+            SparseMatrixBuilder( std::size_t rows, std::size_t cols );
+            SparseMatrixBuilder( std::size_t rows, std::size_t cols, std::size_t nonzeros );
+
+            void setSize( std::size_t rows, std::size_t ) {
+                this->rows = rows;
+            }
+
+            void add( std::size_t i, std::size_t j, Scalar val );
+            template< typename Return > SparseMatrix< Return > convert();
+
+        private:
+            int rows = 0;
+            template< typename S, typename U, typename T >
+            friend class conv;
+    };
+}
+
+#include "SparseMatrix_impl.hpp"
+
+#endif //OPM_SPARSEMATRIX_HEADER

--- a/opm/core/linalg/SparseMatrix_csr.hpp
+++ b/opm/core/linalg/SparseMatrix_csr.hpp
@@ -1,0 +1,289 @@
+#ifndef OPM_SPARSEMATRIX_CSR
+#define OPM_SPARSEMATRIX_CSR
+
+/*
+ * Opm::CSR<> specializations for SparseMatrix.
+ */
+
+namespace Opm {
+
+    namespace {
+
+        /* Put in an anonymous namespace because it can be considered a private
+         * function.
+         *
+         * This snippet is a bit syntax heavy.
+         *
+         * SparseMatrixBuilder has a convert() method that must be specialized
+         * for the relevant combinations of underlying storage and target type.
+         * Since functions in C++ cannot be partially specialized, this has to
+         * be accomplished via a "worker" class - struct conv.
+         *
+         * We want partially specialized functions because of the fundamental
+         * type parameter. While somewhat hard to understand, they enable a
+         * neat final interface for the -user-.
+         *
+         * The first template<> line is us telling the compiler that this is a
+         * fully specialized instance of the conv class.
+         *
+         * template< Scalar > means that this specialization is parametrised on
+         * Scalar.
+         *
+         * Then the actually struct *re-implementation* for this specific type.
+         * This is a C++ specification detail, and for why this is moved to its
+         * own, independent class.
+         *
+         * The SparseMatrixBuilder has struct conv as a friend, meaning the
+         * obj* passed is equivalent to this*.
+         *
+         * None of this is visible in user code. The external interface is
+         * builder.convert< target_type >();
+         */
+
+    template<>
+    template< typename Scalar >
+    struct conv< Scalar, std::map< CO, Scalar >, CSR< Scalar > > {
+    static SparseMatrix< CSR< Scalar > >
+        convert( SparseMatrixBuilder< Scalar, std::map< CO, Scalar > >* obj ) {
+
+        /* the CSR format only represents to the deepest row with a nonzero in
+         * it
+         *
+         * TODO: consider support for explicitly representing more trailing
+         * zero-rows
+         *
+         * we add 2 to the highest found row index in order to have room for
+         * the end-pointer (so not to special-case the final delta) and to
+         * account for off-by-one errors in allocation
+         */
+        const std::size_t rows = obj->rbegin()->first.row_ + 2;
+
+        std::unique_ptr< Scalar[] > values( new Scalar[ obj->size() ] );
+        std::unique_ptr< int[] > col_ind( new int[ obj->size() ] );
+        std::unique_ptr< int[] > row_ind( new int[ rows ] );
+
+        /* first pass: copy column indices and nonzero values */
+        auto* curr_col = col_ind.get();
+        auto* curr_val = values.get();
+        for( const auto val : *obj ) {
+            *curr_col++ = val.first.col_;
+            *curr_val++ = val.second;
+        }
+
+        /* second pass: build the row indices array.
+         *
+         * The range of rows are represented through the delta rows[ i ]
+         * rows[ i + 1 ]. If a row is empty then rows[ i ] == rows[ i + 1 ]
+         * (which both then points to the same offset in vals/cols)
+         */
+        auto* curr_row = row_ind.get();
+        *curr_row = 0;
+        auto valitr = obj->cbegin();
+        for( unsigned int i = 0; i < obj->size(); ++i, ++valitr ) {
+            assert( curr_row > row_ind.get() );
+
+            /* determine what index we're currently at */
+            const std::size_t row_pos = std::distance( row_ind.get(), curr_row );
+            const auto& val_row = valitr->first.row_;
+
+            /* no advancement, we're still on the same row */
+            if( row_pos == val_row ) continue;
+
+            /* fill all deltas between previously set row_ind and obj with i -
+             * obj handles the case of an empty row
+             */
+            std::fill_n( curr_row + 1, val_row - row_pos, i );
+            curr_row += val_row - row_pos;
+        }
+
+        row_ind[ rows - 1 ] = obj->size();
+
+        return SparseMatrix< CSR< Scalar > >( rows - 1, obj->size(),
+                values.release(), col_ind.release(), row_ind.release() );
+    }
+
+    };
+
+    }
+
+    /*
+     * CSR-specific re-implementation of the SparseMatrix class. This is picked
+     * whenver SparseMatrix< CSR< double > > is requested.
+     */
+    template<>
+    template< typename Scalar >
+    class SparseMatrix< CSR< Scalar > >
+    : private CSR< Scalar > {
+        private:
+            typedef CSR< Scalar > Storage;
+
+        public:
+            /* typedefs can be forwarded directly from CSR */
+            typedef Scalar type;
+            typedef Scalar scalar;
+
+            typedef typename Storage::size_type size_type;
+
+            typedef typename Storage::unmanaged unmanaged;
+
+            typedef typename Storage::iterator iterator;
+            typedef typename Storage::const_iterator const_iterator;
+
+            typedef typename Storage::template row_ref< Scalar > row_ref;
+            typedef typename Storage::template row_ref< const Scalar > const_row_ref;
+
+        SparseMatrix() = default;
+        SparseMatrix( size_type rows, size_type nonzero,
+                Scalar* values, int* col_ind, int* row_ind );
+
+        /*
+         * A test to see if the (x,y) coordinate is nonzero. log(n) complexity
+         * for CSR
+         */
+        bool exists( size_type, size_type ) const;
+
+        /* bounds checked operator[][] (Not implemented yet) */
+        Scalar& at( size_type, size_type );
+
+        row_ref operator[]( size_type );
+        const_row_ref operator[]( size_type ) const;
+
+        iterator begin();
+        iterator end();
+
+        const_iterator cbegin() const;
+        const_iterator cend() const;
+
+        size_type rows() const;
+        /*
+         * cols() does -not- actually guarantee returning the correct result
+         * for CSR storage. The reason for this is that there could be columns
+         * all filled with zeros which aren't represented (and really not very
+         * useful) that are supposed to be there, but aren't. For most cases
+         * this should be irrelevant, and this estimate is ok.
+         *
+         * O(n) with the size of nonzeros.
+         */
+        size_type cols() const;
+        size_type nonzeros() const;
+
+        Storage& unsafe() { return *this; }
+    };
+
+    template<>
+    template< typename Scalar >
+    SparseMatrix< CSR< Scalar > >::SparseMatrix(
+            size_type rows, size_type nonzero,
+            Scalar* values, int* col_ind, int* row_ind ) :
+        CSR< Scalar >( rows, nonzero, values, col_ind, row_ind )
+    {
+        assert( values );
+        assert( col_ind );
+        assert( row_ind );
+    }
+
+
+    template<>
+    template< typename Scalar >
+    bool SparseMatrix< CSR< Scalar > >
+    ::exists( size_type x, size_type y ) const {
+        assert( x < this->rows() - 1 );
+
+        /* Not determined yet - set threshold for when to do linear search
+         * instead of binary search
+         */
+        const unsigned int threshold = 0;
+
+        const auto row_begin = this->col_ind_ + this->row_ind_[ x ];
+        const auto row_end = this->col_ind_ + this->row_ind_[ x + 1 ];
+
+
+        /*
+         * Search the range [begin,end) and see if the y column is set
+         */
+        if( row_end - row_begin < threshold )
+            return std::find( row_begin, row_end, y ) != row_end;
+
+        return std::binary_search( row_begin, row_end, y );
+    }
+
+    template<>
+    template< typename Scalar >
+    typename SparseMatrix< CSR< Scalar > >::row_ref
+    SparseMatrix< CSR< Scalar > >::operator[]( size_type x ) {
+        assert( x < this->rows() - 1 );
+
+        return *iterator( this->values_, this->col_ind_, this->row_ind_, x );
+    }
+
+    template<>
+    template< typename Scalar >
+    typename SparseMatrix< CSR< Scalar > >::const_row_ref
+    SparseMatrix< CSR< Scalar > >::operator[]( size_type x ) const {
+        return this->operator[]( x );
+    }
+
+    template<>
+    template< typename Scalar >
+    typename SparseMatrix< CSR< Scalar > >::iterator
+    SparseMatrix< CSR< Scalar > >::begin() {
+        return iterator( this->values_, this->col_ind_, this->row_ind_, 0 );
+    }
+
+    template<>
+    template< typename Scalar >
+    typename SparseMatrix< CSR< Scalar > >::iterator
+    SparseMatrix< CSR< Scalar > >::end() {
+        return iterator( this->values_, this->col_ind_, this->row_ind_, this->rows() );
+    }
+
+    template<>
+    template< typename Scalar >
+    typename SparseMatrix< CSR< Scalar > >::const_iterator
+    SparseMatrix< CSR< Scalar > >::cbegin() const {
+        return const_iterator( this->values_, this->col_ind_, this->row_ind_, 0 );
+    }
+
+    template<>
+    template< typename Scalar >
+    typename SparseMatrix< CSR< Scalar > >::const_iterator
+    SparseMatrix< CSR< Scalar > >::cend() const {
+        return const_iterator( this->values_, this->col_ind_, this->row_ind_, this->rows() );
+    }
+
+    static inline std::size_t guess_cols( const int* col_ind, std::size_t len ) {
+        /* We cannot really be sure how many columns the matrix should have
+         * because that's information not really stored (in all cases,
+         * anyways). However, in CSR & friends we can assume that there is an
+         * element in the "last" column, reducing the problem to finding the
+         * max value in the col_ind array. Information beyond this point is
+         * never stored or touched anyway, so it shouldn't matter.
+         *
+         * This value as a boundary, however, can NOT be relied upon
+         */
+        return *std::max_element( col_ind, col_ind + len ) + 1;
+    }
+
+    template<>
+    template< typename Scalar >
+    typename SparseMatrix< CSR< Scalar > >::size_type
+    SparseMatrix< CSR< Scalar > >::rows() const {
+        return this->rows_;
+    }
+
+    template<>
+    template< typename Scalar >
+    typename SparseMatrix< CSR< Scalar > >::size_type
+    SparseMatrix< CSR< Scalar > >::cols() const {
+        return guess_cols( this->col_ind_, this->nonzeros_ );
+    }
+
+    template<>
+    template< typename Scalar >
+    typename SparseMatrix< CSR< Scalar > >::size_type
+    SparseMatrix< CSR< Scalar > >::nonzeros() const {
+        return this->nonzeros_;
+    }
+}
+
+#endif //OPM_SPARSEMATRIX_CSR

--- a/opm/core/linalg/SparseMatrix_dune.hpp
+++ b/opm/core/linalg/SparseMatrix_dune.hpp
@@ -1,0 +1,145 @@
+#if HAVE_DUNE_ISTL
+
+#ifndef OPM_SPARSEMATRIX_DUNE
+#define OPM_SPARSEMATRIX_DUNE
+
+#include <dune/istl/bcrsmatrix.hh>
+#include <dune/common/fmatrix.hh>
+
+namespace Opm {
+
+    /*
+     * For rationale and some elaboration, see SparseMatrix_csr.hpp
+     */
+    namespace {
+    template<>
+    template< typename Scalar, typename B >
+    struct conv< Scalar, std::map< CO, Scalar >, Dune::BCRSMatrix< B > > {
+    static SparseMatrix< Dune::BCRSMatrix< B > >
+        convert( SparseMatrixBuilder< Scalar, std::map< CO, Scalar > >* obj ) {
+
+            typedef Dune::BCRSMatrix< B > Mat;
+
+            auto rows = obj->rows;
+            Mat A( rows, rows, obj->size(), Mat::row_wise );
+
+            auto valitr = obj->cbegin();
+            for( auto row = A.createbegin(); row != A.createend(); ++row ) {
+                const int ri = row.index();
+                for( ; valitr->first.row_ == ri; ++valitr ) {
+                    row.insert( valitr->first.col_ );
+                }
+            }
+
+            for( auto itr = obj->cbegin(); itr != obj->cend(); ++itr ) {
+                A[ itr->first.row_ ][ itr->first.col_ ] = itr->second;
+            }
+
+            return A;
+        }
+    };
+
+    }
+
+    /*
+     * Dune::BCRSMatrix' interface happens to be very similar to
+     * Opm::SparseMatrix. The entire implementation is simple forwards or
+     * aliases.
+     */
+
+    template<>
+    template< typename B >
+    class SparseMatrix< Dune::BCRSMatrix< B > >
+    : private Dune::BCRSMatrix< B > {
+        private:
+            typedef Dune::BCRSMatrix< B > Storage;
+
+        public:
+            typedef typename Storage::field_type scalar;
+            typedef scalar type;
+
+            typedef typename Storage::size_type size_type;
+
+            typedef Storage unmanaged;
+
+            typedef typename Storage::iterator iterator;
+            typedef typename Storage::const_iterator const_iterator;
+
+            /*
+             * NOTICE:
+             * operator[] does NOT return row_ref as in the (basic) interface,
+             * but rather row_ref&. This is an implementation detail from DUNE.
+             */
+            typedef typename Storage::row_type row_ref;
+            typedef const typename Storage::row_type const_row_ref;
+
+        SparseMatrix() = default;
+        /*
+         * Not implemented yet. Relies on Dune move constructors
+         * SparseMatrix( Storage&& );
+         */
+
+        SparseMatrix( const Storage& );
+
+        /*
+         * Not implemented yet.
+         * Currently code depends on them. Will be sorted out along with move
+         * semantics
+         * SparseMatrix( const SparseMatrix& ) = delete;
+         * SparseMatrix& operator=( const SparseMatrix& ) = delete;
+         */
+
+        using Storage::exists;
+
+        scalar& at( size_type, size_type );
+
+        using Storage::operator[];
+
+        using Storage::begin;
+        using Storage::end;
+
+        size_type rows() const;
+        size_type cols() const;
+        size_type nonzeros() const;
+
+        Storage& unsafe() { return *this; }
+    };
+
+    template<>
+    template< typename B >
+    SparseMatrix< Dune::BCRSMatrix< B > >
+    ::SparseMatrix( const Storage& x ) : Storage( x ) {}
+
+    template<>
+    template< typename B >
+    typename SparseMatrix< Dune::BCRSMatrix< B > >::scalar&
+    SparseMatrix< Dune::BCRSMatrix< B > >
+    ::at( size_type x, size_type y ) {
+        return this->entry( x, y );
+    }
+
+    template<>
+    template< typename B >
+    typename SparseMatrix< Dune::BCRSMatrix< B > >::size_type
+    SparseMatrix< Dune::BCRSMatrix< B > >::rows() const {
+        return this->N();
+    }
+
+    template<>
+    template< typename B >
+    typename SparseMatrix< Dune::BCRSMatrix< B > >::size_type
+    SparseMatrix< Dune::BCRSMatrix< B > >::cols() const {
+        return this->M();
+    }
+
+    template<>
+    template< typename B >
+    typename SparseMatrix< Dune::BCRSMatrix< B > >::size_type
+    SparseMatrix< Dune::BCRSMatrix< B > >::nonzeros() const {
+        return this->nonzeroes();
+    }
+}
+
+#endif //OPM_SPARSEMATRIX_DUNE
+
+#endif //HAVE_DUNE_ISTL

--- a/opm/core/linalg/SparseMatrix_impl.hpp
+++ b/opm/core/linalg/SparseMatrix_impl.hpp
@@ -1,0 +1,293 @@
+#ifndef OPM_SPARSEMATRIX_IMPL
+#define OPM_SPARSEMATRIX_IMPL
+
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+
+namespace Opm {
+
+    template< typename Scalar >
+    unmanaged::CSR< Scalar >::CSR(
+            std::size_t rows, std::size_t nonzeros,
+            Scalar* values, int* col_ind, int* row_ind ) :
+        rows_( rows ),
+        nonzeros_( nonzeros ),
+        values_( values ),
+        col_ind_( col_ind ),
+        row_ind_( row_ind )
+    {}
+
+    template< typename Scalar >
+    template< typename T, typename Derived >
+    Derived CSR< Scalar >::base_itr< T, Derived >::operator++( int ) {
+        Derived itr( *this );
+        this->operator++();
+        return itr;
+    }
+
+    template< typename Scalar >
+    template< typename T, typename Derived >
+    Derived CSR< Scalar >::base_itr< T, Derived >::operator--( int ) {
+        Derived itr( *this );
+        this->operator--();
+        return itr;
+    }
+
+    template< typename Scalar >
+    template< typename T, typename Derived>
+    bool CSR< Scalar >::base_itr< T, Derived >::operator!=(
+        const Derived& other ) const {
+        return !static_cast< const Derived* >( this )->operator==( other );
+    }
+
+    template< typename Scalar >
+    template< typename T, typename Derived>
+    T* CSR< Scalar >::base_itr< T, Derived >::operator->() {
+        return &this->operator*();
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    CSR< Scalar >::col_itr< T >::col_itr(
+            Scalar* values,
+            int* col_ind,
+            std::size_t index ) :
+        values_( values ),
+        col_ind_( col_ind ),
+        index_( index )
+    {}
+
+    template< typename Scalar >
+    template< typename T >
+    typename CSR< Scalar >::template col_itr< T >&
+    CSR< Scalar >::col_itr< T >::operator++() {
+        ++this->index_;
+        return *this;
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    typename CSR< Scalar >::template col_itr< T >&
+    CSR< Scalar >::col_itr< T >::operator--() {
+        --this->index_;
+        return *this;
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    bool CSR< Scalar >::col_itr< T >::operator==(
+        const CSR< Scalar >::col_itr< T >& other ) const {
+        return this->index_ == other.index_;
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    T& CSR< Scalar >::col_itr< T >::operator*() {
+        return this->values_[ this->index_ ];
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    std::size_t CSR< Scalar >::col_itr< T >::index() const {
+        return this->col_ind_[ this->index_ ];
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    typename CSR< Scalar >::template col_itr< T >
+    CSR< Scalar >::row_ref< T >::begin() {
+        return col_itr< T >(
+                this->values_,
+                this->col_ind_,
+                this->row_ind_[ this->index_ ] );
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    typename CSR< Scalar >::template col_itr< T >
+    CSR< Scalar >::row_ref< T >::end() {
+        const auto offset = this->row_ind_[ this->index_ + 1 ];
+        return col_itr< T >( this->values_, this->col_ind_, offset );
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    T& CSR< Scalar >::row_ref< T >::operator[]( std::size_t x ) {
+        /*
+         * Assumes the matrix coordinate is nonzero - returns result anyways,
+         * but behaviour is undefined if matrix coordinate has an (implicit)
+         * zero.
+         */
+        const auto begin = this->col_ind_ + this->row_ind_[ this->index_ ];
+        const auto end = this->col_ind_ + this->row_ind_[ this->index_ + 1 ];
+
+        const auto target = std::lower_bound( begin, end, x );
+
+        /* for debug builds we check the validity of the returned value
+         * if *target != x then the searched-for matrix coordinate is implicit
+         * zero, i.e. not set in the matrix. this is an error and we won't
+         * guarantee correct results. if this check is necessary during
+         * run-time, use at()
+         */
+        assert( *target == x );
+
+        return this->values_[ std::distance( this->col_ind_, target ) ];
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    const T& CSR< Scalar >::row_ref< T >::operator[]( std::size_t x ) const {
+        return this->operator[]( x );
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    std::size_t CSR< Scalar >::row_ref< T >::index() const {
+        return this->index_;
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    std::size_t CSR< Scalar >::row_ref< T >::size() const {
+        return this->row_ind_[ this->index_ + 1 ] - this->row_ind_[ this->index_ ];
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    CSR< Scalar >::row_ref< T >::row_ref(
+            Scalar* values,
+            int* col_ind,
+            int* row_ind,
+            std::size_t index ) :
+        values_( values ),
+        col_ind_( col_ind ),
+        row_ind_( row_ind ),
+        index_( index )
+    {}
+
+    template< typename Scalar >
+    template< typename T >
+    CSR< Scalar >::row_itr< T >::row_itr(
+            Scalar* values,
+            int* col_ind,
+            int* row_ind,
+            std::size_t index ) :
+        row_ref< T >( values, col_ind, row_ind, index )
+    {}
+
+    template< typename Scalar >
+    template< typename T >
+    typename CSR< Scalar >::template row_itr< T >&
+    CSR< Scalar >::row_itr< T >::operator++() {
+        ++this->index_;
+        return *this;
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    typename CSR< Scalar >::template row_itr< T >&
+    CSR< Scalar >::row_itr< T >::operator--() {
+        --this->index_;
+        return *this;
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    bool CSR< Scalar >::row_itr< T >::operator==(
+        const CSR< Scalar >::row_itr< T >& other ) const {
+        return this->index_ == other.index_;
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    typename CSR< Scalar >::template row_ref< T >&
+    CSR< Scalar >::row_itr< T >::operator*() {
+        return *this;
+    }
+
+    template< typename Scalar >
+    template< typename T >
+    typename CSR< Scalar >::template row_ref< T >*
+    CSR< Scalar >::row_itr< T >::operator->() {
+        return this;
+    }
+
+    /*
+     * Explicitly default-construct (i.e. 0) all fields. This ensures that no
+     * value is ever uninitialized, even in the POD unmanaged::CSR struct
+     */
+    template< typename Scalar >
+    CSR< Scalar >::CSR() : unmanaged( 0, 0, NULL, NULL, NULL ) {}
+
+    template< typename Scalar >
+    CSR< Scalar >::CSR(
+            std::size_t rows, std::size_t nonzero,
+            Scalar* values, int* col_ind, int* row_ind ) :
+        unmanaged( rows, nonzero, values, col_ind, row_ind )
+    {
+        assert( values );
+        assert( col_ind );
+        assert( row_ind );
+    }
+
+    template< typename Scalar >
+    CSR< Scalar >::CSR( CSR< Scalar >&& mv ) :
+        unmanaged( mv.release() )
+    {}
+
+    template< typename Scalar >
+    CSR< Scalar >::~CSR() {
+        if( this->values_ ) delete[] this->values_;
+        if( this->col_ind_ ) delete[] this->col_ind_;
+        if( this->row_ind_ ) delete[] this->row_ind_;
+    }
+
+    template< typename Scalar >
+    typename unmanaged::CSR< Scalar >
+    CSR< Scalar >::get() {
+        return *this;
+    }
+
+    template< typename Scalar >
+    typename unmanaged::CSR< Scalar >
+    CSR< Scalar >::release() {
+        unmanaged x = *this;
+        this->values_ = NULL;
+        this->col_ind_ = this->row_ind_ = NULL;
+        return x;
+    }
+
+    template< typename Storage >
+    SparseMatrix< Storage >&
+    SparseMatrix< Storage >::operator=(
+        SparseMatrix< Storage >&& mv ) {
+
+        this->rows_ = mv.rows_;
+        this->nonzeros_ = mv.nonzeros_;
+        this->values_ = mv.values_;
+        this->col_ind_ = mv.col_ind_;
+        this->row_ind_ = mv.row_ind_;
+
+        mv.release();
+        return *this;
+    }
+
+    template< typename Storage >
+    Storage& SparseMatrix< Storage >::unsafe() {
+        return *this;
+    }
+
+    template< typename Scalar, typename Storage >
+    void SparseMatrixBuilder< Scalar, Storage >::add( std::size_t i, std::size_t j, Scalar val ) {
+        this->insert( std::make_pair( CO{ i, j }, val ) );
+    }
+
+    template< typename Scalar, typename Storage >
+    template< typename Return >
+    SparseMatrix< Return > SparseMatrixBuilder< Scalar, Storage >::convert() {
+        return conv< Scalar, Storage, Return >::convert( this );
+    }
+}
+
+#endif //OPM_SPARSEMATRIX_IMPL

--- a/opm/core/linalg/SparseMatrix_impl.hpp
+++ b/opm/core/linalg/SparseMatrix_impl.hpp
@@ -290,4 +290,6 @@ namespace Opm {
     }
 }
 
+#include "SparseMatrix_csr.hpp"
+
 #endif //OPM_SPARSEMATRIX_IMPL

--- a/opm/core/linalg/SparseMatrix_impl.hpp
+++ b/opm/core/linalg/SparseMatrix_impl.hpp
@@ -291,5 +291,6 @@ namespace Opm {
 }
 
 #include "SparseMatrix_csr.hpp"
+#include "SparseMatrix_dune.hpp"
 
 #endif //OPM_SPARSEMATRIX_IMPL

--- a/tests/test_sparsematrix.cpp
+++ b/tests/test_sparsematrix.cpp
@@ -73,6 +73,8 @@ static void coverage() {
      */
 
     test_coverage< Opm::CSR< double > >();
+    test_coverage< Dune::BCRSMatrix< Dune::FieldMatrix< double, 1, 1 > > >();
+    test_coverage< Dune::BCRSMatrix< Dune::FieldMatrix< double, 2, 2 > > >();
 }
 
 BOOST_AUTO_TEST_CASE(test_interface) {
@@ -108,6 +110,7 @@ BOOST_AUTO_TEST_CASE(test_builder_sparse) {
     builder.add( 4, 3, 2.0 );
 
     auto csr = builder.convert< Opm::CSR< double > >();
+    auto csr1 = builder.convert< Dune::BCRSMatrix< Dune::FieldMatrix< double, 1, 1 > > >();
 
     BOOST_CHECK( csr.rows() == 5 );
     BOOST_CHECK( csr.nonzeros() == 4 );

--- a/tests/test_sparsematrix.cpp
+++ b/tests/test_sparsematrix.cpp
@@ -1,0 +1,123 @@
+#include <config.h>
+
+#include <opm/core/linalg/SparseMatrix.hpp>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+#define BOOST_TEST_MODULE MatrixTest
+#define BOOST_TEST_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+template< typename S >
+static void test_public_types() {
+    typename Opm::SparseMatrix< S >::scalar scalar;
+    typename Opm::SparseMatrix< S >::type type;
+    typename Opm::SparseMatrix< S >::size_type size_type;
+    typename Opm::SparseMatrix< S >::unmanaged unmanaged;
+    typename Opm::SparseMatrix< S >::iterator iterator;
+    typename Opm::SparseMatrix< S >::const_iterator const_iterator;
+    typename Opm::SparseMatrix< S >::row_ref row_ref;
+    typename Opm::SparseMatrix< S >::const_row_ref const_row_ref;
+
+    /*
+     * Ignore "unused variable" warnings
+     */
+    (void) scalar;
+    (void) type;
+    (void) size_type;
+    (void) unmanaged;
+    (void) iterator;
+    (void) const_iterator;
+    (void) row_ref;
+    (void) const_row_ref;
+}
+
+template< typename S >
+static void test_constructors() {
+    Opm::SparseMatrix< S > def;
+}
+
+template< typename S >
+static void test_methods() {
+    Opm::SparseMatrixBuilder< double > builder;
+    builder.add( 0, 0, 1.0 );
+
+    auto matrix = builder.convert< S >();
+
+    matrix.exists( 0, 0 );
+    matrix[ 0 ];
+    matrix[ 0 ][ 0 ];
+
+    matrix.begin();
+    matrix.end();
+
+    matrix.rows();
+    matrix.cols();
+    matrix.nonzeros();
+}
+
+template< typename S >
+static void test_coverage() {
+    test_public_types< S >();
+    test_constructors< S >();
+    test_methods< S >();
+}
+
+static void coverage() {
+    /* A test to see if the SparseMatrix implementations have implemented all
+     * required methods. Add a test_coverage< Storage_type >() and this test
+     * will fail to compile if something is missing. Does not test for
+     * correctness.
+     */
+
+    test_coverage< Opm::CSR< double > >();
+}
+
+BOOST_AUTO_TEST_CASE(test_interface) {
+    coverage();
+}
+
+BOOST_AUTO_TEST_CASE(test_builder_add) {
+
+    Opm::SparseMatrixBuilder< double > builder;
+
+    for( auto i = 0; i < 5; ++i ) {
+        for( int j = 0; j < 5; ++j ) 
+            builder.add( i, j, 1.0 * i + j );
+    }
+
+    auto csr = builder.convert< Opm::CSR< double > >();
+
+    BOOST_CHECK( csr.rows() == 5 );
+    BOOST_CHECK( csr.nonzeros() == 5 * 5 );
+
+    BOOST_CHECK( csr[ 0 ][ 0 ] == 0.0 );
+    BOOST_CHECK( csr[ 0 ][ 1 ] == 1.0 );
+    BOOST_CHECK( csr[ 2 ][ 1 ] == 3.0 );
+}
+
+BOOST_AUTO_TEST_CASE(test_builder_sparse) {
+
+    Opm::SparseMatrixBuilder< double > builder;
+
+    builder.add( 1, 4, 1.0 );
+    builder.add( 0, 2, 3.0 );
+    builder.add( 2, 1, 5.0 );
+    builder.add( 4, 3, 2.0 );
+
+    auto csr = builder.convert< Opm::CSR< double > >();
+
+    BOOST_CHECK( csr.rows() == 5 );
+    BOOST_CHECK( csr.nonzeros() == 4 );
+
+    BOOST_CHECK( csr[ 1 ][ 4 ] == 1.0 );
+    BOOST_CHECK( csr[ 0 ][ 2 ] == 3.0 );
+    BOOST_CHECK( csr[ 2 ][ 1 ] == 5.0 );
+    BOOST_CHECK( csr[ 4 ][ 3 ] == 2.0 );
+
+    BOOST_CHECK( !csr.exists( 0, 0 ) );
+    BOOST_CHECK( csr.exists( 1, 4 ) );
+}
+


### PR DESCRIPTION
More details are found in the commit messages and source file comments, but a short summary:

These three patches implement support for a unified linear solver interface for programmers. For most cases they should act as thin wrappers to whatever native type want, with the option of quickly replacing said native type at a later stage (if that type is supported).

The first patch commits the interface itself, the second and third implements the CSR reference implementation and Dune BCRS respectively.

In addition this introduces the similar `SparseMatrixBuilder`. A lot of linear solver libraries use the same class and type for matrices in the building phase and matrices that are "ready" and fixed. My proposal is that these processes are to be separated explicitly so we don't have to juggle state and sometimes-legal-operations. Safer & nicer code.

This is a part of the process to support multiple linear solvers backends in OPM. The idea is that `LinearSolverInterface` and friends later can be aware of these interfaces and give them to their algorithms as desired.

I have done as much as I can to abstract away all nastiness from user-facing code, although the files themselves are quite daunting. Most of the complexity comes from trying to be both type safe, flexible and easy to use at once.

In user code it is as simple as:

``` C++
SparseMatrix< CSR< double > /* or some other type */ > matrix;
matrix[ i ][ j ] *= 2;
```

The use of `auto` should make it even more pleasant to use.

The implementation itself is not quite yet complete - a few things must still be figured out, such as `Dune::BCRSMatrix` as storage for `MatrixBuilder` and move semantics, but most of the implementation should be ok for experimental use.

I tested this implementation  with benchmark-upscale-relperm and it is not measurably different to use the generic `SparseMatrix` container as opposed to the Dune container directly.
