### PR TITLE
build system: do not separate the debugging symbols by default

### DIFF
--- a/cmake/Modules/OpmCompile.cmake
+++ b/cmake/Modules/OpmCompile.cmake
@@ -1,5 +1,7 @@
 # - Compile main library target
 
+option (STRIP_DEBUGGING_SYMBOLS "use separate files for the executable code and the debugging symbols" OFF)
+
 macro (opm_compile opm)
   # some CMake properties do not do list expansion
   string (REPLACE ";" " " ${opm}_LINKER_FLAGS_STR "${${opm}_LINKER_FLAGS}")
@@ -28,8 +30,10 @@ macro (opm_compile opm)
 	  )
 	target_link_libraries (${${opm}_TARGET} ${${opm}_LIBRARIES})
 
-	# queue this executable to be stripped
-	strip_debug_symbols (${${opm}_TARGET} ${opm}_DEBUG)
+        if (STRIP_DEBUGGING_SYMBOLS)
+	  # queue this executable to be stripped
+	  strip_debug_symbols (${${opm}_TARGET} ${opm}_DEBUG)
+        endif()
   else (${opm}_SOURCES)
 	# unset this variable to signal that no library is generated
 	set (${opm}_TARGET)

--- a/cmake/Modules/OpmSatellites.cmake
+++ b/cmake/Modules/OpmSatellites.cmake
@@ -70,8 +70,10 @@ macro (opm_compile_satellites opm satellite excl_all test_regexp)
 	  set (_test_lib "")
 	endif (NOT "${test_regexp}" STREQUAL "")
 	target_link_libraries (${_sat_NAME} ${${opm}_TARGET} ${${opm}_LIBRARIES} ${_test_lib})
-	strip_debug_symbols (${_sat_NAME} _sat_DEBUG)
-	list (APPEND ${satellite}_DEBUG ${_sat_DEBUG})
+        if (STRIP_DEBUGGING_SYMBOLS)
+	  strip_debug_symbols (${_sat_NAME} _sat_DEBUG)
+	  list (APPEND ${satellite}_DEBUG ${_sat_DEBUG})
+        endif()
 
 	# variable with regular expression doubles as a flag for
 	# whether tests should be setup or not

--- a/cmake/Modules/UseDebugSymbols.cmake
+++ b/cmake/Modules/UseDebugSymbols.cmake
@@ -18,12 +18,10 @@ if (CXX_COMPAT_GCC)
   # default debug level, if not specified by the user
   set_default_option (CXX _dbg_flag "-ggdb3" "(^|\ )-g")
 
-  # add debug symbols to *all* targets, regardless. there WILL come a
-  # time when you need to find a bug which only manifests itself in a
-  # release target on a production system!
+  # add debug symbols to *all* targets if the build mode is either "Debug" or "RelWithDebInfo"
   if (_dbg_flag)
 	message (STATUS "Generating debug symbols: ${_dbg_flag}")
-	add_options (ALL_LANGUAGES ALL_BUILDS "${_dbg_flag}")
+	add_options (ALL_LANGUAGES "Debug;RelWithDebInfo" "${_dbg_flag}")
   endif (_dbg_flag)
 
   # extracting the debug info is done by a separate utility in the GNU

--- a/cmake/Scripts/configure
+++ b/cmake/Scripts/configure
@@ -21,6 +21,7 @@ Optional Features:
                           [default=no]
   --disable-runpath       do not use RUNPATH in installed library [default=yes]
   --enable-lto            use whole program optimization [default=no]
+  --enable-strip-debug    separate the executable code and the debugging symbols [default=no]
   --disable-tests         do not compile and enable unit tests [default=yes]
   --disable-examples      do not compile example programs [default=yes]
   --disable-pch           do not use precompiled headers (if buggy compiler)
@@ -123,6 +124,8 @@ silent_rules=
 debug_loc=
 #use_lto=" -DWHOLE_PROG_OPTIM=OFF"
 use_lto=
+#strip_debug=" -DSTRIP_DEBUGGING_SYMBOLS=OFF"
+strip_debug=
 #use_runpath=" -DUSE_RUNPATH=OFF"
 use_runpath=
 #use_tests=" -DBUILD_TESTING=ON"
@@ -314,6 +317,10 @@ for OPT in "$@"; do
               use_lto=" -DWHOLE_PROG_OPTIM=OFF"
               pkgname=""
               ;;
