### PR TITLE
Build system update

### DIFF
--- a/cmake/Modules/FindMETIS.cmake
+++ b/cmake/Modules/FindMETIS.cmake
@@ -20,7 +20,7 @@ endif()
 find_path (METIS_INCLUDE_DIRS
   NAMES "metis.h"
   PATHS ${METIS_SEARCH_PATH}
-  PATH_SUFFIXES "include" "METISLib"
+  PATH_SUFFIXES "include" "METISLib" "include/metis"
   ${METIS_NO_DEFAULT_PATH})
 
 # only search in architecture-relevant directory
@@ -39,7 +39,7 @@ if (METIS_INCLUDE_DIRS OR METIS_LIBRARIES)
   set(METIS_FOUND TRUE)
   set(HAVE_METIS TRUE)
 endif()
-  
+
 # print a message to indicate status of this package
 include (FindPackageHandleStandardArgs)
 find_package_handle_standard_args(METIS

--- a/cmake/Modules/FindZOLTAN.cmake
+++ b/cmake/Modules/FindZOLTAN.cmake
@@ -1,0 +1,51 @@
+# -*-cmake-*-
+#
+# Try to find the libzoltan graph partioning library
+#
+# Once done, this will define:
+#
+#  ZOLTAN_FOUND        - system has the libzoltan graph partioning library
+#  HAVE_ZOLTAN         - like ZOLTAN_FOUND, but for the inclusion in config.h
+#  ZOLTAN_INCLUDE_DIR  - incude paths to use libzoltan
+#  ZOLTAN_LIBRARIES    - Link these to use libzoltan
+
+set(ZOLTAN_SEARCH_PATH "/usr" "/usr/local" "/opt" "/opt/local")
+set(ZOLTAN_NO_DEFAULT_PATH "")
+if(ZOLTAN_ROOT)
+  set(ZOLTAN_SEARCH_PATH "${ZOLTAN_ROOT}")
+  set(ZOLTAN_NO_DEFAULT_PATH "NO_DEFAULT_PATH")
+endif()
+
+# search for files which implements this module
+find_path (ZOLTAN_INCLUDE_DIRS
+  NAMES "zoltan.h"
+  PATHS ${ZOLTAN_SEARCH_PATH}
+  PATH_SUFFIXES "include" 
+  ${ZOLTAN_NO_DEFAULT_PATH})
+
+# only search in architecture-relevant directory
+if (CMAKE_SIZEOF_VOID_P)
+  math (EXPR _BITS "8 * ${CMAKE_SIZEOF_VOID_P}")
+endif (CMAKE_SIZEOF_VOID_P)
+
+find_library(ZOLTAN_LIBRARIES
+  NAMES "zoltan"
+  PATHS ${ZOLTAN_SEARCH_PATH}
+  PATH_SUFFIXES "lib/.libs" "lib" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+  ${ZOLTAN_NO_DEFAULT_PATH})
+
+set (ZOLTAN_FOUND FALSE)
+if (ZOLTAN_INCLUDE_DIRS OR ZOLTAN_LIBRARIES)
+  set(ZOLTAN_FOUND TRUE)
+  set(HAVE_ZOLTAN 1)
+endif()
+
+set (ZOLTAN_CONFIG_VAR HAVE_ZOLTAN)
+  
+# print a message to indicate status of this package
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ZOLTAN
+  DEFAULT_MSG
+  ZOLTAN_LIBRARIES
+  ZOLTAN_INCLUDE_DIRS
+  )

--- a/cmake/Modules/Finddune-alugrid.cmake
+++ b/cmake/Modules/Finddune-alugrid.cmake
@@ -22,6 +22,7 @@ find_opm_package (
   "CXX11Features REQUIRED;
    dune-grid REQUIRED;
    ZLIB REQUIRED;
+   ZOLTAN;
    METIS
   "
   # header to search for

--- a/cmake/Modules/ewoms-prereqs.cmake
+++ b/cmake/Modules/ewoms-prereqs.cmake
@@ -1,10 +1,15 @@
 # -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t; compile-command: "cmake -Wdev" -*-
 # vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
 
+# this avoids an annoying deprecation warning on DUNE 2.4 (which we
+# are not interested in anyway)
+set(DUNE_AVOID_CAPABILITIES_IS_PARALLEL_DEPRECATION_WARNING 1)
+
 # defines that must be present in config.h for our headers
 set (ewoms_CONFIG_VAR
 	HAVE_QUAD
 	HAVE_VALGRIND
+	DUNE_AVOID_CAPABILITIES_IS_PARALLEL_DEPRECATION_WARNING
 	)
 
 # dependencies


### PR DESCRIPTION
this PR contains a few smallish build system updates which enable ZOLTAN for alugrid, fix the METIS detection on some distributions and work around a dune 2.4 deprecation warning (the last patch is pretty hacky, but the dune build system does this in a similar way). most of the work was done by @dr-robertk.