### PR TITLE
Introduce interface for SimulatorTimers and support writing of substeps with EclipseWriter.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -367,6 +367,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/simulator/SimulatorOutput.hpp
 	opm/core/simulator/SimulatorReport.hpp
 	opm/core/simulator/SimulatorState.hpp
+	opm/core/simulator/SimulatorTimerInterface.hpp
 	opm/core/simulator/SimulatorTimer.hpp
 	opm/core/simulator/TimeStepControlInterface.hpp
 	opm/core/simulator/TwophaseState.hpp

--- a/opm/core/io/OutputWriter.cpp
+++ b/opm/core/io/OutputWriter.cpp
@@ -26,26 +26,17 @@ struct MultiWriter : public OutputWriter {
     MultiWriter (ptr_t writers) : writers_ (std::move (writers)) { }
 
     /// Forward the call to all writers
-    virtual void writeInit(const SimulatorTimer &timer) {
+    virtual void writeInit(const SimulatorTimerInterface &timer) {
         for (it_t it = writers_->begin (); it != writers_->end (); ++it) {
             (*it)->writeInit (timer);
         }
     }
 
-    virtual void writeTimeStep(const SimulatorTimer& timer,
-                                 const SimulatorState& reservoirState,
-                                 const WellState& wellState) {
-        for (it_t it = writers_->begin (); it != writers_->end(); ++it) {
-            (*it)->writeTimeStep (timer, reservoirState, wellState);
-        }
-    }
-
-    virtual void writeTimeStep(const SimulatorTimer& timer,
-                               const AdaptiveSimulatorTimer& substepTimer,
+    virtual void writeTimeStep(const SimulatorTimerInterface& timer,
                                const SimulatorState& reservoirState,
                                const WellState& wellState) {
         for (it_t it = writers_->begin (); it != writers_->end(); ++it) {
-            (*it)->writeTimeStep (timer, substepTimer, reservoirState, wellState);
+            (*it)->writeTimeStep (timer, reservoirState, wellState);
         }
     }
 

--- a/opm/core/io/OutputWriter.cpp
+++ b/opm/core/io/OutputWriter.cpp
@@ -40,6 +40,15 @@ struct MultiWriter : public OutputWriter {
         }
     }
 
+    virtual void writeTimeStep(const SimulatorTimer& timer,
+                               const AdaptiveSimulatorTimer& substepTimer,
+                               const SimulatorState& reservoirState,
+                               const WellState& wellState) {
+        for (it_t it = writers_->begin (); it != writers_->end(); ++it) {
+            (*it)->writeTimeStep (timer, substepTimer, reservoirState, wellState);
+        }
+    }
+
 private:
     ptr_t writers_;
 };

--- a/opm/core/io/OutputWriter.hpp
+++ b/opm/core/io/OutputWriter.hpp
@@ -21,6 +21,7 @@
 #define OPM_OUTPUT_WRITER_HPP
 
 #include <memory>  // unique_ptr, shared_ptr
+#include <opm/core/simulator/SimulatorTimerInterface.hpp>
 
 struct UnstructuredGrid;
 
@@ -30,8 +31,6 @@ namespace Opm {
 class EclipseState;
 namespace parameter { class ParameterGroup; }
 class SimulatorState;
-class SimulatorTimer;
-class AdaptiveSimulatorTimer;
 class WellState;
 struct PhaseUsage;
 
@@ -74,7 +73,7 @@ public:
      * This routine should be called before the first timestep (i.e. when
      * timer.currentStepNum () == 0)
      */
-    virtual void writeInit(const SimulatorTimer &timer) = 0;
+    virtual void writeInit(const SimulatorTimerInterface &timer) = 0;
 
     /*!
      * \brief Write a blackoil reservoir state to disk for later inspection with
@@ -87,24 +86,7 @@ public:
      * This routine should be called after the timestep has been advanced,
      * i.e. timer.currentStepNum () > 0.
      */
-    virtual void writeTimeStep(const SimulatorTimer& timer,
-                               const SimulatorState& reservoirState,
-                               const WellState& wellState) = 0;
-
-    /*!
-     * \brief Write a blackoil reservoir state to disk for later inspection with
-     *        visualization tools like ResInsight
-     *
-     * \param[in] timer          The timer providing time, time step, etc. information
-     * \param[in] subStepTimer   The timer providing sub step time information
-     * \param[in] reservoirState The thermodynamic state of the reservoir
-     * \param[in] wellState      The production/injection data for all wells
-     *
-     * This routine should be called after the timestep has been advanced,
-     * i.e. timer.currentStepNum () > 0.
-     */
-    virtual void writeTimeStep(const SimulatorTimer& timer,
-                               const AdaptiveSimulatorTimer& subStepTimer,
+    virtual void writeTimeStep(const SimulatorTimerInterface& timer,
                                const SimulatorState& reservoirState,
                                const WellState& wellState) = 0;
 

--- a/opm/core/io/OutputWriter.hpp
+++ b/opm/core/io/OutputWriter.hpp
@@ -31,6 +31,7 @@ class EclipseState;
 namespace parameter { class ParameterGroup; }
 class SimulatorState;
 class SimulatorTimer;
+class AdaptiveSimulatorTimer;
 class WellState;
 struct PhaseUsage;
 
@@ -79,13 +80,31 @@ public:
      * \brief Write a blackoil reservoir state to disk for later inspection with
      *        visualization tools like ResInsight
      *
+     * \param[in] timer          The timer providing time, time step, etc. information
      * \param[in] reservoirState The thermodynamic state of the reservoir
-     * \param[in] wellState The production/injection data for all wells
+     * \param[in] wellState      The production/injection data for all wells
      *
      * This routine should be called after the timestep has been advanced,
      * i.e. timer.currentStepNum () > 0.
      */
     virtual void writeTimeStep(const SimulatorTimer& timer,
+                               const SimulatorState& reservoirState,
+                               const WellState& wellState) = 0;
+
+    /*!
+     * \brief Write a blackoil reservoir state to disk for later inspection with
+     *        visualization tools like ResInsight
+     *
+     * \param[in] timer          The timer providing time, time step, etc. information
+     * \param[in] subStepTimer   The timer providing sub step time information
+     * \param[in] reservoirState The thermodynamic state of the reservoir
+     * \param[in] wellState      The production/injection data for all wells
+     *
+     * This routine should be called after the timestep has been advanced,
+     * i.e. timer.currentStepNum () > 0.
+     */
+    virtual void writeTimeStep(const SimulatorTimer& timer,
+                               const AdaptiveSimulatorTimer& subStepTimer,
                                const SimulatorState& reservoirState,
                                const WellState& wellState) = 0;
 

--- a/opm/core/io/eclipse/EclipseWriter.hpp
+++ b/opm/core/io/eclipse/EclipseWriter.hpp
@@ -1,6 +1,7 @@
 /*
   Copyright (c) 2013 Andreas Lauser
   Copyright (c) 2013 Uni Research AS
+  Copyright (c) 2014 IRIS AS
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -39,10 +40,12 @@ namespace Opm {
 // forward declarations
 namespace EclipseWriterDetails {
 class Summary;
+struct WriterTimer;
 }
 
 class SimulatorState;
 class SimulatorTimer;
+class AdaptiveSimulatorTimer;
 class WellState;
 
 namespace parameter { class ParameterGroup; }
@@ -91,10 +94,33 @@ public:
      * ERT or ECLIPSE. Note that calling this method is only
      * meaningful after the first time step has been completed.
      *
+     * \param[in] timer          The timer providing time step and time information
      * \param[in] reservoirState The thermodynamic state of the reservoir
-     * \param[in] wellState The production/injection data for all wells
+     * \param[in] wellState      The production/injection data for all wells
      */
     virtual void writeTimeStep(const SimulatorTimer& timer,
+                               const SimulatorState& reservoirState,
+                               const WellState& wellState);
+
+
+    /*!
+     * \brief Write a reservoir state and summary information to disk.
+     *
+     *
+     * The reservoir state can be inspected with visualization tools like
+     * ResInsight.
+     *
+     * The summary information can then be visualized using tools from
+     * ERT or ECLIPSE. Note that calling this method is only
+     * meaningful after the first time step has been completed.
+     *
+     * \param[in] timer          The timer providing time step and time information
+     * \param[in] subStepTimer   The timer providing sub step information
+     * \param[in] reservoirState The thermodynamic state of the reservoir
+     * \param[in] wellState      The production/injection data for all wells
+     */
+    virtual void writeTimeStep(const SimulatorTimer& timer,
+                               const AdaptiveSimulatorTimer& subStepTimer,
                                const SimulatorState& reservoirState,
                                const WellState& wellState);
 
@@ -117,6 +143,13 @@ private:
     std::shared_ptr<EclipseWriterDetails::Summary> summary_;
 
     void init(const parameter::ParameterGroup& params);
+    // implementation of writeInit
+    void writeInit(const EclipseWriterDetails::WriterTimer &timer);
+    // implementation of writeTimeStep
+    void writeTimeStep(const EclipseWriterDetails::WriterTimer& timer,
+                       const SimulatorState& reservoirState,
+                       const WellState& wellState);
+
 };
 
 typedef std::shared_ptr<EclipseWriter> EclipseWriterPtr;

--- a/opm/core/io/eclipse/EclipseWriter.hpp
+++ b/opm/core/io/eclipse/EclipseWriter.hpp
@@ -25,6 +25,7 @@
 #include <opm/core/io/OutputWriter.hpp>
 #include <opm/core/props/BlackoilPhases.hpp>
 #include <opm/core/wells.h> // WellType
+#include <opm/core/simulator/SimulatorTimerInterface.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
@@ -44,8 +45,6 @@ struct WriterTimer;
 }
 
 class SimulatorState;
-class SimulatorTimer;
-class AdaptiveSimulatorTimer;
 class WellState;
 
 namespace parameter { class ParameterGroup; }
@@ -81,7 +80,7 @@ public:
     /**
      * Write the static eclipse data (grid, PVT curves, etc) to disk.
      */
-    virtual void writeInit(const SimulatorTimer &timer);
+    virtual void writeInit(const SimulatorTimerInterface &timer);
 
     /*!
      * \brief Write a reservoir state and summary information to disk.
@@ -98,31 +97,10 @@ public:
      * \param[in] reservoirState The thermodynamic state of the reservoir
      * \param[in] wellState      The production/injection data for all wells
      */
-    virtual void writeTimeStep(const SimulatorTimer& timer,
+    virtual void writeTimeStep(const SimulatorTimerInterface& timer,
                                const SimulatorState& reservoirState,
                                const WellState& wellState);
 
-
-    /*!
-     * \brief Write a reservoir state and summary information to disk.
-     *
-     *
-     * The reservoir state can be inspected with visualization tools like
-     * ResInsight.
-     *
-     * The summary information can then be visualized using tools from
-     * ERT or ECLIPSE. Note that calling this method is only
-     * meaningful after the first time step has been completed.
-     *
-     * \param[in] timer          The timer providing time step and time information
-     * \param[in] subStepTimer   The timer providing sub step information
-     * \param[in] reservoirState The thermodynamic state of the reservoir
-     * \param[in] wellState      The production/injection data for all wells
-     */
-    virtual void writeTimeStep(const SimulatorTimer& timer,
-                               const AdaptiveSimulatorTimer& subStepTimer,
-                               const SimulatorState& reservoirState,
-                               const WellState& wellState);
 
     static int eclipseWellTypeMask(WellType wellType, WellInjector::TypeEnum injectorType);
     static int eclipseWellStatusMask(WellCommon::StatusEnum wellStatus);

--- a/opm/core/io/eclipse/EclipseWriter.hpp
+++ b/opm/core/io/eclipse/EclipseWriter.hpp
@@ -114,7 +114,7 @@ private:
     double deckToSiPressure_;
     bool enableOutput_;
     int outputInterval_;
-    int reportStepIdx_;
+    int writeStepIdx_;
     std::string outputDir_;
     std::string baseName_;
     PhaseUsage phaseUsage_; // active phases in the input deck

--- a/opm/core/io/eclipse/EclipseWriter.hpp
+++ b/opm/core/io/eclipse/EclipseWriter.hpp
@@ -41,7 +41,6 @@ namespace Opm {
 // forward declarations
 namespace EclipseWriterDetails {
 class Summary;
-struct WriterTimer;
 }
 
 class SimulatorState;
@@ -121,13 +120,6 @@ private:
     std::shared_ptr<EclipseWriterDetails::Summary> summary_;
 
     void init(const parameter::ParameterGroup& params);
-    // implementation of writeInit
-    void writeInit(const EclipseWriterDetails::WriterTimer &timer);
-    // implementation of writeTimeStep
-    void writeTimeStep(const EclipseWriterDetails::WriterTimer& timer,
-                       const SimulatorState& reservoirState,
-                       const WellState& wellState);
-
 };
 
 typedef std::shared_ptr<EclipseWriter> EclipseWriterPtr;

--- a/opm/core/simulator/AdaptiveSimulatorTimer.cpp
+++ b/opm/core/simulator/AdaptiveSimulatorTimer.cpp
@@ -31,7 +31,7 @@ namespace Opm
 {
     AdaptiveSimulatorTimer::
     AdaptiveSimulatorTimer( const SimulatorTimerInterface& timer, const double lastStepTaken )
-        : start_date_( timer.startDate() )
+        : start_date_time_( timer.startDateTime() )
         , start_time_( timer.simulationTimeElapsed() )
         , total_time_( start_time_ + timer.currentStepLength() )
         , report_step_( timer.reportStepNum() )
@@ -156,9 +156,9 @@ namespace Opm
         std::cout << "sub steps end time = " << unit::convert::to( simulationTimeElapsed(), unit::day ) << " (days)" << std::endl;
     }
 
-    boost::gregorian::date AdaptiveSimulatorTimer::startDate() const
+    boost::posix_time::ptime AdaptiveSimulatorTimer::startDateTime() const
     {
-        return start_date_;
+        return start_date_time_;
     }
 
     double AdaptiveSimulatorTimer::

--- a/opm/core/simulator/AdaptiveSimulatorTimer.cpp
+++ b/opm/core/simulator/AdaptiveSimulatorTimer.cpp
@@ -100,7 +100,7 @@ namespace Opm
     double AdaptiveSimulatorTimer::stepLengthTaken() const
     {
         assert( ! steps_.empty() );
-        return *(steps_.rbegin());
+        return steps_.back();
     }
 
 

--- a/opm/core/simulator/AdaptiveSimulatorTimer.hpp
+++ b/opm/core/simulator/AdaptiveSimulatorTimer.hpp
@@ -27,6 +27,8 @@
 #include <algorithm>
 #include <numeric>
 
+#include <opm/core/simulator/SimulatorTimerInterface.hpp>
+
 namespace Opm
 {
 
@@ -35,14 +37,12 @@ namespace Opm
     /// \brief Simulation timer for adaptive time stepping
     ///
     /////////////////////////////////////////////////////////
-    class AdaptiveSimulatorTimer
+    class AdaptiveSimulatorTimer : public SimulatorTimerInterface
     {
     public:
         /// \brief constructor taking a simulator timer to determine start and end time
-        ///  \param start_time     start time of timer
-        ///  \param total_time     total time of timer
-        ///  \param lastDt         last suggested length of time step interval
-        AdaptiveSimulatorTimer( const double start_time, const double total_time, const double lastDt );
+        ///  \param timer   in case of sub stepping this is the outer timer
+        explicit AdaptiveSimulatorTimer( const SimulatorTimerInterface& timer, const double lastStepTaken );
 
         /// \brief advance time by currentStepLength
         AdaptiveSimulatorTimer& operator++ ();
@@ -52,6 +52,9 @@ namespace Opm
 
         /// \brief \copydoc SimulationTimer::currentStepNum
         int currentStepNum () const;
+
+        /// \brief return current report step
+        int reportStepNum() const;
 
         /// \brief \copydoc SimulationTimer::currentStepLength
         double currentStepLength () const;
@@ -80,12 +83,22 @@ namespace Opm
         /// \brief return average suggested step length
         double suggestedAverage () const;
 
+        /// \brief Previous step length. This is the length of the step that
+        ///        was taken to arrive at this time.
+        double stepLengthTaken () const;
+
         /// \brief report start and end time as well as used steps so far
         void report(std::ostream& os) const;
 
+        /// \brief start date of simulation
+        boost::gregorian::date startDate() const;
+
     protected:
+        const boost::gregorian::date start_date_;
         const double start_time_;
         const double total_time_;
+        const int report_step_;
+
         double current_time_;
         double dt_;
         int current_step_;

--- a/opm/core/simulator/AdaptiveSimulatorTimer.hpp
+++ b/opm/core/simulator/AdaptiveSimulatorTimer.hpp
@@ -89,11 +89,11 @@ namespace Opm
         /// \brief report start and end time as well as used steps so far
         void report(std::ostream& os) const;
 
-        /// \brief start date of simulation
-        boost::gregorian::date startDate() const;
+        /// \brief start date time of simulation
+        boost::posix_time::ptime startDateTime() const;
 
     protected:
-        const boost::gregorian::date start_date_;
+        const boost::posix_time::ptime start_date_time_;
         const double start_time_;
         const double total_time_;
         const int report_step_;

--- a/opm/core/simulator/AdaptiveSimulatorTimer.hpp
+++ b/opm/core/simulator/AdaptiveSimulatorTimer.hpp
@@ -16,7 +16,6 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-
 #ifndef OPM_ADAPTIVESIMULATORTIMER_HEADER_INCLUDED
 #define OPM_ADAPTIVESIMULATORTIMER_HEADER_INCLUDED
 

--- a/opm/core/simulator/AdaptiveTimeStepping.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping.hpp
@@ -6,33 +6,66 @@
 
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/core/simulator/SimulatorTimer.hpp>
 #include <opm/core/simulator/TimeStepControlInterface.hpp>
 
 namespace Opm {
 
-    // AdaptiveTimeStepping 
+
+    // AdaptiveTimeStepping
     //---------------------
-    
+
     class AdaptiveTimeStepping
     {
-    public:    
+    public:
         //! \brief contructor taking parameter object
         AdaptiveTimeStepping( const parameter::ParameterGroup& param );
 
         /** \brief  step method that acts like the solver::step method
-                    in a sub cycle of time steps 
-            
+                    in a sub cycle of time steps
+
             \param  solver      solver object that must implement a method step( dt, state, well_state )
-            \param  state       current state of the solution variables 
+            \param  state       current state of the solution variables
             \param  well_state  additional well state object
             \param  time        current simulation time
-            \param  timestep    current time step length that is to be sub cycled 
-        */          
+            \param  timestep    current time step length that is to be sub cycled
+        */
         template <class Solver, class State, class WellState>
         void step( Solver& solver, State& state, WellState& well_state,
                    const double time, const double timestep );
 
+        /** \brief  step method that acts like the solver::step method
+                    in a sub cycle of time steps
+
+            \param  timer       simulator timer providing time and timestep
+            \param  solver      solver object that must implement a method step( dt, state, well_state )
+            \param  state       current state of the solution variables
+            \param  well_state  additional well state object
+        */
+        template <class Solver, class State, class WellState>
+        void step( const SimulatorTimer& timer,
+                   Solver& solver, State& state, WellState& well_state );
+
+        /** \brief  step method that acts like the solver::step method
+                    in a sub cycle of time steps
+
+            \param  timer        simulator timer providing time and timestep
+            \param  solver       solver object that must implement a method step( dt, state, well_state )
+            \param  state        current state of the solution variables
+            \param  well_state   additional well state object
+            \param  outputWriter writer object to write sub steps
+        */
+        template <class Solver, class State, class WellState>
+        void step( const SimulatorTimer& timer,
+                   Solver& solver, State& state, WellState& well_state,
+                   OutputWriter& outputWriter );
+
     protected:
+        template <class Solver, class State, class WellState>
+        void stepImpl( Solver& solver, State& state, WellState& well_state,
+                       const double time, const double timestep,
+                       const SimulatorTimer* timer, OutputWriter* outputWriter);
+
         typedef std::unique_ptr< TimeStepControlInterface > TimeStepControlType;
 
         TimeStepControlType timeStepControl_; //!< time step control object
@@ -40,8 +73,8 @@ namespace Opm {
         const double restart_factor_;         //!< factor to multiply time step with when solver fails to converge
         const double growth_factor_;          //!< factor to multiply time step when solver recovered from failed convergence
         const int solver_restart_max_;        //!< how many restart of solver are allowed
-        const bool solver_verbose_;           //!< solver verbosity 
-        const bool timestep_verbose_;         //!< timestep verbosity 
+        const bool solver_verbose_;           //!< solver verbosity
+        const bool timestep_verbose_;         //!< timestep verbosity
         double last_timestep_;                //!< size of last timestep
     };
 }

--- a/opm/core/simulator/AdaptiveTimeStepping.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping.hpp
@@ -1,3 +1,21 @@
+/*
+  Copyright 2014 IRIS AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
 #ifndef OPM_SUBSTEPPING_HEADER_INCLUDED
 #define OPM_SUBSTEPPING_HEADER_INCLUDED
 
@@ -20,19 +38,6 @@ namespace Opm {
     public:
         //! \brief contructor taking parameter object
         AdaptiveTimeStepping( const parameter::ParameterGroup& param );
-
-        /** \brief  step method that acts like the solver::step method
-                    in a sub cycle of time steps
-
-            \param  solver      solver object that must implement a method step( dt, state, well_state )
-            \param  state       current state of the solution variables
-            \param  well_state  additional well state object
-            \param  time        current simulation time
-            \param  timestep    current time step length that is to be sub cycled
-        */
-        template <class Solver, class State, class WellState>
-        void step( Solver& solver, State& state, WellState& well_state,
-                   const double time, const double timestep );
 
         /** \brief  step method that acts like the solver::step method
                     in a sub cycle of time steps
@@ -62,9 +67,9 @@ namespace Opm {
 
     protected:
         template <class Solver, class State, class WellState>
-        void stepImpl( Solver& solver, State& state, WellState& well_state,
-                       const double time, const double timestep,
-                       const SimulatorTimer* timer, OutputWriter* outputWriter);
+        void stepImpl( const SimulatorTimer& timer,
+                       Solver& solver, State& state, WellState& well_state,
+                       OutputWriter* outputWriter);
 
         typedef std::unique_ptr< TimeStepControlInterface > TimeStepControlType;
 

--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -151,7 +151,12 @@ namespace Opm {
                     std::cout << std::endl
                               <<"Substep( " << substepTimer.currentStepNum()
                                             << " ): Current time (days)         "  << unit::convert::to(substepTimer.simulationTimeElapsed(),unit::day) << std::endl
-                                  << "               Current stepsize est (days) " << unit::convert::to(dtEstimate, unit::day) << std::endl;
+                                  << "              Current stepsize est (days) " << unit::convert::to(dtEstimate, unit::day) << std::endl;
+                }
+
+                // write data if outputWriter was provided
+                if( outputWriter ) {
+                    outputWriter->writeTimeStep( substepTimer, state, well_state );
                 }
 
                 // set new time step length
@@ -161,10 +166,6 @@ namespace Opm {
                 last_state      = state ;
                 last_well_state = well_state;
 
-                // write data if outputWriter was provided
-                if( outputWriter ) {
-                    outputWriter->writeTimeStep( substepTimer, state, well_state );
-                }
             }
             else // in case of no convergence (linearIterations < 0)
             {

--- a/opm/core/simulator/SimulatorTimer.cpp
+++ b/opm/core/simulator/SimulatorTimer.cpp
@@ -100,18 +100,10 @@ namespace Opm
         return current_time_;
     }
 
-    /// time elapsed since the start of the POSIX epoch (Jan 1st, 1970) [s].
-    time_t SimulatorTimer::currentPosixTime() const
+    boost::gregorian::date SimulatorTimer::startDate() const
     {
-        tm t = boost::posix_time::to_tm(currentDateTime());
-        return std::mktime(&t);
+        return start_date_;
     }
-
-    boost::posix_time::ptime SimulatorTimer::currentDateTime() const
-    {
-        return boost::posix_time::ptime(start_date_) + boost::posix_time::seconds( (int) current_time_ );
-    }
-
 
 
     /// Total time.

--- a/opm/core/simulator/SimulatorTimer.cpp
+++ b/opm/core/simulator/SimulatorTimer.cpp
@@ -100,9 +100,9 @@ namespace Opm
         return current_time_;
     }
 
-    boost::gregorian::date SimulatorTimer::startDate() const
+    boost::posix_time::ptime SimulatorTimer::startDateTime() const
     {
-        return start_date_;
+        return boost::posix_time::ptime(start_date_);
     }
 
 

--- a/opm/core/simulator/SimulatorTimer.hpp
+++ b/opm/core/simulator/SimulatorTimer.hpp
@@ -83,7 +83,7 @@ namespace Opm
         double totalTime() const;
 
         /// Return start date of simulation
-        boost::gregorian::date startDate() const;
+        boost::posix_time::ptime startDateTime() const;
 
         /// Set total time.
         /// This is primarily intended for multi-epoch schedules,

--- a/opm/core/simulator/SimulatorTimer.hpp
+++ b/opm/core/simulator/SimulatorTimer.hpp
@@ -21,20 +21,23 @@
 #define OPM_SIMULATORTIMER_HEADER_INCLUDED
 
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
+#include <opm/core/simulator/SimulatorTimerInterface.hpp>
 
 #include <iosfwd>
 #include <vector>
-#include <boost/date_time/gregorian/gregorian.hpp>
-#include <boost/date_time/posix_time/posix_time_types.hpp>
 
 namespace Opm
 {
 
     namespace parameter { class ParameterGroup; }
 
-    class SimulatorTimer
+    class SimulatorTimer : public SimulatorTimerInterface
     {
     public:
+        // use default implementation of these methods
+        using SimulatorTimerInterface::currentDateTime;
+        using SimulatorTimerInterface::currentPosixTime;
+
         /// Default constructor.
         SimulatorTimer();
 
@@ -72,19 +75,15 @@ namespace Opm
         /// it is an error to call stepLengthTaken().
         double stepLengthTaken () const;
 
-        /// Time elapsed since the start of the POSIX epoch (Jan 1st,
-        /// 1970) until the current time step begins [s].
-        time_t currentPosixTime() const;
-
         /// Time elapsed since the start of the simulation until the
         /// beginning of the current time step [s].
         double simulationTimeElapsed() const;
 
-        /// Return the current time as a posix time object.
-        boost::posix_time::ptime currentDateTime() const;
-
         /// Total time.
         double totalTime() const;
+
+        /// Return start date of simulation
+        boost::gregorian::date startDate() const;
 
         /// Set total time.
         /// This is primarily intended for multi-epoch schedules,

--- a/opm/core/simulator/SimulatorTimerInterface.hpp
+++ b/opm/core/simulator/SimulatorTimerInterface.hpp
@@ -37,6 +37,9 @@ namespace Opm
         SimulatorTimerInterface() {}
 
     public:
+        /// destructor
+        virtual ~SimulatorTimerInterface() {}
+
         /// Current step number. This is the number of timesteps that
         /// has been completed from the start of the run. The time
         /// after initialization but before the simulation has started
@@ -60,6 +63,14 @@ namespace Opm
         /// it is an error to call stepLengthTaken().
         virtual double stepLengthTaken () const = 0;
 
+        /// Previous report step length. This is the length of the step that
+        /// was taken to arrive at this report step time.
+        ///
+        /// @note if no increments have been done (i.e. the timer is
+        /// still in its constructed state and reportStepNum() == 0),
+        /// it is an error to call stepLengthTaken().
+        virtual double reportStepLengthTaken () const { return stepLengthTaken(); }
+
         /// Time elapsed since the start of the simulation until the
         /// beginning of the current time step [s].
         virtual double simulationTimeElapsed() const = 0;
@@ -68,12 +79,13 @@ namespace Opm
         virtual bool done() const = 0;
 
         /// Return start date of simulation
-        virtual boost::gregorian::date startDate() const = 0;
+        virtual boost::posix_time::ptime startDateTime() const = 0;
 
         /// Return the current time as a posix time object.
         virtual boost::posix_time::ptime currentDateTime() const
         {
-           return boost::posix_time::ptime(startDate()) +  boost::posix_time::seconds( (int) simulationTimeElapsed());
+           return startDateTime() + boost::posix_time::seconds( (int) simulationTimeElapsed());
+               //boost::posix_time::ptime(startDate()) +  boost::posix_time::seconds( (int) simulationTimeElapsed());
         }
 
         /// Time elapsed since the start of the POSIX epoch (Jan 1st,
@@ -83,10 +95,6 @@ namespace Opm
             tm t = boost::posix_time::to_tm(currentDateTime());
             return std::mktime(&t);
         }
-
-        /// Print a report with current and total time etc.
-        /// Note: if done(), it is an error to call report().
-        //virtual void report(std::ostream& os) const = 0;
     };
 
 

--- a/opm/core/simulator/SimulatorTimerInterface.hpp
+++ b/opm/core/simulator/SimulatorTimerInterface.hpp
@@ -1,0 +1,95 @@
+/*
+  Copyright (c) 2014 IRIS AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_SIMULATORTIMERINTERFACE_HEADER_INCLUDED
+#define OPM_SIMULATORTIMERINTERFACE_HEADER_INCLUDED
+
+#include <boost/date_time/gregorian/gregorian.hpp>
+#include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/date_time/posix_time/conversion.hpp>
+
+namespace Opm
+{
+
+    namespace parameter { class ParameterGroup; }
+
+    /// Interface class for SimulatorTimer objects, to be improved.
+    class SimulatorTimerInterface
+    {
+    protected:
+        /// Default constructor, protected to not allow explicit instances of this class.
+        SimulatorTimerInterface() {}
+
+    public:
+        /// Current step number. This is the number of timesteps that
+        /// has been completed from the start of the run. The time
+        /// after initialization but before the simulation has started
+        /// is timestep number zero.
+        virtual int currentStepNum() const = 0;
+
+        /// Current report step number. This might differ from currentStepNum in case of sub stepping
+        virtual int reportStepNum() const { return currentStepNum(); }
+
+        /// Current step length. This is the length of the step
+        /// the simulator will take in the next iteration.
+        ///
+        /// @note if done(), it is an error to call currentStepLength().
+        virtual double currentStepLength() const = 0;
+
+        /// Previous step length. This is the length of the step that
+        /// was taken to arrive at this time.
+        ///
+        /// @note if no increments have been done (i.e. the timer is
+        /// still in its constructed state and currentStepNum() == 0),
+        /// it is an error to call stepLengthTaken().
+        virtual double stepLengthTaken () const = 0;
+
+        /// Time elapsed since the start of the simulation until the
+        /// beginning of the current time step [s].
+        virtual double simulationTimeElapsed() const = 0;
+
+        /// Return true if timer indicates that simulation of timer interval is finished
+        virtual bool done() const = 0;
+
+        /// Return start date of simulation
+        virtual boost::gregorian::date startDate() const = 0;
+
+        /// Return the current time as a posix time object.
+        virtual boost::posix_time::ptime currentDateTime() const
+        {
+           return boost::posix_time::ptime(startDate()) +  boost::posix_time::seconds( (int) simulationTimeElapsed());
+        }
+
+        /// Time elapsed since the start of the POSIX epoch (Jan 1st,
+        /// 1970) until the current time step begins [s].
+        virtual time_t currentPosixTime() const
+        {
+            tm t = boost::posix_time::to_tm(currentDateTime());
+            return std::mktime(&t);
+        }
+
+        /// Print a report with current and total time etc.
+        /// Note: if done(), it is an error to call report().
+        //virtual void report(std::ostream& os) const = 0;
+    };
+
+
+} // namespace Opm
+
+#endif // OPM_SIMULATORTIMER_HEADER_INCLUDED


### PR DESCRIPTION
This PR introduces an interface for SimulatorTimers implemented by SimulatorTimer and AdaptiveSimulatorTimer. 

The EclipseWriter has been revised to support writing of substeps when used with the AdaptiveTimeStepping.

It has been tested with the SPE9 case and the solution as well as the dates look ok. 