+            strip-debug  )
+              strip_debug=" -DSTRIP_DEBUGGING_SYMBOLS=OFF"
+              pkgname=""
+              ;;
             openmp)
               use_openmp=" -DUSE_OPENMP=OFF"
               pkgname=""
@@ -396,6 +403,10 @@ for OPT in "$@"; do
             lto)
               use_lto=" -DWHOLE_PROG_OPTIM=ON"
               shared=""
+              ;;
+            strip-debug  )
+              strip_debug=" -DSTRIP_DEBUGGING_SYMBOLS=ON"
+              pkgname=""
               ;;
             tests)
               use_tests=" -DBUILD_TESTING=ON"
@@ -534,7 +545,7 @@ elif test "$c_compiler$c_opts$cxx_compiler$cxx_opts$fort_compiler$fort_opts" != 
 fi
 
 # pass everything on to CMake
-CMDLINE="${ENVVARS}${CMAKE_COMMAND} \"${srcdir}\" ${use_ninja}\"-DCMAKE_INSTALL_PREFIX=$prefix\"${buildtype}${pch_use}${silent_rules}${debug_loc}${use_openmp}${use_mpi}${use_lto}${use_runpath}${use_tests}${use_samples}${use_underscoring}${c_compiler}${c_opts}${cxx_compiler}${cxx_opts}${fort_compiler}${fort_opts}${boost_opts}${buildname}${site} ${FEATURES}"
+CMDLINE="${ENVVARS}${CMAKE_COMMAND} \"${srcdir}\" ${use_ninja}\"-DCMAKE_INSTALL_PREFIX=$prefix\"${buildtype}${pch_use}${silent_rules}${debug_loc}${use_openmp}${use_mpi}${use_lto}${strip_debug}${use_runpath}${use_tests}${use_samples}${use_underscoring}${c_compiler}${c_opts}${cxx_compiler}${cxx_opts}${fort_compiler}${fort_opts}${boost_opts}${buildname}${site} ${FEATURES}"
 echo --- calling CMake ---
 echo "${CMDLINE}"
 eval exec "${CMDLINE}"

--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,7 @@ override_dh_auto_build:
 
 # consider using -DUSE_VERSIONED_DIR=ON if backporting
 override_dh_auto_configure:
-	dh_auto_configure --buildsystem=cmake -- -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_DOCDIR=share/doc/libopm-core1 -DWHOLE_PROG_OPTIM=ON -DUSE_RUNPATH=OFF
+	dh_auto_configure --buildsystem=cmake -- -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSTRIP_DEBUGGING_SYMBOLS=ON -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_DOCDIR=share/doc/libopm-core1 -DWHOLE_PROG_OPTIM=ON -DUSE_RUNPATH=OFF
 
 override_dh_auto_install:
 	dh_auto_install -- install-html

--- a/redhat/opm-core.spec
+++ b/redhat/opm-core.spec
@@ -81,7 +81,7 @@ This package contains the debug symbols for opm-core
 
 # consider using -DUSE_VERSIONED_DIR=ON if backporting
 %build
-cmake28 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{_prefix} -DCMAKE_INSTALL_DOCDIR=share/doc/%{name}-%{version} -DUSE_RUNPATH=OFF %{?el5:-DCMAKE_CXX_COMPILER=g++44 -DCMAKE_C_COMPILER=gcc44 -DBOOST_LIBRARYDIR=%{_libdir}/boost141 -DBOOST_INCLUDEDIR=/usr/include/boost141}
+cmake28 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo  -DSTRIP_DEBUGGING_SYMBOLS=ON -DCMAKE_INSTALL_PREFIX=%{_prefix} -DCMAKE_INSTALL_DOCDIR=share/doc/%{name}-%{version} -DUSE_RUNPATH=OFF %{?el5:-DCMAKE_CXX_COMPILER=g++44 -DCMAKE_C_COMPILER=gcc44 -DBOOST_LIBRARYDIR=%{_libdir}/boost141 -DBOOST_INCLUDEDIR=/usr/include/boost141}
 make
 
 %install


### PR DESCRIPTION
the reason is that the tools for profiling and for coverage analysis
(i.e., gprof and gcov) have trouble with this and crash. if you want
this to be enabled for whatever reason, use the cmake flag
-DSTRIP_DEBUGGING_SYMBOLS=ON or pass configure the
--enable-strip-debug option.
