### PR TITLE
Add support for stopped wells

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -191,6 +191,7 @@ list (APPEND TEST_SOURCE_FILES
 	tests/test_minpvprocessor.cpp
 	tests/test_gridutilities.cpp
 	tests/test_anisotropiceikonal.cpp
+	tests/test_stoppedwells.cpp
   )
 
 # originally generated with the command:
@@ -219,9 +220,10 @@ list (APPEND TEST_DATA_FILES
 	tests/wells_manager_data.data
 	tests/wells_manager_data_expanded.data
 	tests/wells_manager_data_wellSTOP.data
-	tests/wells_group.data
-	tests/TESTTIMER.DATA
+        tests/wells_group.data
+        tests/TESTTIMER.DATA
         tests/CORNERPOINT_ACTNUM.DATA
+        tests/wells_stopped.data
 	)
 
 # originally generated with the command:

--- a/opm/core/pressure/tpfa/cfs_tpfa_residual.c
+++ b/opm/core/pressure/tpfa/cfs_tpfa_residual.c
@@ -869,7 +869,7 @@ assemble_completion_to_well(int i, int w, int c, int nc, int np,
     W    = wells->W;
     ctrl = W->ctrls[ w ];
 
-    if (well_controls_well_is_shut( ctrl )) {
+    if (well_controls_well_is_stopped( ctrl )) {
         /* Interpreting a negative current control index to mean a shut well */
         welleq_coeff_shut(np, h, &res, &w2c, &w2w);
     }

--- a/opm/core/pressure/tpfa/cfs_tpfa_residual.c
+++ b/opm/core/pressure/tpfa/cfs_tpfa_residual.c
@@ -870,7 +870,7 @@ assemble_completion_to_well(int i, int w, int c, int nc, int np,
     ctrl = W->ctrls[ w ];
 
     if (well_controls_well_is_stopped( ctrl )) {
-        /* Interpreting a negative current control index to mean a shut well */
+        fprintf(stderr, "Stopped well detected: will be treated as completely shut\n");
         welleq_coeff_shut(np, h, &res, &w2c, &w2w);
     }
     else {

--- a/opm/core/pressure/tpfa/ifs_tpfa.c
+++ b/opm/core/pressure/tpfa/ifs_tpfa.c
@@ -363,7 +363,7 @@ assemble_well_contrib(int                   nc ,
     for (w = 0; w < W->number_of_wells; w++) {
         ctrls = W->ctrls[ w ];
 
-        if (well_controls_well_is_shut(ctrls) ) {
+        if (well_controls_well_is_stopped(ctrls) ) {
 
             /* Treat this well as a shut well, isolated from the domain. */
 

--- a/opm/core/pressure/tpfa/ifs_tpfa.c
+++ b/opm/core/pressure/tpfa/ifs_tpfa.c
@@ -364,9 +364,8 @@ assemble_well_contrib(int                   nc ,
         ctrls = W->ctrls[ w ];
 
         if (well_controls_well_is_stopped(ctrls) ) {
-
+            fprintf(stderr, "Stopped well detected: will be treated as completely shut\n");
             /* Treat this well as a shut well, isolated from the domain. */
-
             assemble_shut_well(nc, w, W, mt, h);
 
         } else {

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -49,7 +49,7 @@ namespace Opm
                 for (int w = 0; w < nw; ++w) {
                     assert((wells->type[w] == INJECTOR) || (wells->type[w] == PRODUCER));
                     const WellControls* ctrl = wells->ctrls[w];
-                    if (well_controls_well_is_shut(ctrl)) {
+                    if (well_controls_well_is_stopped(ctrl)) {
                         // Shut well:
                         // 1. Assign zero well rates.
                         for (int p = 0; p < np; ++p) {

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -50,7 +50,7 @@ namespace Opm
                     assert((wells->type[w] == INJECTOR) || (wells->type[w] == PRODUCER));
                     const WellControls* ctrl = wells->ctrls[w];
                     if (well_controls_well_is_stopped(ctrl)) {
-                        // Shut well:
+                        // Stopped well:
                         // 1. Assign zero well rates.
                         for (int p = 0; p < np; ++p) {
                             wellrates_[np*w + p] = 0.0;

--- a/opm/core/well_controls.h
+++ b/opm/core/well_controls.h
@@ -70,7 +70,7 @@ well_controls_set_current( struct WellControls * ctrl, int current);
 
 
 bool 
-well_controls_well_is_shut(const struct WellControls * ctrl);
+well_controls_well_is_stopped(const struct WellControls * ctrl);
 
 bool 
 well_controls_well_is_open(const struct WellControls * ctrl);
@@ -79,7 +79,7 @@ void
 well_controls_open_well( struct WellControls * ctrl);
 
 void 
-well_controls_shut_well( struct WellControls * ctrl);
+well_controls_stop_well( struct WellControls * ctrl);
 
 int
 well_controls_add_new(enum WellControlType type , double target , const double * distr , struct WellControls * ctrl);

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -747,7 +747,7 @@ namespace Opm
     void WellNode::shutWell()
     {
         if (shut_well_) {
-            well_controls_shut_well( wells_->ctrls[self_index_]);
+            well_controls_stop_well( wells_->ctrls[self_index_]);
         }
         else {
             const double target = 0.0;

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -412,8 +412,9 @@ namespace Opm
         for (auto wellIter= wells.begin(); wellIter != wells.end(); ++wellIter) {
             WellConstPtr well = (*wellIter);
 
-            if ( !( well->getStatus( timeStep ) == WellCommon::SHUT || well->getStatus( timeStep ) == WellCommon::OPEN) ) {
-                OPM_THROW(std::runtime_error, "Currently we do not support well status " << WellCommon::Status2String(well->getStatus( timeStep )));
+            if (well->getStatus(timeStep) == WellCommon::STOP) {
+                // STOPed wells are added to the well list with the given controll and closed.
+                well_controls_shut_well(w_->ctrls[well_index]);
             }
 
             if (well->getStatus(timeStep) == WellCommon::SHUT) {

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -414,7 +414,7 @@ namespace Opm
 
             if (well->getStatus(timeStep) == WellCommon::STOP) {
                 // STOPed wells are added to the well list with the given controll and closed.
-                well_controls_shut_well(w_->ctrls[well_index]);
+                well_controls_stop_well(w_->ctrls[well_index]);
             }
 
             if (well->getStatus(timeStep) == WellCommon::SHUT) {

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -413,7 +413,7 @@ namespace Opm
             WellConstPtr well = (*wellIter);
 
             if (well->getStatus(timeStep) == WellCommon::STOP) {
-                // STOPed wells are added to the well list with the given controll and closed.
+                // STOPed wells are kept in the well list but marked as stopped.
                 well_controls_stop_well(w_->ctrls[well_index]);
             }
 

--- a/opm/core/wells/well_controls.c
+++ b/opm/core/wells/well_controls.c
@@ -228,7 +228,7 @@ well_controls_clone(const struct WellControls *ctrl)
                     well_controls_open_well(new);
                 }
                 else {
-                    well_controls_shut_well(new);
+                    well_controls_stop_well(new);
                 }
             }
         }
@@ -254,7 +254,7 @@ well_controls_set_current( struct WellControls * ctrl, int current) {
     ctrl->current = current;
 }
 
-bool well_controls_well_is_shut(const struct WellControls * ctrl) {
+bool well_controls_well_is_stopped(const struct WellControls * ctrl) {
     return !ctrl->well_is_open;
 }
 
@@ -266,7 +266,7 @@ void well_controls_open_well( struct WellControls * ctrl) {
     ctrl->well_is_open = true;
 }
 
-void well_controls_shut_well( struct WellControls * ctrl) {
+void well_controls_stop_well( struct WellControls * ctrl) {
     ctrl->well_is_open = false;
 }
 

--- a/tests/test_stoppedwells.cpp
+++ b/tests/test_stoppedwells.cpp
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(TestStoppedWells)
     const Wells* wells = wellsManager.c_wells();
     const struct WellControls* ctrls0 = wells->ctrls[0];
     const struct WellControls* ctrls1 = wells->ctrls[1];
-    BOOST_CHECK(well_controls_well_is_shut(ctrls0)); // injector is stopped
+    BOOST_CHECK(well_controls_well_is_stopped(ctrls0)); // injector is stopped
     BOOST_CHECK(well_controls_well_is_open(ctrls1));
 
     WellState wellstate;

--- a/tests/test_stoppedwells.cpp
+++ b/tests/test_stoppedwells.cpp
@@ -1,0 +1,95 @@
+/*
+  Copyright 2014 IRIS
+  
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define BOOST_TEST_MODULE StoppedWellsTests
+#include <boost/test/unit_test.hpp>
+
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+
+#include <opm/core/wells/WellsManager.hpp>
+#include <opm/core/wells.h>
+#include <opm/core/well_controls.h>
+#include <opm/core/simulator/BlackoilState.hpp>
+#include <opm/core/simulator/WellState.hpp>
+#include <opm/core/grid/GridManager.hpp>
+
+
+using namespace Opm;
+
+BOOST_AUTO_TEST_CASE(TestStoppedWells)
+{
+    const std::string filename = "wells_stopped.data";
+    Opm::ParserPtr parser(new Opm::Parser());
+    Opm::DeckConstPtr deck(parser->parseFile(filename));
+
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck));
+    Opm::GridManager gridManager(deck);
+
+    double target_surfacerate_inj;
+    double target_surfacerate_prod;
+
+    BlackoilState state;
+    const std::vector<double> pressure = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+    state.pressure() = pressure;
+
+    // Both wells are open in the first schedule step
+    {
+    Opm::WellsManager wellsManager(eclipseState , 0 , *gridManager.c_grid(), NULL);
+    const Wells* wells = wellsManager.c_wells();
+    const struct WellControls* ctrls0 = wells->ctrls[0];
+    const struct WellControls* ctrls1 = wells->ctrls[1];
+    BOOST_CHECK(well_controls_well_is_open(ctrls0));
+    BOOST_CHECK(well_controls_well_is_open(ctrls1));
+
+    target_surfacerate_inj = well_controls_iget_target(ctrls0 , 0);
+    target_surfacerate_prod = well_controls_iget_target(ctrls1 , 0);
+
+    WellState wellstate;
+    wellstate.init(wells, state);
+    const std::vector<double> wellrates = wellstate.wellRates();
+    BOOST_CHECK_EQUAL (target_surfacerate_inj, wellrates[2]); // Gas injector
+    BOOST_CHECK_EQUAL (target_surfacerate_prod, wellrates[4]); // Oil target rate
+    }
+
+
+    // The injector is stopped
+    {
+    Opm::WellsManager wellsManager(eclipseState , 1 , *gridManager.c_grid(), NULL);
+    const Wells* wells = wellsManager.c_wells();
+    const struct WellControls* ctrls0 = wells->ctrls[0];
+    const struct WellControls* ctrls1 = wells->ctrls[1];
+    BOOST_CHECK(well_controls_well_is_shut(ctrls0)); // injector is stopped
+    BOOST_CHECK(well_controls_well_is_open(ctrls1));
+
+    WellState wellstate;
+    wellstate.init(wells, state);
+
+    const std::vector<double> wellrates = wellstate.wellRates();
+    BOOST_CHECK_EQUAL (0, wellrates[2]); // Gas injector
+    BOOST_CHECK_EQUAL (target_surfacerate_prod, wellrates[4]); // Oil target rate
+    }
+
+}

--- a/tests/test_wellcontrols.cpp
+++ b/tests/test_wellcontrols.cpp
@@ -103,15 +103,15 @@ BOOST_AUTO_TEST_CASE(OpenClose)
     struct WellControls * ctrls = well_controls_create();
 
     BOOST_CHECK_EQUAL( true , well_controls_well_is_open(ctrls) );
-    BOOST_CHECK_EQUAL( false , well_controls_well_is_shut(ctrls) );
+    BOOST_CHECK_EQUAL( false , well_controls_well_is_stopped(ctrls) );
 
     well_controls_open_well( ctrls );
     BOOST_CHECK_EQUAL( true   , well_controls_well_is_open(ctrls) );
-    BOOST_CHECK_EQUAL( false  , well_controls_well_is_shut(ctrls) );
+    BOOST_CHECK_EQUAL( false  , well_controls_well_is_stopped(ctrls) );
 
-    well_controls_shut_well( ctrls );
+    well_controls_stop_well( ctrls );
     BOOST_CHECK_EQUAL( false   , well_controls_well_is_open(ctrls) );
-    BOOST_CHECK_EQUAL( true    , well_controls_well_is_shut(ctrls) );
+    BOOST_CHECK_EQUAL( true    , well_controls_well_is_stopped(ctrls) );
     
     well_controls_destroy( ctrls );
 }

--- a/tests/test_wellsmanager.cpp
+++ b/tests/test_wellsmanager.cpp
@@ -280,7 +280,7 @@ BOOST_AUTO_TEST_CASE(WellShutOK) {
 
 
 
-BOOST_AUTO_TEST_CASE(WellHasSTOP_ExceptionIsThrown) {
+BOOST_AUTO_TEST_CASE(WellSTOPOK) {
     const std::string filename = "wells_manager_data_wellSTOP.data";
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck(parser->parseFile(filename));
@@ -288,5 +288,12 @@ BOOST_AUTO_TEST_CASE(WellHasSTOP_ExceptionIsThrown) {
     Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck));
     Opm::GridManager gridManager(deck);
 
-    BOOST_CHECK_THROW( new Opm::WellsManager(eclipseState, 0, *gridManager.c_grid(), NULL), std::runtime_error );
+    Opm::WellsManager wellsManager(eclipseState , 0 , *gridManager.c_grid(), NULL);
+
+    const Wells* wells = wellsManager.c_wells();
+    const struct WellControls* ctrls0 = wells->ctrls[0];
+    const struct WellControls* ctrls1 = wells->ctrls[1];
+
+    BOOST_CHECK(well_controls_well_is_shut(ctrls0)); // The first well is closed
+    BOOST_CHECK(well_controls_well_is_open(ctrls1));  // The second well is open
 }

--- a/tests/test_wellsmanager.cpp
+++ b/tests/test_wellsmanager.cpp
@@ -294,6 +294,6 @@ BOOST_AUTO_TEST_CASE(WellSTOPOK) {
     const struct WellControls* ctrls0 = wells->ctrls[0];
     const struct WellControls* ctrls1 = wells->ctrls[1];
 
-    BOOST_CHECK(well_controls_well_is_shut(ctrls0)); // The first well is closed
+    BOOST_CHECK(well_controls_well_is_stopped(ctrls0)); // The first well is closed
     BOOST_CHECK(well_controls_well_is_open(ctrls1));  // The second well is open
 }

--- a/tests/wells_manager_data_wellSTOP.data
+++ b/tests/wells_manager_data_wellSTOP.data
@@ -34,6 +34,15 @@ COMPDAT
     'PROD1'  10 3 3  3 'OPEN' 0   10.6092   0.5  /
 /
 
+WCONPROD
+     'PROD1' 'OPEN' 'ORAT' 20000  4* 1000 /
+/
+
+WCONINJE
+     'INJ1' 'GAS' 'OPEN' 'RATE' 100 200 400 /
+/
+
+
 WELOPEN
    'INJ1' 'STOP' 5* /
 /

--- a/tests/wells_stopped.data
+++ b/tests/wells_stopped.data
@@ -1,0 +1,58 @@
+RUNSPEC
+
+OIL
+GAS
+WATER
+
+
+DIMENS
+   10 10  1  /
+
+GRID
+
+DXV
+10*1000.0
+/
+
+DYV
+10*1000.0
+/
+
+DZ
+100*20.0 
+/
+
+TOPS
+100*10
+/
+
+
+SCHEDULE
+
+WELSPECS
+    'INJ1' 'G'    1  1    8335 'GAS'  /
+    'PROD1' 'G'   10 10    8400 'OIL'  /
+/
+
+COMPDAT
+    'INJ1'   1  1 1  1 'OPEN' 1   10.6092   0.5  /
+    'PROD1'  10 1 1  1 'OPEN' 0   10.6092   0.5  /
+/
+
+WCONPROD
+     'PROD1' 'OPEN' 'ORAT' 20000  4* 1000 /
+/
+
+WCONINJE
+     'INJ1' 'GAS' 'OPEN' 'RATE' 100 200 400 /
+/
+
+
+TSTEP
+  1 /
+
+WELOPEN
+   'INJ1' 'STOP' 5* /
+/
+
+END


### PR DESCRIPTION
With this PR the simulator distinguish between OPEN, STOP and SHUT wells. 
STOP: Well stopped off above the formation. The total rate is set to zero.  I.e. It allows for flow in the well.
SHUT: Well completely isolated from the formation. The well is removed
from the well list. 

This PR also contain a test case that check that the well rate is zero.

This is the last peace that is needed in order to run the full Norne deck. The results do not match satisfactory yet. 
