### PR TITLE
PETSc support: vector

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -50,6 +50,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/core/linalg/LinearSolverIstl.cpp
 	opm/core/linalg/LinearSolverUmfpack.cpp
 	opm/core/linalg/LinearSolverPetsc.cpp
+	opm/core/linalg/petscvector.cpp
 	opm/core/linalg/petsc.cpp
 	opm/core/linalg/call_umfpack.c
 	opm/core/linalg/sparse_sys.c
@@ -165,6 +166,7 @@ list (APPEND TEST_SOURCE_FILES
 	tests/test_event.cpp
 	tests/test_nonuniformtablelinear.cpp
 	tests/test_sparsevector.cpp
+	tests/test_petscvector.cpp
 	tests/test_sparsetable.cpp
 	tests/test_velocityinterpolation.cpp
 	tests/test_quadratures.cpp
@@ -293,6 +295,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/linalg/LinearSolverUmfpack.hpp
 	opm/core/linalg/LinearSolverPetsc.hpp
 	opm/core/linalg/petsc.hpp
+	opm/core/linalg/petscvector.hpp
 	opm/core/linalg/blas_lapack.h
 	opm/core/linalg/call_umfpack.h
 	opm/core/linalg/sparse_sys.h

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -50,6 +50,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/core/linalg/LinearSolverIstl.cpp
 	opm/core/linalg/LinearSolverUmfpack.cpp
 	opm/core/linalg/LinearSolverPetsc.cpp
+	opm/core/linalg/petsc.cpp
 	opm/core/linalg/call_umfpack.c
 	opm/core/linalg/sparse_sys.c
 	opm/core/pressure/CompressibleTpfa.cpp
@@ -291,6 +292,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/linalg/LinearSolverIstl.hpp
 	opm/core/linalg/LinearSolverUmfpack.hpp
 	opm/core/linalg/LinearSolverPetsc.hpp
+	opm/core/linalg/petsc.hpp
 	opm/core/linalg/blas_lapack.h
 	opm/core/linalg/call_umfpack.h
 	opm/core/linalg/sparse_sys.h

--- a/opm/core/linalg/petsc.cpp
+++ b/opm/core/linalg/petsc.cpp
@@ -1,0 +1,20 @@
+#include <opm/core/linalg/petsc.hpp>
+
+namespace Opm {
+namespace petsc {
+
+petsc::petsc(
+        int* argc,
+        char*** argv,
+        const char* file,
+        const char* help ) {
+
+    PetscInitialize( argc, argv, file, help );
+}
+
+petsc::~petsc() {
+    PetscFinalize();
+}
+
+}
+}

--- a/opm/core/linalg/petsc.hpp
+++ b/opm/core/linalg/petsc.hpp
@@ -1,0 +1,31 @@
+#ifndef OPM_PETSC_H
+#define OPM_PETSC_H
+
+/*
+ * This file introduces the Opm::petsc namespace for petsc support, as well as
+ * a RAII helper class to manage the lifetime of the petsc database and MPI
+ * use.
+ */
+
+#define PETSC_CLANGUAGE_CXX 1 //For CHKERRXX macro
+#include <petsc.h>
+
+namespace Opm {
+namespace petsc {
+
+/*
+ * Initialize this class at the start of your program, and pass argc and argv
+ * from main, then forget about it. This object must be alive before any other
+ * petsc feature is used.
+ */
+
+class petsc {
+    public:
+        petsc( int* argc, char*** argv, const char* file, const char* help );
+        ~petsc();
+};
+
+}
+}
+
+#endif //OPM_PETSC_H

--- a/opm/core/linalg/petscvector.cpp
+++ b/opm/core/linalg/petscvector.cpp
@@ -1,0 +1,209 @@
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscvector.hpp>
+
+#include <cassert>
+#include <memory>
+#include <utility>
+
+#include <iostream>
+
+/* Slight hack to get things working. This sets the communicator used when
+ * constructing new vectors - however, this should be configurable. When full
+ * petsc support is figured out this will be changed.
+ */
+static inline MPI_Comm get_comm() { return PETSC_COMM_WORLD; }
+
+namespace Opm {
+namespace petsc {
+
+/* ideally replace this with C++11's std::iota */
+#ifndef HAVE_STD_IOTA
+template< class ForwardIterator, class T >
+static inline void iota( ForwardIterator first, ForwardIterator last, T value ) {
+        while(first != last) *first++ = value++;
+}
+#endif //HAVE_STD_IOTA
+
+template< typename T = vector::size_type, typename U = T >
+static inline std::vector< T > range( U begin, U end ) {
+    using namespace std;
+
+    std::vector< T > x( end - begin );
+    /* if std::iota is available, the function defined above shouldn't be
+     * compiled in and std::iota should be used
+     */
+    iota( x.begin(), x.end(), begin );
+    return x;
+}
+
+vector::vector() {
+    /* Meant to be used by other constructors. */
+    Vec x;
+    VecCreate( get_comm(), &x );
+    VecSetFromOptions( x );
+
+    this->v.reset( x );
+}
+
+vector::vector( Vec x ) : v( x ) {}
+
+vector::vector( const vector& x ) {
+    Vec y;
+    auto err = VecDuplicate( x, &y ); CHKERRXX( err );
+    err = VecCopy( x, y ); CHKERRXX( err );
+
+    this->v.reset( y );
+}
+
+vector::vector( vector::size_type size ) {
+    vector vec;
+
+    this->v.swap( vec.v );
+
+    auto err = VecSetSizes( this->ptr(), PETSC_DECIDE, size );
+    CHKERRXX( err );
+}
+
+vector::vector( vector::size_type size, vector::scalar x ) {
+    vector vec( size );
+    this->v.swap( vec.v );
+    this->assign( x );
+}
+
+vector::vector( const std::vector< vector::scalar >& values ) {
+    vector vec( values.data(), values.size() );
+    this->v.swap( vec.v );
+}
+
+vector::vector( const std::vector< vector::scalar >& values,
+                const std::vector< vector::size_type >& indexset ) {
+
+    assert( indexset.size() == values.size() );
+
+    vector vec( values.data(), indexset.data(), values.size() );
+    this->v.swap( vec.v );
+}
+
+vector::vector( const vector::scalar* values, vector::size_type size ) {
+    auto indices = range( 0, size );
+    vector vec( values, indices.data(), size );
+
+    this->v.swap( vec.v );
+}
+
+vector::vector(
+        const vector::scalar* values,
+        const vector::size_type* indexset,
+        vector::size_type size ) {
+
+    vector vec( size );
+
+    this->v.swap( vec.v );
+    this->set( values, indexset, size );
+}
+
+vector::operator Vec() const {
+    return this->ptr();
+}
+
+vector::size_type vector::size() const {
+    PetscInt x;
+    auto err = VecGetSize( this->ptr(), &x ); CHKERRXX( err );
+    return x;
+}
+
+void vector::assign( vector::scalar x ) {
+    auto err = VecSet( this->ptr(), x ); CHKERRXX( err );
+}
+
+vector& vector::operator+=( vector::scalar rhs ) {
+    auto err = VecShift( this->ptr(), rhs ); CHKERRXX( err );
+    return *this;
+}
+
+vector& vector::operator-=( vector::scalar rhs ) {
+    return *this += -rhs;
+}
+
+vector& vector::operator*=( vector::scalar rhs ) {
+    auto err = VecScale( this->ptr(), rhs ); CHKERRXX( err );
+    return *this;
+}
+
+vector& vector::operator/=( vector::scalar rhs ) {
+    return *this *= ( 1 / rhs );
+}
+
+vector operator+( vector lhs, vector::scalar rhs ) {
+    return lhs += rhs;
+}
+
+vector operator-( vector lhs, vector::scalar rhs ) {
+    return lhs -= rhs;
+}
+
+vector operator*( vector lhs, vector::scalar rhs ) {
+    return lhs *= rhs;
+}
+
+vector operator/( vector lhs, vector::scalar rhs ) {
+    return lhs /= rhs;
+}
+
+vector::scalar operator*( const vector& lhs, const vector& rhs ) {
+    assert( lhs.size() == rhs.size() );
+     
+    return dot( lhs, rhs );
+}
+
+bool vector::operator==( const vector& other ) const {
+    PetscBool eq;
+    VecEqual( this->ptr(), other, &eq );
+    return eq;
+}
+
+bool vector::operator!=( const vector& other ) const {
+    return !( *this == other );
+}
+
+inline void vector::set( const vector::scalar* values,
+        const vector::size_type* indices,
+        vector::size_type size ) {
+
+    auto err = VecSetValues( this->ptr(), size,
+            indices, values, INSERT_VALUES ); CHKERRXX( err );
+
+    err = VecAssemblyBegin( this->ptr() ); CHKERRXX( err );
+    err = VecAssemblyEnd( this->ptr() ); CHKERRXX( err );
+}
+
+inline Vec vector::ptr() const {
+    return this->v.get();
+}
+
+vector::scalar dot( const vector& lhs, const vector& rhs ) {
+    vector::scalar x;
+    VecDot( lhs, rhs, &x );
+    return x;
+}
+
+vector::scalar sum( const vector& v ) {
+    vector::scalar x;
+    auto err = VecSum( v, &x ); CHKERRXX( err );
+    return x;
+}
+
+vector::scalar max( const vector& v ) {
+    vector::scalar x;
+    auto err = VecMax( v, NULL, &x ); CHKERRXX( err );
+    return x;
+}
+
+vector::scalar min( const vector& v ) {
+    vector::scalar x;
+    auto err = VecMin( v, NULL, &x ); CHKERRXX( err );
+    return x;
+}
+
+}
+}

--- a/opm/core/linalg/petscvector.cpp
+++ b/opm/core/linalg/petscvector.cpp
@@ -134,6 +134,26 @@ vector& vector::operator/=( vector::scalar rhs ) {
     return *this *= ( 1 / rhs );
 }
 
+vector& vector::operator+=( const vector& rhs ) {
+    /* VecAXPY breaks if the vectors are not different. If they are equal,
+     * *this += *this, then it is equal to *this *= 2.
+     */
+    if( this->ptr() == rhs.ptr() ) return *this *= 2;
+
+    auto err = VecAXPY( this->ptr(), 1, rhs ); CHKERRXX( err );
+    return *this;
+}
+
+vector& vector::operator-=( const vector& rhs ) {
+    /* VecAXPY breaks if the vectors are not different. In the case of
+     * *this -= *this, this is identical to assign( 0 ) or *this *= 0.
+     */
+    if( this->ptr() == rhs.ptr() ) return *this *= 0;
+
+    auto err = VecAXPY( this->ptr(), -1, rhs ); CHKERRXX( err );
+    return *this;
+}
+
 vector operator+( vector lhs, vector::scalar rhs ) {
     return lhs += rhs;
 }
@@ -150,9 +170,17 @@ vector operator/( vector lhs, vector::scalar rhs ) {
     return lhs /= rhs;
 }
 
+vector operator+( vector lhs, const vector& rhs ) {
+    return lhs += rhs;
+}
+
+vector operator-( vector lhs, const vector& rhs ) {
+    return lhs -= rhs;
+}
+
 vector::scalar operator*( const vector& lhs, const vector& rhs ) {
     assert( lhs.size() == rhs.size() );
-     
+
     return dot( lhs, rhs );
 }
 

--- a/opm/core/linalg/petscvector.hpp
+++ b/opm/core/linalg/petscvector.hpp
@@ -1,0 +1,119 @@
+#ifndef OPM_PETSCVECTOR_H
+#define OPM_PETSCVECTOR_H
+
+/*
+ * C++ bindings to petsc Vec.
+ *
+ * Provides an easy-to-use C++-esque implementation with no extra indirection
+ * for petsc Vec. Slightly radical in design, but in spirit with petsc: no
+ * direct memory access is allowed, and no iterators are provided. Due to the
+ * nature of petsc there usually is no guarantee that the memory you want to
+ * access lives in your process. All interactions with the vector should happen
+ * through functions - possibly general higher-order functions at a later time.
+ *
+ * The idea is to get (some) of petsc's power, but easier to use. Tested to
+ * without effort be able to use MPI. Supports arithmetic operators and should
+ * be easy to reason about. Lifetime is managed through unique_ptr for safety
+ * and simplicity - no need to implement custom assignment and move operators.
+ *
+ * Note that a default-constructed vector is NOT allowed. While this makes it
+ * slightly harder to use in a class (you most likely shouldn't anyways), it
+ * disallows more invalid states at compile-time.
+ *
+ * Also note that there are no set-methods for values. This is by design, but
+ * they might be added later if there is a need for it. Structurally, this
+ * leaves the vector immutable.
+ *
+ * Please note that all methods in the vector class only deal with it's
+ * structure. This is by design - everything needed to compute something about
+ * the vector is or will be provided as free functions, in order to keep
+ * responsibilities separate.
+ *
+ * The vector gives no guarantees for internal representation.
+ *
+ * TODO: When full C++11 support can be used, most constructors can be
+ * rewritten to use ineheriting constructors.
+ */
+
+#include <opm/core/linalg/petsc.hpp>
+
+#include <petscvec.h>
+
+#include <memory>
+#include <vector>
+
+namespace Opm {
+namespace petsc {
+
+    class vector {
+        public:
+            typedef PetscScalar scalar;
+            typedef PetscInt size_type;
+
+            /* Just take ownership over a given Vec. */
+            explicit vector( Vec );
+            vector( const vector& );
+
+            explicit vector( size_type );
+            explicit vector( size_type, scalar );
+
+            vector( const std::vector< scalar >& );
+            vector( const std::vector< scalar >&,
+                    const std::vector< size_type >& indexset );
+
+            vector( const scalar*, size_type );
+            vector( const scalar*, const size_type* indexset, size_type );
+
+            /* implicit conversion to Vec.
+             *
+             * We want this so the class can be dropped into petsc functions.
+             */
+            operator Vec() const;
+
+            size_type size() const;
+
+            /* assign a value to -all- cells */
+            void assign( scalar );
+
+            vector& operator+=( scalar );
+            vector& operator-=( scalar );
+            vector& operator*=( scalar );
+            vector& operator/=( scalar );
+
+            /* these currently do not have to be friends (since vector is
+             * implicitly convertible), but they are for least possible
+             * surprise
+             */
+            friend vector operator+( vector, scalar );
+            friend vector operator-( vector, scalar );
+            friend vector operator*( vector, scalar );
+            friend vector operator/( vector, scalar );
+
+            friend scalar operator*( const vector&, const vector& );
+
+            bool operator==( const vector& ) const;
+            bool operator!=( const vector& ) const;
+
+        private:
+            vector();
+
+            /* We rely on unique_ptr to manage lifetime semantics. */
+            struct del { void operator()( Vec v ) { VecDestroy( &v ); } };
+            std::unique_ptr< _p_Vec, del > v;
+
+            inline void set( const scalar*, const size_type*, size_type );
+
+            /* a convenient, explicit way to get the underlying Vec */
+            inline Vec ptr() const;
+    };
+
+    vector::scalar dot( const vector&, const vector& );
+
+    vector::scalar sum( const vector& );
+    vector::scalar max( const vector& );
+    vector::scalar min( const vector& );
+
+}
+}
+
+#endif //OPM_PETSCVECTOR_H

--- a/opm/core/linalg/petscvector.hpp
+++ b/opm/core/linalg/petscvector.hpp
@@ -117,6 +117,13 @@ namespace petsc {
             /// \param[in] scalar   Value to scale with
             vector& operator/=( scalar );
 
+            /// Vector addition, X + Y.
+            /// \param[in] vector   Vector to add
+            vector& operator+=( const vector& );
+            /// Vector subtraction, X - Y.
+            /// \param[in] vector   Vector to subtract
+            vector& operator-=( const vector& );
+
             /* these currently do not have to be friends (since vector is
              * implicitly convertible), but they are for least possible
              * surprise
@@ -126,6 +133,8 @@ namespace petsc {
             friend vector operator*( vector, scalar );
             friend vector operator/( vector, scalar );
 
+            friend vector operator+( vector, const vector& );
+            friend vector operator-( vector, const vector& );
             friend scalar operator*( const vector&, const vector& );
 
             /// Equality check

--- a/opm/core/linalg/petscvector.hpp
+++ b/opm/core/linalg/petscvector.hpp
@@ -45,39 +45,76 @@
 namespace Opm {
 namespace petsc {
 
+    /// Class implementing C++-support for PETSc's Vec object. Provides no
+    /// extra indirection and can be used as a handle for vanilla PETSc
+    /// functions, should the need be.
+
     class vector {
         public:
             typedef PetscScalar scalar;
             typedef PetscInt size_type;
 
-            /* Just take ownership over a given Vec. */
+            /// Takes ownership of a Vec produced by some other means. The
+            /// destruction and lifetime is now managed by vector
             explicit vector( Vec );
+            /// Copy constructor
             vector( const vector& );
 
+            /// Constructor. Does not populate the vector with values.
+            /// \param[in] size     Number of elements
             explicit vector( size_type );
+            /// Constructor. Populate [0..n-1] with scalar. This is equivalent
+            /// vector v( size ); v.assign( scalar );
+            /// \param[in]  size    Number of elements
+            /// \param[in]  scalar  Value to set
             explicit vector( size_type, scalar );
 
+            /// Construct from std::vector.
+            /// \param[in] vector   std::vector to copy from
             vector( const std::vector< scalar >& );
+            /// Construct from std::vector at the indices provided by
+            /// indexset. Negative indices are ignored.
+            /// \param[in] vector   std::vector to copy from
+            /// \param[in] indexset indices to assign values from the vector.
             vector( const std::vector< scalar >&,
                     const std::vector< size_type >& indexset );
 
+            /// Construct from array. Provided to support legacy APIs and
+            /// C or C-style libraries. Works like the std::vector-constructor,
+            /// but with raw arrays.
+            /// \param[in] vector   array to copy from
+            /// \param[in] size     size of the array
             vector( const scalar*, size_type );
+            /// Construct from array at the indices provided by indexset.
+            /// Provided to support legacy APIs and C or C-style libraries.
+            /// Works like the std::vector-constructor, but with raw arrays.
+            /// \param[in] vector   array to copy from
+            /// \param[in] indexset indices to assign values from the vector.
+            /// \param[in] size     size of the array
             vector( const scalar*, const size_type* indexset, size_type );
 
-            /* implicit conversion to Vec.
-             *
-             * We want this so the class can be dropped into petsc functions.
-             */
+            /// Implicit conversion to Vec for compability with PETSc functions
             operator Vec() const;
 
+            /// Get vector size.
+            /// \param[out] size    Number of elements in the vector
             size_type size() const;
 
-            /* assign a value to -all- cells */
+            /// Assign a value to all elements in the vector.
+            /// \param[in] scalar  The value all elements will have
             void assign( scalar );
 
+            /// Add a value to all elements in the vector
+            /// \param[in] scalar   Value to add to all elements
             vector& operator+=( scalar );
+            /// Subtract a value from all elements in the vector
+            /// \param[in] scalar   Value to subtract from all elements
             vector& operator-=( scalar );
+            /// Scalar multiplication
+            /// \param[in] scalar   Value to scale with
             vector& operator*=( scalar );
+            /// Inverse scalar multiplication (division)
+            /// \param[in] scalar   Value to scale with
             vector& operator/=( scalar );
 
             /* these currently do not have to be friends (since vector is
@@ -91,7 +128,11 @@ namespace petsc {
 
             friend scalar operator*( const vector&, const vector& );
 
+            /// Equality check
+            /// \param[out] eq  Returns true if equal, false if not
             bool operator==( const vector& ) const;
+            /// Unequality check
+            /// \param[out] eq  Returns false if equal, true if not
             bool operator!=( const vector& ) const;
 
         private:
@@ -107,10 +148,14 @@ namespace petsc {
             inline Vec ptr() const;
     };
 
+    /// Calculate the dot product of two vectors
     vector::scalar dot( const vector&, const vector& );
 
+    /// Calculate the sum of all values in the vector
     vector::scalar sum( const vector& );
+    /// Find the biggest element in the vector
     vector::scalar max( const vector& );
+    /// Find the smallest element in the vector
     vector::scalar min( const vector& );
 
 }

--- a/tests/test_petscvector.cpp
+++ b/tests/test_petscvector.cpp
@@ -101,6 +101,8 @@ BOOST_AUTO_TEST_CASE(test_petscvector_arithmetic) {
 
     vector vec1( range( 0.0, 10.0 ) );
     vector vec_add_target( range( 2.0, 12.0 ) );
+    vector vec_empty( 10, 0.0 );
+
     auto vec_add = vec1 + 2;
     auto vec_sub = vec_add_target - 2;
 
@@ -112,6 +114,7 @@ BOOST_AUTO_TEST_CASE(test_petscvector_arithmetic) {
     BOOST_CHECK( vec_sub == vec1 );
     BOOST_CHECK( vec_mul == vec_mul_target );
     BOOST_CHECK( vec_div == vec1 );
+    BOOST_CHECK( vec_empty == vec1 - vec1 );
 }
 
 BOOST_AUTO_TEST_CASE(test_petscvector_functional) {

--- a/tests/test_petscvector.cpp
+++ b/tests/test_petscvector.cpp
@@ -1,0 +1,127 @@
+#include <config.h>
+
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscvector.hpp>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+#define BOOST_TEST_MODULE MatrixTest
+#define BOOST_TEST_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+int argc = 0;
+char** argv = 0;
+Opm::petsc::petsc handle( &argc, &argv, NULL, "help" );
+
+template< class ForwardIterator, class T >
+static inline void iota( ForwardIterator first, ForwardIterator last, T value, T step ) {
+    while(first != last) { 
+        *first++ = value;
+        value += step;
+    }
+}
+
+template< typename T >
+static inline std::vector< T > range( T begin, T end, T step = T( 1 ) ) {
+    using namespace std;
+
+    std::vector< T > x( ( end - begin ) / step );
+    /* if std::iota is available, the function defined above shouldn't be
+     * compiled in and std::iota should be used
+     */
+    iota( x.begin(), x.end(), begin, step );
+    return x;
+}
+
+static void have_public_types() {
+    typename Opm::petsc::vector::scalar scalar;
+    typename Opm::petsc::vector::size_type size_type;
+
+    /*
+     * Ignore "unused variable" warnings
+     */
+    (void) scalar;
+    (void) size_type;
+}
+
+BOOST_AUTO_TEST_CASE(test_petscvector_coverage) {
+    /* Test that the required public types are exposed.
+     *
+     * Will provide compile error if not
+     */
+    have_public_types();
+}
+
+BOOST_AUTO_TEST_CASE(test_petscvector_constructors) {
+    using Opm::petsc::vector;
+
+    /* Create reference vector petsc styles. */
+    Vec vec_petsc;
+    VecCreate( PETSC_COMM_WORLD, &vec_petsc );
+    VecSetSizes( vec_petsc, PETSC_DECIDE, 10 );
+    VecSetFromOptions( vec_petsc );
+
+    /* ownership transferring constructor */
+    vector vector_petsc( vec_petsc );
+
+    /* test copy constructor */
+    auto vector_copy = vector( vector_petsc );
+
+    vector vector_size( 10 );
+    vector vector_size_elems( 10, 0.0 );
+
+    /* construction from std::vector */
+    std::vector< vector::scalar > std_vec( 10, 0.0 );
+    auto stdidx = range( 0, 10 );
+    vector vector_from_stdvec( std_vec );
+    vector vector_from_stdidx( std_vec, stdidx );
+
+    /* construct from raw arrays */
+    double vals[] = { 0.0, 1.0, 2.0, 3.0, 4.0 };
+    int idx[] = { 0, 1, 2, 3, 4 };
+    vector vector_from_array( vals, 5 );
+    vector vector_from_idx( vals, idx, 5 );
+
+    BOOST_CHECK( vector_copy == vector_petsc );
+    BOOST_CHECK( vector_from_stdvec == vector_from_stdidx );
+    BOOST_CHECK( vector_from_array == vector_from_idx );
+
+    BOOST_CHECK( !( vector_copy != vector_petsc ) );
+    BOOST_CHECK( !( vector_from_stdvec != vector_from_stdidx ) );
+    BOOST_CHECK( !( vector_from_array != vector_from_idx ) );
+}
+
+BOOST_AUTO_TEST_CASE(test_petscvector_arithmetic) {
+    using Opm::petsc::vector;
+
+
+    vector vec1( range( 0.0, 10.0 ) );
+    vector vec_add_target( range( 2.0, 12.0 ) );
+    auto vec_add = vec1 + 2;
+    auto vec_sub = vec_add_target - 2;
+
+    vector vec_mul_target( range( 0.0, 30.0, 3.0 ) );
+    auto vec_mul = vec1 * 3;
+    auto vec_div = vec_mul_target / 3;
+
+    BOOST_CHECK( vec_add == vec_add_target );
+    BOOST_CHECK( vec_sub == vec1 );
+    BOOST_CHECK( vec_mul == vec_mul_target );
+    BOOST_CHECK( vec_div == vec1 );
+}
+
+BOOST_AUTO_TEST_CASE(test_petscvector_functional) {
+    using Opm::petsc::vector;
+
+    vector vec1( range( 0.0, 10.0 ) );
+    vector vec2( range( 0.0, 20.0, 2.0 ) );
+
+    BOOST_CHECK( ( vec1 * vec2 ) == 570.0 );
+    BOOST_CHECK( Opm::petsc::max( vec1 ) ==  9.0 );
+    BOOST_CHECK( Opm::petsc::min( vec1 ) ==  0.0 );
+    BOOST_CHECK( Opm::petsc::sum( vec1 ) == 45.0 );
+}


### PR DESCRIPTION
This patchset introduces better petsc session management through Opm::petsc::petsc class, as well as a C++ vector implementation over the petsc vector.

The vector implementation introduces no extra indirection, and should with good inlining hardly introduce overhead at all. It is designed around RAII, and should be quite easy to use. Tests included.

The design is slightly radical, in the sense that it won't (partially for technical reasons) provide any form of direct memory acccess. It will instead provide interfaces, and some are implemented, for manipulating the vector functionally, which should hopefully provide benefits for parallelism.

Local testing demonstrates that an MPI-oriented vector is trivial to accomplish. It can used without modifications in petsc functions, which can be a nice tool in development.
