### PR TITLE
Adds a free function to UgGridHelpers to access the face tag.

### DIFF
--- a/opm/core/grid/GridHelpers.cpp
+++ b/opm/core/grid/GridHelpers.cpp
@@ -63,6 +63,12 @@ double faceArea(const UnstructuredGrid& grid, int face_index)
     return grid.face_areas[face_index];
 }
 
+int faceTag(const UnstructuredGrid& grid,
+            boost::iterator_range<const int*>::const_iterator face)
+{
+    return grid.cell_facetag[&(*face)-&(*(cell2Faces(grid)[0].begin()))];
+}
+
 SparseTableView cell2Faces(const UnstructuredGrid& grid)
 {
     return SparseTableView(grid.cell_faces, grid.cell_facepos, numCells(grid));

--- a/opm/core/grid/GridHelpers.cpp
+++ b/opm/core/grid/GridHelpers.cpp
@@ -66,7 +66,7 @@ double faceArea(const UnstructuredGrid& grid, int face_index)
 int faceTag(const UnstructuredGrid& grid,
             boost::iterator_range<const int*>::const_iterator face)
 {
-    return grid.cell_facetag[&(*face)-&(*(cell2Faces(grid)[0].begin()))];
+    return grid.cell_facetag[face-cell2Faces(grid)[0].begin()];
 }
 
 SparseTableView cell2Faces(const UnstructuredGrid& grid)

--- a/opm/core/grid/GridHelpers.hpp
+++ b/opm/core/grid/GridHelpers.hpp
@@ -183,7 +183,6 @@ double faceArea(const UnstructuredGrid& grid, int face_index);
 
 /// \brief Get Eclipse Cartesian tag of a face
 /// \param grid The grid that the face is part of.
-/// \param cell_index The index of the cell that the face is attached to.
 /// \param cell_face The face attached to a cell as obtained from cell2Faces()
 /// \return 0, 1, 2, 3, 4, 5 for I-, I+, J-, J+, K-, K+
 int faceTag(const UnstructuredGrid& grid, boost::iterator_range<const int*>::const_iterator cell_face);

--- a/opm/core/grid/GridHelpers.hpp
+++ b/opm/core/grid/GridHelpers.hpp
@@ -181,6 +181,13 @@ const double* faceNormal(const UnstructuredGrid& grid, int face_index);
 /// \param face_index The index of the face in the grid.
 double faceArea(const UnstructuredGrid& grid, int face_index);
 
+/// \brief Get Eclipse Cartesian tag of a face
+/// \param grid The grid that the face is part of.
+/// \param cell_index The index of the cell that the face is attached to.
+/// \param cell_face The face attached to a cell as obtained from cell2Faces()
+/// \return 0, 1, 2, 3, 4, 5 for I-, I+, J-, J+, K-, K+
+int faceTag(const UnstructuredGrid& grid, boost::iterator_range<const int*>::const_iterator cell_face);
+
 /// \brief Maps the grid type to the associated type of the cell to faces mapping.
 ///
 /// Provides a type named Type.


### PR DESCRIPTION
To identify the face tag we use the iterator over the cell faces. This provides all the information needed both for UG and CpGrid.

For UG we can directly compute the half face index from by subtracting
```C++
&(*cellFaces()[0].begin())
```
from it. For `CpGrid` the iterator will provide the cell index and we will use Bard's proposal to compute the face tag correctly.

Supersedes and closes #719