### PR TITLE
FindAlugrid.cmake: do not try to include the whole grid

### DIFF
--- a/cmake/Modules/Finddune-alugrid.cmake
+++ b/cmake/Modules/Finddune-alugrid.cmake
@@ -34,10 +34,8 @@ find_opm_package (
   ""
 
   # test program
-"#include <dune/alugrid/grid.hh>
+"#include <dune/alugrid/2d/indexsets.hh>
 int main (void) {
-   Dune::ALUGrid</*dim=*/2, /*dimWorld=*/2, Dune::simplex, Dune::nonconforming> grid;
-   grid.leafGridView().size(/*codim=*/0);
    return 0;
 }
 "


### PR DESCRIPTION
first this makes the test very slow, second (and more importantly) it
makes the test fail on dune master as the header relies on the
presence of the DUNE_GRID_VERSION* macros which are not present at the
configure stage of the build...