### PR TITLE
Finddune-grid.cmake: always enable the experimental grid extensions

### DIFF
--- a/cmake/Modules/Finddune-grid.cmake
+++ b/cmake/Modules/Finddune-grid.cmake
@@ -11,6 +11,9 @@
 # This code is licensed under The GNU General Public License v3.0
 
 include (OpmPackage)
+
+set(DUNE_GRID_EXPERIMENTAL_GRID_EXTENSIONS 1)
+
 find_opm_package (
   # module name
   "dune-grid"
@@ -52,7 +55,8 @@ int main (void) {
    HAVE_PSURFACE;
    HAVE_AMIRAMESH;
    HAVE_ALBERTA;
-   HAVE_STDINT_H
+   HAVE_STDINT_H;
+   DUNE_GRID_EXPERIMENTAL_GRID_EXTENSIONS
   ")
 
 #debug_find_vars ("dune-grid")


### PR DESCRIPTION
this is now done by a config.h macro. The reason is that quite a bit
of code depends on boundary IDs which are only available as an
"experimental" grid extension in recent Dune releases...
