### PR TITLE
PETSc support: matrix

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -50,6 +50,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/core/linalg/LinearSolverIstl.cpp
 	opm/core/linalg/LinearSolverUmfpack.cpp
 	opm/core/linalg/LinearSolverPetsc.cpp
+	opm/core/linalg/petscvector.cpp
 	opm/core/linalg/petsc.cpp
 	opm/core/linalg/call_umfpack.c
 	opm/core/linalg/sparse_sys.c
@@ -165,6 +166,7 @@ list (APPEND TEST_SOURCE_FILES
 	tests/test_event.cpp
 	tests/test_nonuniformtablelinear.cpp
 	tests/test_sparsevector.cpp
+	tests/test_petscvector.cpp
 	tests/test_sparsetable.cpp
 	tests/test_velocityinterpolation.cpp
 	tests/test_quadratures.cpp
@@ -293,6 +295,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/linalg/LinearSolverUmfpack.hpp
 	opm/core/linalg/LinearSolverPetsc.hpp
 	opm/core/linalg/petsc.hpp
+	opm/core/linalg/petscvector.hpp
 	opm/core/linalg/blas_lapack.h
 	opm/core/linalg/call_umfpack.h
 	opm/core/linalg/sparse_sys.h

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -50,6 +50,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/core/linalg/LinearSolverIstl.cpp
 	opm/core/linalg/LinearSolverUmfpack.cpp
 	opm/core/linalg/LinearSolverPetsc.cpp
+	opm/core/linalg/petsc.cpp
 	opm/core/linalg/call_umfpack.c
 	opm/core/linalg/sparse_sys.c
 	opm/core/pressure/CompressibleTpfa.cpp
@@ -291,6 +292,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/linalg/LinearSolverIstl.hpp
 	opm/core/linalg/LinearSolverUmfpack.hpp
 	opm/core/linalg/LinearSolverPetsc.hpp
+	opm/core/linalg/petsc.hpp
 	opm/core/linalg/blas_lapack.h
 	opm/core/linalg/call_umfpack.h
 	opm/core/linalg/sparse_sys.h

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -51,6 +51,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/core/linalg/LinearSolverUmfpack.cpp
 	opm/core/linalg/LinearSolverPetsc.cpp
 	opm/core/linalg/petscvector.cpp
+	opm/core/linalg/petscmatrix.cpp
 	opm/core/linalg/petsc.cpp
 	opm/core/linalg/call_umfpack.c
 	opm/core/linalg/sparse_sys.c
@@ -167,6 +168,7 @@ list (APPEND TEST_SOURCE_FILES
 	tests/test_nonuniformtablelinear.cpp
 	tests/test_sparsevector.cpp
 	tests/test_petscvector.cpp
+	tests/test_petscmatrix.cpp
 	tests/test_sparsetable.cpp
 	tests/test_velocityinterpolation.cpp
 	tests/test_quadratures.cpp
@@ -296,6 +298,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/linalg/LinearSolverPetsc.hpp
 	opm/core/linalg/petsc.hpp
 	opm/core/linalg/petscvector.hpp
+	opm/core/linalg/petscmatrix.hpp
 	opm/core/linalg/blas_lapack.h
 	opm/core/linalg/call_umfpack.h
 	opm/core/linalg/sparse_sys.h

--- a/opm/core/linalg/petsc.cpp
+++ b/opm/core/linalg/petsc.cpp
@@ -1,0 +1,20 @@
+#include <opm/core/linalg/petsc.hpp>
+
+namespace Opm {
+namespace petsc {
+
+petsc::petsc(
+        int* argc,
+        char*** argv,
+        const char* file,
+        const char* help ) {
+
+    PetscInitialize( argc, argv, file, help );
+}
+
+petsc::~petsc() {
+    PetscFinalize();
+}
+
+}
+}

--- a/opm/core/linalg/petsc.hpp
+++ b/opm/core/linalg/petsc.hpp
@@ -1,0 +1,31 @@
+#ifndef OPM_PETSC_H
+#define OPM_PETSC_H
+
+/*
+ * This file introduces the Opm::petsc namespace for petsc support, as well as
+ * a RAII helper class to manage the lifetime of the petsc database and MPI
+ * use.
+ */
+
+#define PETSC_CLANGUAGE_CXX 1 //For CHKERRXX macro
+#include <petsc.h>
+
+namespace Opm {
+namespace petsc {
+
+/*
+ * Initialize this class at the start of your program, and pass argc and argv
+ * from main, then forget about it. This object must be alive before any other
+ * petsc feature is used.
+ */
+
+class petsc {
+    public:
+        petsc( int* argc, char*** argv, const char* file, const char* help );
+        ~petsc();
+};
+
+}
+}
+
+#endif //OPM_PETSC_H

--- a/opm/core/linalg/petscmatrix.cpp
+++ b/opm/core/linalg/petscmatrix.cpp
@@ -1,0 +1,420 @@
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscvector.hpp>
+#include <opm/core/linalg/petscmatrix.hpp>
+
+#include <cassert>
+#include <memory>
+#include <utility>
+#include <vector>
+
+/* Slight hack to get things working. This sets the communicator used when
+ * constructing new vectors - however, this should be configurable. When full
+ * petsc support is figured out this will be changed.
+ */
+static inline MPI_Comm get_comm() { return PETSC_COMM_WORLD; }
+
+/* ideally replace this with C++11's std::iota */
+#ifndef HAVE_STD_IOTA
+template< class ForwardIterator, class T >
+static inline void iota( ForwardIterator first, ForwardIterator last, T value ) {
+        while(first != last) *first++ = value++;
+}
+#endif //HAVE_STD_IOTA
+
+template< typename T = Opm::petsc::matrix::size_type, typename U >
+static inline std::vector< T > range( U begin, U end ) {
+    using namespace std;
+
+    std::vector< T > x( end - begin );
+    /* if std::iota is available, the function defined above shouldn't be
+     * compiled in and std::iota should be used
+     */
+    iota( x.begin(), x.end(), begin );
+    return x;
+}
+
+namespace Opm {
+namespace petsc {
+
+/*
+ * Trivial translation between the strongly typed enum and the
+ * implicit-convertible MatStructure enum.
+ */
+static inline MatStructure
+nz_structure( matrix::nonzero_pattern x ) {
+    switch( x ) {
+        case matrix::nonzero_pattern::different:
+            return DIFFERENT_NONZERO_PATTERN;
+
+        case matrix::nonzero_pattern::subset:
+            return SUBSET_NONZERO_PATTERN;
+
+        case matrix::nonzero_pattern::same:
+            return SAME_NONZERO_PATTERN;
+    }
+
+    assert( false );
+    /* To silence non-void without return statement warning. This should never
+     * be reached anyways, and is a sure error.
+     */
+    throw;
+}
+
+matrix::matrix() {
+    /* Meant to be used by other constructors. */
+    Mat x;
+    MatCreate( get_comm(), &x );
+    MatSetFromOptions( x );
+
+    this->m.reset( x );
+}
+
+matrix::matrix( Mat x ) : m( x ) {}
+
+matrix::matrix( const matrix& x ) {
+    Mat y;
+    auto err = MatDuplicate( x, MAT_COPY_VALUES, &y ); CHKERRXX( err );
+    err = MatCopy( x, y, SAME_NONZERO_PATTERN ); CHKERRXX( err );
+
+    this->m.reset( y );
+}
+
+matrix::matrix( const matrix::builder& builder ) : m( builder.commit().m ) {}
+
+matrix::matrix( matrix::builder&& builder ) :
+    /* assemble and move the builder's matrix object into this one */
+    m( builder.assemble().m.m.release() ) 
+{}
+
+matrix::matrix( matrix::size_type rows, matrix::size_type cols ) {
+    matrix mat;
+
+    this->m.swap( mat.m );
+
+    auto err = MatSetSizes( this->ptr(),
+            PETSC_DECIDE, PETSC_DECIDE,
+            rows, cols );
+    CHKERRXX( err );
+}
+
+matrix::matrix( const std::vector< matrix::scalar >& values,
+                matrix::size_type rows,
+                matrix::size_type cols ) {
+
+    assert( values.size() == rows * cols );
+
+    /* We know we want a dense matrix from this constructor, so we can afford
+     * to assume MatCreateDense is the right call
+     */
+    Mat mat;
+    auto err = MatCreateDense( get_comm(),
+                        PETSC_DECIDE, PETSC_DECIDE,
+                        rows, cols,
+                        NULL, &mat );
+    CHKERRXX( err );
+    this->m.reset( mat );
+
+    const auto indices = range( 0, std::max( rows, cols ) );
+
+    err = MatSetValues( this->ptr(),
+                    rows, indices.data(),
+                    cols, indices.data(),
+                    values.data(), INSERT_VALUES );
+    CHKERRXX( err );
+
+    err = MatAssemblyBegin( this->ptr(), MAT_FINAL_ASSEMBLY );
+    CHKERRXX( err );
+    err = MatAssemblyEnd( this->ptr(), MAT_FINAL_ASSEMBLY );
+    CHKERRXX( err );
+}
+
+matrix::operator Mat() const {
+    return this->m.get();
+}
+
+matrix::size_type matrix::rows() const {
+    PetscInt x;
+    auto err = MatGetSize( this->ptr(), &x, NULL ); CHKERRXX( err );
+    return x;
+}
+
+matrix::size_type matrix::cols() const {
+    PetscInt x;
+    auto err = MatGetSize( this->ptr(), NULL, &x ); CHKERRXX( err );
+    return x;
+}
+
+matrix& matrix::operator*=( matrix::scalar rhs ) {
+    auto err = MatScale( this->ptr(), rhs ); CHKERRXX( err );
+    return *this;
+}
+
+matrix& matrix::operator/=( matrix::scalar rhs ) {
+    return *this *= ( 1 / rhs );
+}
+
+matrix& matrix::operator+=( const matrix& rhs ) {
+    return this->axpy( rhs, 1, nonzero_pattern::different );
+}
+
+matrix& matrix::operator-=( const matrix& rhs ) {
+    return this->axpy( rhs, -1, nonzero_pattern::different );
+}
+
+matrix& matrix::operator*=( const matrix& rhs ) {
+    return this->multiply( rhs );
+}
+
+matrix operator*( matrix lhs, matrix::scalar rhs ) {
+    return lhs *= rhs;
+}
+
+matrix operator*( matrix::scalar lhs, matrix rhs ) {
+    return rhs *= lhs;
+}
+
+matrix operator/( matrix lhs, matrix::scalar rhs ) {
+    return lhs /= rhs;
+}
+
+matrix operator+( matrix lhs, const matrix& rhs ) {
+    return lhs += rhs;
+}
+
+matrix operator-( matrix lhs, const matrix& rhs ) {
+    return lhs -= rhs;
+}
+
+matrix operator*( const matrix& lhs, const matrix& rhs ) {
+    return multiply( lhs, rhs );
+}
+
+vector operator*( const matrix& lhs, const vector& rhs ) {
+    return multiply( lhs, rhs );
+}
+
+vector operator*( const vector& lhs, const matrix& rhs ) {
+    return multiply( rhs, lhs );
+}
+
+bool identical( const matrix& lhs, const matrix& rhs ) {
+    /* Comparing a matrix to itself means they're obviously identical */
+    if( lhs.ptr() == rhs.ptr() ) return true;
+
+    /* PETSc throws an exception if matrices are of different sizes. Because
+     * two matrices of different sizes -cannot- be equal, we check this first
+     */
+    PetscInt row_lhs, col_lhs, row_rhs, col_rhs;
+    auto err = MatGetSize( lhs, &row_lhs, &col_lhs ); CHKERRXX( err );
+    err = MatGetSize( rhs, &row_rhs, &col_rhs ); CHKERRXX( err );
+
+    if( row_lhs != row_rhs ) return false;
+    if( col_lhs != col_rhs ) return false;
+
+    /* MatEqual also considers structure when testing for equality. See:
+     * http://lists.mcs.anl.gov/pipermail/petsc-users/2015-January/024059.html
+     */
+    PetscBool eq;
+    err = MatEqual( lhs, rhs, &eq ); CHKERRXX( err );
+    return eq;
+}
+
+matrix& matrix::axpy(
+        const matrix& x,
+        matrix::scalar a,
+        matrix::nonzero_pattern nz ) {
+
+    auto err = MatAXPY( this->ptr(), a, x, nz_structure( nz ) );
+    CHKERRXX( err );
+
+    return *this;
+}
+
+matrix& matrix::xpy( const matrix& x, matrix::nonzero_pattern nz ) {
+    return this->axpy( x, 1, nz );
+}
+
+matrix& matrix::multiply( const matrix& x ) {
+    auto err = MatMatMult( this->ptr(), x,
+            MAT_REUSE_MATRIX, PETSC_DEFAULT, NULL );
+    CHKERRXX( err );
+
+    return *this;
+}
+
+matrix& matrix::transpose() {
+    Mat handle = this->ptr();
+    auto err = MatTranspose( handle, MAT_REUSE_MATRIX, &handle );
+    CHKERRXX( err );
+
+    return *this;
+}
+
+matrix& matrix::hermitian_transpose() {
+    auto handle = this->ptr();
+    auto err = MatHermitianTranspose( handle,
+            MAT_REUSE_MATRIX, &handle );
+    CHKERRXX( err );
+
+    return *this;
+}
+
+inline Mat matrix::ptr() const {
+    return this->m.get();
+}
+
+matrix multiply( const matrix& rhs, const matrix& lhs, matrix::scalar fill ) {
+    Mat x;
+    MatMatMult( rhs, lhs, MAT_INITIAL_MATRIX, fill, &x );
+
+    return matrix( x );
+}
+
+vector multiply( const matrix& lhs, const vector& rhs ) {
+    Vec x;
+    auto err = VecDuplicate( rhs, &x ); CHKERRXX( err );
+    MatMult( lhs, rhs, x );
+    return vector( x );
+}
+
+matrix transpose( const matrix& rhs ) {
+    Mat x;
+    MatTranspose( rhs, MAT_INITIAL_MATRIX, &x );
+    return matrix( x );
+}
+
+matrix hermitian_transpose( matrix rhs ) {
+    matrix x( rhs );
+    x.hermitian_transpose();
+    return x;
+}
+
+matrix::builder::builder( matrix::size_type rows, matrix::size_type cols ) :
+    m( matrix( rows, cols ) )
+{
+    auto err = MatSetUp( this->ptr() );
+    CHKERRXX( err );
+}
+
+matrix::builder::builder( const matrix::builder& x ) : m( x ) {}
+
+matrix::builder& matrix::builder::insert(
+        matrix::size_type row,
+        matrix::size_type col,
+        matrix::scalar value ) {
+
+    const size_type rows[] = { row };
+    const size_type cols[] = { col };
+    const scalar vals[] = { value };
+
+    auto err = MatSetValues( this->ptr(),
+            1, rows,
+            1, cols,
+            vals, INSERT_VALUES ); CHKERRXX( err );
+
+    return *this;
+}
+
+matrix::builder& matrix::builder::insert(
+        const std::vector< matrix::scalar >& nonzeros,
+        const std::vector< matrix::size_type >& row_indices,
+        const std::vector< matrix::size_type >& col_indices ) {
+
+    assert( nonzeros.size() == col_indices.size() );
+
+    for( unsigned int i = 0; i < row_indices.size() - 1; ++i ) {
+        /* the difference between two consecutive elements are the indices in
+         * the col&nonzero vectors where the current row i is stored
+         */
+        const auto row_entries = row_indices[ i + 1 ] - row_indices[ i ];
+
+        /* empty row - skip ahead */
+        if( !row_entries ) continue;
+
+        /* MatSetValues takes an array */
+        const matrix::size_type row_index[] = { matrix::size_type( i ) };
+
+        /* offset to start insertion from */
+        const auto offset = row_indices[ i ];
+
+        const auto err = MatSetValues( this->ptr(),
+                1, row_index,
+                row_entries, col_indices.data() + offset,
+                nonzeros.data() + offset, INSERT_VALUES );
+
+        CHKERRXX( err );
+    }
+
+    return *this;
+}
+
+matrix::builder& matrix::builder::insert_row(
+        matrix::size_type row,
+        const std::vector< matrix::scalar >& values,
+        matrix::size_type begin ) {
+
+    const auto indices = range( begin, size_type( begin + values.size() ) );
+
+    return this->insert_row( row, indices, values );
+}
+
+matrix::builder& matrix::builder::insert_row(
+        matrix::size_type row,
+        const std::vector< matrix::size_type >& indices,
+        const std::vector< matrix::scalar >& values ) {
+
+    /* MatSetValues takes an array */
+    const matrix::size_type row_index[] = { row };
+
+    const auto err = MatSetValues( this->ptr(),
+            1, row_index,
+            indices.size(), indices.data(),
+            values.data(), INSERT_VALUES );
+
+    CHKERRXX( err );
+
+    return *this;
+}
+
+matrix matrix::builder::commit() const {
+    /*
+     * This is a peculiar case. So commit (and copy) doesn't actually -change-
+     * the builder, but it does require mutability. the assemble method calls
+     * MatAssemble from PETSc which flushes the caches and sets up the matrix
+     * structure. However, this is an implementation detail, and the object
+     * that the builder exposes is oblivious to this. We use the const_cast
+     * trick to -appear- immutable, while we need mutability to flush our
+     * caches.
+     *
+     * This is ok because the -visible- object does not change, and is for all
+     * intents and purposes still const
+     */
+    return const_cast< builder& >( *this ).assemble().m;
+}
+
+matrix matrix::builder::move() {
+    /* 
+     * We assume that matrix' constructor( builder&& ) handles the actual move
+     * and assembly. The reason for this is that we want return builder; to
+     * construct matrices, and we want the move constructor to behave nicely.
+     * Furthermore, this leads to less code duplication.
+     */
+    return *this;
+}
+
+
+matrix::builder& matrix::builder::assemble() {
+    auto err = MatAssemblyBegin( this->ptr(), MAT_FINAL_ASSEMBLY );
+    CHKERRXX( err );
+    err = MatAssemblyEnd( this->ptr(), MAT_FINAL_ASSEMBLY );
+    CHKERRXX( err );
+
+    return *this;
+}
+
+inline Mat matrix::builder::ptr() const {
+    return this->m;
+}
+
+}
+}

--- a/opm/core/linalg/petscmatrix.hpp
+++ b/opm/core/linalg/petscmatrix.hpp
@@ -1,0 +1,256 @@
+#ifndef OPM_PETSCMATRIX_H
+#define OPM_PETSCMATRIX_H
+
+#include <opm/core/linalg/petsc.hpp>
+
+#include <petscmat.h>
+
+#include <memory>
+#include <vector>
+
+namespace Opm {
+namespace petsc {
+
+    class vector;
+
+    /// Class implementing C++-support for PETSc's Mat object. Provides no
+    /// extra indirection and can be used as a handle for vanilla PETSc
+    /// functions, should the need be.
+
+    class matrix {
+        public:
+            typedef PetscScalar scalar;
+            typedef PetscInt size_type;
+
+            enum class nonzero_pattern { different, subset, same };
+
+            /* Forward declaration of the (nested) builder class that is meant
+             * to build in place of the constructors
+             */
+            class builder;
+
+            /// Takes ownership of a Mat produced by some other means. The
+            /// destruction and lifetime is now managed by matrix. Provided for
+            /// compability with raw PETSc
+            explicit matrix( Mat );
+            /// Copy constructor
+            matrix( const matrix& );
+
+            matrix( const builder& );
+            matrix( builder&& );
+
+            /// Construct a (dense) matrix from std::vector
+            /// Interprets the vector as a logical rows*columns 2D array
+            /// \param[in] vector       Logically 2D std::vector to copy from
+            /// \param[in] rows         Number of rows
+            /// \param[in] columns      Number of columns
+            matrix( const std::vector< scalar >&, size_type, size_type );
+
+            /// Implicit conversion to Mat for compability with PETSc functions
+            operator Mat() const;
+
+            /// Get number of rows.
+            /// \param[out] size    Number of rows in the matrix
+            size_type rows() const;
+            /// Get number of cols.
+            /// \param[out] size    Number of columns in the matrix 
+            size_type cols() const;
+
+            /// Add a value to all elements in the matrix
+            /// \param[in] scalar   Value to add to all elements
+            //matrix& operator+=( scalar );
+            /// Subtract a value from all elements in the matrix
+            /// \param[in] scalar   Value to subtract from all elements
+            //matrix& operator-=( scalar );
+            /// Scalar multiplication
+            /// \param[in] scalar   Value to scale with
+            matrix& operator*=( scalar );
+            /// Inverse scalar multiplication (division)
+            /// \param[in] scalar   Value to scale with
+            matrix& operator/=( scalar );
+
+            /// Matrix addition, A + B.
+            /// Equivalent to axpy( x, 1, different ). If you know your
+            /// matrices have identical nonzero patterns, consider using axpy
+            /// instead
+            /// \param[in] matrix   Matrix to add
+            matrix& operator+=( const matrix& );
+            /// Matrix subtraction, A - B.
+            /// Equivalent to axpy( x, -1, different ). If you know your
+            /// matrices have identical nonzero patterns, consider using axpy
+            /// instead
+            /// \param[in] matrix   Matrix to add
+            matrix& operator-=( const matrix& );
+
+            /// A *= B, where A and B are matrices
+            /// Equivalent to multiply( B );
+            /// \param[in] B        The matrix B
+            matrix& operator*=( const matrix& );
+
+            /* these currently do not have to be friends (since matrix is
+             * implicitly convertible to Mat), but they are for least possible
+             * surprise
+             */
+            friend matrix operator*( matrix, scalar );
+            friend matrix operator*( scalar, matrix );
+            friend matrix operator/( matrix, scalar );
+
+            friend matrix operator+( matrix, const matrix& );
+            friend matrix operator-( matrix, const matrix& );
+            /// C = A * B
+            /// Equivalent to multiply( A, B )
+            /// \param[in] A    The matrix A
+            /// \param[in] B    The matrix B
+            friend matrix operator*( const matrix&, const matrix& );
+
+            /// y = Ax, matrix-vector multiplication
+            /// Equivalent to multiply( A, x )
+            friend vector operator*( const matrix&, const vector& );
+            friend vector operator*( const vector&, const matrix& );
+
+            /// Tests if two matrices are identical. This also checks matrix structure,
+            /// so two identical sparse matrices with different nonzero structure but
+            /// with explicit zeros will evaluate to false
+            friend bool identical( const matrix&, const matrix& );
+
+            /// A += aB
+            /// \param[in] B        The matrix B
+            /// \param[in] alpha    The constant alpha
+            /// \param[in] pattern  The nonzero pattern relationship
+            matrix& axpy( const matrix&, scalar, nonzero_pattern );
+
+            /// A += B, equivalent to axpy( matrix, 1, pattern )
+            /// \param[in] matrix   The matrix X
+            /// \param[in] alpha    The constant alpha
+            /// \param[in] pattern  The nonzero pattern relationship
+            matrix& xpy( const matrix&, nonzero_pattern );
+
+            /// A *= B, where A and B are matrices
+            /// Assumes, if sparse, that A and B have the same nonzero pattern
+            /// \param[in] B        The matrix B
+            matrix& multiply( const matrix& );
+
+            /// A *= B, where A and B are matrices
+            /// Assumes, if sparse, that A and B have the same nonzero pattern
+            /// \param[in] B        The matrix B
+            /// \param[in] fill     The nonzero fill ratio
+            /// nnz(C)/( nnz(A) + nnz(B) )
+            matrix& multiply( const matrix&, scalar fill );
+
+            /// In-place transposes the matrix, A <- A^T
+            matrix& transpose();
+
+            /// In-place hermitian transposes the matrix, A <- A^H
+            matrix& hermitian_transpose();
+
+        private:
+            matrix();
+            matrix( size_type, size_type );
+
+            /* We rely on unique_ptr to manage lifetime semantics. */
+            struct del { void operator()( Mat m ) { MatDestroy( &m ); } };
+            std::unique_ptr< _p_Mat, del > m;
+
+            template< typename T > T operator+( T );
+
+            /* a convenient, explicit way to get the underlying Mat */
+            inline Mat ptr() const;
+    };
+
+    /// Matrix-matrix multiplication. This is similar to operator*, but with
+    /// more flexibility as you can tune the fill. The expected fill ratio of
+    /// the multiplication C = A * B is nonzero(C)/(nonzero(A)+nonzero(B)).
+    /// Defaults to letting PETSc decide.
+    /// If experimenting, using PETSc's -info option can print the correct
+    /// ratio (under Fill ratio)
+    /// \param[in] A    Matrix A (left-hand side)
+    /// \param[in] B    Matrix B (right-hand side)
+    /// \param[in] fill (Optional) Matrix fill ratio
+    matrix multiply( const matrix&, const matrix&, matrix::scalar = PETSC_DECIDE );
+
+    /// Matrix-vector multiplication, y = Ax
+    /// \param[in] A    The matrix
+    /// \param[in] x    The vector
+    vector multiply( const matrix&, const vector& );
+
+    matrix transpose( const matrix& );
+    matrix hermitian_transpose( matrix );
+
+    class matrix::builder {
+        public:
+            typedef matrix::scalar scalar;
+            typedef matrix::size_type size_type;
+
+            builder() = delete;
+
+            /// Constructor. PETSc -needs- to know the dimensions of the matrix
+            /// beforehand, so a default constructor is not provided.
+            builder( size_type, size_type );
+
+            /// Copy constructor. Copies the currently built state. Particulary
+            /// useful when several matrices share some structure, but diverges
+            /// at a certain point
+            builder( const builder& );
+
+            /// Insert a single value. Defaults to 0 if you're only setting
+            /// nonzero structure
+            /// \param[in] row      The row to insert at
+            /// \param[in] col      The col to insert at
+            /// \param[in] value    (Optional) the value to insert.
+            builder& insert( size_type, size_type, scalar = scalar() );
+
+            /// Insert a full (sub)matrix in CSR format. This is more efficient
+            /// than inserting single values. If the (sub)matrix sets some
+            /// value previously set, that value will be overwritten by the
+            /// latest.
+            /// This might in the future be superseded by a stricter CSR type
+            /// \param[in]      nonzero     The CSR nonzero vector
+            builder& insert(    const std::vector< scalar >& nonzeros,
+                                const std::vector< size_type >& row_indices,
+                                const std::vector< size_type >& col_indices );
+
+            /// Insert a row into the matrix. Inserts from [begin, begin + vec.size())
+            /// This does not overwrite anything beyond vec.size()
+            /// \param[in] row      Row to insert
+            /// \param[in] values   Values to insert
+            /// \param[in] begin    Where in the row to start insertion
+            builder& insert_row(
+                    size_type,
+                    const std::vector< scalar >&,
+                    size_type = 0 );
+
+            /// Insert a row into the matrix at specific indices.
+            /// This does not overwrite anything not touched by the column
+            /// indices vector. Values must be equal in size to columns.
+            /// \param[in] row      Row to insert
+            /// \param[in] columns  Vector of column indices to insert
+            /// \param[in] values   Values to insert
+            builder& insert_row(    size_type,
+                                    const std::vector< size_type >&,
+                                    const std::vector< scalar >& );
+
+            /// Commit the currently built structure into a completed matrix.
+            /// This copies the currently built structure and returns a
+            /// completed, ready-to-use matrix. Ideal for when several matrices
+            /// have identical submatrices.
+            matrix commit() const;
+
+            /// An explicit move constructor. The builder object is left in a
+            /// valid, but undefined state, i.e. you cannot keep adding values
+            /// to it.
+            matrix move();
+
+        private:
+            matrix m;
+
+            builder& assemble();
+
+            inline Mat ptr() const;
+
+            friend class matrix;
+    };
+
+}
+}
+
+#endif //OPM_PETSCMATRIX_H

--- a/opm/core/linalg/petscvector.cpp
+++ b/opm/core/linalg/petscvector.cpp
@@ -1,0 +1,209 @@
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscvector.hpp>
+
+#include <cassert>
+#include <memory>
+#include <utility>
+
+#include <iostream>
+
+/* Slight hack to get things working. This sets the communicator used when
+ * constructing new vectors - however, this should be configurable. When full
+ * petsc support is figured out this will be changed.
+ */
+static inline MPI_Comm get_comm() { return PETSC_COMM_WORLD; }
+
+namespace Opm {
+namespace petsc {
+
+/* ideally replace this with C++11's std::iota */
+#ifndef HAVE_STD_IOTA
+template< class ForwardIterator, class T >
+static inline void iota( ForwardIterator first, ForwardIterator last, T value ) {
+        while(first != last) *first++ = value++;
+}
+#endif //HAVE_STD_IOTA
+
+template< typename T = vector::size_type, typename U = T >
+static inline std::vector< T > range( U begin, U end ) {
+    using namespace std;
+
+    std::vector< T > x( end - begin );
+    /* if std::iota is available, the function defined above shouldn't be
+     * compiled in and std::iota should be used
+     */
+    iota( x.begin(), x.end(), begin );
+    return x;
+}
+
+vector::vector() {
+    /* Meant to be used by other constructors. */
+    Vec x;
+    VecCreate( get_comm(), &x );
+    VecSetFromOptions( x );
+
+    this->v.reset( x );
+}
+
+vector::vector( Vec x ) : v( x ) {}
+
+vector::vector( const vector& x ) {
+    Vec y;
+    auto err = VecDuplicate( x, &y ); CHKERRXX( err );
+    err = VecCopy( x, y ); CHKERRXX( err );
+
+    this->v.reset( y );
+}
+
+vector::vector( vector::size_type size ) {
+    vector vec;
+
+    this->v.swap( vec.v );
+
+    auto err = VecSetSizes( this->ptr(), PETSC_DECIDE, size );
+    CHKERRXX( err );
+}
+
+vector::vector( vector::size_type size, vector::scalar x ) {
+    vector vec( size );
+    this->v.swap( vec.v );
+    this->assign( x );
+}
+
+vector::vector( const std::vector< vector::scalar >& values ) {
+    vector vec( values.data(), values.size() );
+    this->v.swap( vec.v );
+}
+
+vector::vector( const std::vector< vector::scalar >& values,
+                const std::vector< vector::size_type >& indexset ) {
+
+    assert( indexset.size() == values.size() );
+
+    vector vec( values.data(), indexset.data(), values.size() );
+    this->v.swap( vec.v );
+}
+
+vector::vector( const vector::scalar* values, vector::size_type size ) {
+    auto indices = range( 0, size );
+    vector vec( values, indices.data(), size );
+
+    this->v.swap( vec.v );
+}
+
+vector::vector(
+        const vector::scalar* values,
+        const vector::size_type* indexset,
+        vector::size_type size ) {
+
+    vector vec( size );
+
+    this->v.swap( vec.v );
+    this->set( values, indexset, size );
+}
+
+vector::operator Vec() const {
+    return this->ptr();
+}
+
+vector::size_type vector::size() const {
+    PetscInt x;
+    auto err = VecGetSize( this->ptr(), &x ); CHKERRXX( err );
+    return x;
+}
+
+void vector::assign( vector::scalar x ) {
+    auto err = VecSet( this->ptr(), x ); CHKERRXX( err );
+}
+
+vector& vector::operator+=( vector::scalar rhs ) {
+    auto err = VecShift( this->ptr(), rhs ); CHKERRXX( err );
+    return *this;
+}
+
+vector& vector::operator-=( vector::scalar rhs ) {
+    return *this += -rhs;
+}
+
+vector& vector::operator*=( vector::scalar rhs ) {
+    auto err = VecScale( this->ptr(), rhs ); CHKERRXX( err );
+    return *this;
+}
+
+vector& vector::operator/=( vector::scalar rhs ) {
+    return *this *= ( 1 / rhs );
+}
+
+vector operator+( vector lhs, vector::scalar rhs ) {
+    return lhs += rhs;
+}
+
+vector operator-( vector lhs, vector::scalar rhs ) {
+    return lhs -= rhs;
+}
+
+vector operator*( vector lhs, vector::scalar rhs ) {
+    return lhs *= rhs;
+}
+
+vector operator/( vector lhs, vector::scalar rhs ) {
+    return lhs /= rhs;
+}
+
+vector::scalar operator*( const vector& lhs, const vector& rhs ) {
+    assert( lhs.size() == rhs.size() );
+     
+    return dot( lhs, rhs );
+}
+
+bool vector::operator==( const vector& other ) const {
+    PetscBool eq;
+    VecEqual( this->ptr(), other, &eq );
+    return eq;
+}
+
+bool vector::operator!=( const vector& other ) const {
+    return !( *this == other );
+}
+
+inline void vector::set( const vector::scalar* values,
+        const vector::size_type* indices,
+        vector::size_type size ) {
+
+    auto err = VecSetValues( this->ptr(), size,
+            indices, values, INSERT_VALUES ); CHKERRXX( err );
+
+    err = VecAssemblyBegin( this->ptr() ); CHKERRXX( err );
+    err = VecAssemblyEnd( this->ptr() ); CHKERRXX( err );
+}
+
+inline Vec vector::ptr() const {
+    return this->v.get();
+}
+
+vector::scalar dot( const vector& lhs, const vector& rhs ) {
+    vector::scalar x;
+    VecDot( lhs, rhs, &x );
+    return x;
+}
+
+vector::scalar sum( const vector& v ) {
+    vector::scalar x;
+    auto err = VecSum( v, &x ); CHKERRXX( err );
+    return x;
+}
+
+vector::scalar max( const vector& v ) {
+    vector::scalar x;
+    auto err = VecMax( v, NULL, &x ); CHKERRXX( err );
+    return x;
+}
+
+vector::scalar min( const vector& v ) {
+    vector::scalar x;
+    auto err = VecMin( v, NULL, &x ); CHKERRXX( err );
+    return x;
+}
+
+}
+}

--- a/opm/core/linalg/petscvector.cpp
+++ b/opm/core/linalg/petscvector.cpp
@@ -134,6 +134,32 @@ vector& vector::operator/=( vector::scalar rhs ) {
     return *this *= ( 1 / rhs );
 }
 
+vector& vector::operator+=( const vector& rhs ) {
+    /* VecAXPY breaks if the vectors are not different, so if they are, copy
+     * one and use that for the addition
+     */
+    if( this->ptr() == rhs.ptr() ) {
+        auto rhs_copy = rhs;
+        return *this += rhs_copy;
+    }
+
+    auto err = VecAXPY( this->ptr(), 1, rhs ); CHKERRXX( err );
+    return *this;
+}
+
+vector& vector::operator-=( const vector& rhs ) {
+    /* VecAXPY breaks if the vectors are not different, so if they are, copy
+     * one and use that for the addition
+     */
+    if( this->ptr() == rhs.ptr() ) {
+        auto rhs_copy = rhs;
+        return *this -= rhs_copy;
+    }
+
+    auto err = VecAXPY( this->ptr(), -1, rhs ); CHKERRXX( err );
+    return *this;
+}
+
 vector operator+( vector lhs, vector::scalar rhs ) {
     return lhs += rhs;
 }
@@ -150,9 +176,17 @@ vector operator/( vector lhs, vector::scalar rhs ) {
     return lhs /= rhs;
 }
 
+vector operator+( vector lhs, const vector& rhs ) {
+    return lhs += rhs;
+}
+
+vector operator-( vector lhs, const vector& rhs ) {
+    return lhs -= rhs;
+}
+
 vector::scalar operator*( const vector& lhs, const vector& rhs ) {
     assert( lhs.size() == rhs.size() );
-     
+
     return dot( lhs, rhs );
 }
 

--- a/opm/core/linalg/petscvector.hpp
+++ b/opm/core/linalg/petscvector.hpp
@@ -1,0 +1,119 @@
+#ifndef OPM_PETSCVECTOR_H
+#define OPM_PETSCVECTOR_H
+
+/*
+ * C++ bindings to petsc Vec.
+ *
+ * Provides an easy-to-use C++-esque implementation with no extra indirection
+ * for petsc Vec. Slightly radical in design, but in spirit with petsc: no
+ * direct memory access is allowed, and no iterators are provided. Due to the
+ * nature of petsc there usually is no guarantee that the memory you want to
+ * access lives in your process. All interactions with the vector should happen
+ * through functions - possibly general higher-order functions at a later time.
+ *
+ * The idea is to get (some) of petsc's power, but easier to use. Tested to
+ * without effort be able to use MPI. Supports arithmetic operators and should
+ * be easy to reason about. Lifetime is managed through unique_ptr for safety
+ * and simplicity - no need to implement custom assignment and move operators.
+ *
+ * Note that a default-constructed vector is NOT allowed. While this makes it
+ * slightly harder to use in a class (you most likely shouldn't anyways), it
+ * disallows more invalid states at compile-time.
+ *
+ * Also note that there are no set-methods for values. This is by design, but
+ * they might be added later if there is a need for it. Structurally, this
+ * leaves the vector immutable.
+ *
+ * Please note that all methods in the vector class only deal with it's
+ * structure. This is by design - everything needed to compute something about
+ * the vector is or will be provided as free functions, in order to keep
+ * responsibilities separate.
+ *
+ * The vector gives no guarantees for internal representation.
+ *
+ * TODO: When full C++11 support can be used, most constructors can be
+ * rewritten to use ineheriting constructors.
+ */
+
+#include <opm/core/linalg/petsc.hpp>
+
+#include <petscvec.h>
+
+#include <memory>
+#include <vector>
+
+namespace Opm {
+namespace petsc {
+
+    class vector {
+        public:
+            typedef PetscScalar scalar;
+            typedef PetscInt size_type;
+
+            /* Just take ownership over a given Vec. */
+            explicit vector( Vec );
+            vector( const vector& );
+
+            explicit vector( size_type );
+            explicit vector( size_type, scalar );
+
+            vector( const std::vector< scalar >& );
+            vector( const std::vector< scalar >&,
+                    const std::vector< size_type >& indexset );
+
+            vector( const scalar*, size_type );
+            vector( const scalar*, const size_type* indexset, size_type );
+
+            /* implicit conversion to Vec.
+             *
+             * We want this so the class can be dropped into petsc functions.
+             */
+            operator Vec() const;
+
+            size_type size() const;
+
+            /* assign a value to -all- cells */
+            void assign( scalar );
+
+            vector& operator+=( scalar );
+            vector& operator-=( scalar );
+            vector& operator*=( scalar );
+            vector& operator/=( scalar );
+
+            /* these currently do not have to be friends (since vector is
+             * implicitly convertible), but they are for least possible
+             * surprise
+             */
+            friend vector operator+( vector, scalar );
+            friend vector operator-( vector, scalar );
+            friend vector operator*( vector, scalar );
+            friend vector operator/( vector, scalar );
+
+            friend scalar operator*( const vector&, const vector& );
+
+            bool operator==( const vector& ) const;
+            bool operator!=( const vector& ) const;
+
+        private:
+            vector();
+
+            /* We rely on unique_ptr to manage lifetime semantics. */
+            struct del { void operator()( Vec v ) { VecDestroy( &v ); } };
+            std::unique_ptr< _p_Vec, del > v;
+
+            inline void set( const scalar*, const size_type*, size_type );
+
+            /* a convenient, explicit way to get the underlying Vec */
+            inline Vec ptr() const;
+    };
+
+    vector::scalar dot( const vector&, const vector& );
+
+    vector::scalar sum( const vector& );
+    vector::scalar max( const vector& );
+    vector::scalar min( const vector& );
+
+}
+}
+
+#endif //OPM_PETSCVECTOR_H

--- a/opm/core/linalg/petscvector.hpp
+++ b/opm/core/linalg/petscvector.hpp
@@ -117,6 +117,13 @@ namespace petsc {
             /// \param[in] scalar   Value to scale with
             vector& operator/=( scalar );
 
+            /// Vector addition, X + Y. Induces a copy if X == Y
+            /// \param[in] vector   Vector to add
+            vector& operator+=( const vector& );
+            /// Vector subtraction, X - Y. Induces a copy if X == Y
+            /// \param[in] vector   Vector to subtract
+            vector& operator-=( const vector& );
+
             /* these currently do not have to be friends (since vector is
              * implicitly convertible), but they are for least possible
              * surprise
@@ -126,6 +133,8 @@ namespace petsc {
             friend vector operator*( vector, scalar );
             friend vector operator/( vector, scalar );
 
+            friend vector operator+( vector, const vector& );
+            friend vector operator-( vector, const vector& );
             friend scalar operator*( const vector&, const vector& );
 
             /// Equality check

--- a/opm/core/linalg/petscvector.hpp
+++ b/opm/core/linalg/petscvector.hpp
@@ -45,39 +45,76 @@
 namespace Opm {
 namespace petsc {
 
+    /// Class implementing C++-support for PETSc's Vec object. Provides no
+    /// extra indirection and can be used as a handle for vanilla PETSc
+    /// functions, should the need be.
+
     class vector {
         public:
             typedef PetscScalar scalar;
             typedef PetscInt size_type;
 
-            /* Just take ownership over a given Vec. */
+            /// Takes ownership of a Vec produced by some other means. The
+            /// destruction and lifetime is now managed by vector
             explicit vector( Vec );
+            /// Copy constructor
             vector( const vector& );
 
+            /// Constructor. Does not populate the vector with values.
+            /// \param[in] size     Number of elements
             explicit vector( size_type );
+            /// Constructor. Populate [0..n-1] with scalar. This is equivalent
+            /// vector v( size ); v.assign( scalar );
+            /// \param[in]  size    Number of elements
+            /// \param[in]  scalar  Value to set
             explicit vector( size_type, scalar );
 
+            /// Construct from std::vector.
+            /// \param[in] vector   std::vector to copy from
             vector( const std::vector< scalar >& );
+            /// Construct from std::vector at the indices provided by
+            /// indexset. Negative indices are ignored.
+            /// \param[in] vector   std::vector to copy from
+            /// \param[in] indexset indices to assign values from the vector.
             vector( const std::vector< scalar >&,
                     const std::vector< size_type >& indexset );
 
+            /// Construct from array. Provided to support legacy APIs and
+            /// C or C-style libraries. Works like the std::vector-constructor,
+            /// but with raw arrays.
+            /// \param[in] vector   array to copy from
+            /// \param[in] size     size of the array
             vector( const scalar*, size_type );
+            /// Construct from array at the indices provided by indexset.
+            /// Provided to support legacy APIs and C or C-style libraries.
+            /// Works like the std::vector-constructor, but with raw arrays.
+            /// \param[in] vector   array to copy from
+            /// \param[in] indexset indices to assign values from the vector.
+            /// \param[in] size     size of the array
             vector( const scalar*, const size_type* indexset, size_type );
 
-            /* implicit conversion to Vec.
-             *
-             * We want this so the class can be dropped into petsc functions.
-             */
+            /// Implicit conversion to Vec for compability with PETSc functions
             operator Vec() const;
 
+            /// Get vector size.
+            /// \param[out] size    Number of elements in the vector
             size_type size() const;
 
-            /* assign a value to -all- cells */
+            /// Assign a value to all elements in the vector.
+            /// \param[in] scalar  The value all elements will have
             void assign( scalar );
 
+            /// Add a value to all elements in the vector
+            /// \param[in] scalar   Value to add to all elements
             vector& operator+=( scalar );
+            /// Subtract a value from all elements in the vector
+            /// \param[in] scalar   Value to subtract from all elements
             vector& operator-=( scalar );
+            /// Scalar multiplication
+            /// \param[in] scalar   Value to scale with
             vector& operator*=( scalar );
+            /// Inverse scalar multiplication (division)
+            /// \param[in] scalar   Value to scale with
             vector& operator/=( scalar );
 
             /* these currently do not have to be friends (since vector is
@@ -91,7 +128,11 @@ namespace petsc {
 
             friend scalar operator*( const vector&, const vector& );
 
+            /// Equality check
+            /// \param[out] eq  Returns true if equal, false if not
             bool operator==( const vector& ) const;
+            /// Unequality check
+            /// \param[out] eq  Returns false if equal, true if not
             bool operator!=( const vector& ) const;
 
         private:
@@ -107,10 +148,14 @@ namespace petsc {
             inline Vec ptr() const;
     };
 
+    /// Calculate the dot product of two vectors
     vector::scalar dot( const vector&, const vector& );
 
+    /// Calculate the sum of all values in the vector
     vector::scalar sum( const vector& );
+    /// Find the biggest element in the vector
     vector::scalar max( const vector& );
+    /// Find the smallest element in the vector
     vector::scalar min( const vector& );
 
 }

--- a/tests/test_petscmatrix.cpp
+++ b/tests/test_petscmatrix.cpp
@@ -1,0 +1,196 @@
+#include <config.h>
+
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscmatrix.hpp>
+#include <opm/core/linalg/petscvector.hpp>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+#define BOOST_TEST_MODULE MatrixTest
+#define BOOST_TEST_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+int argc = 0;
+const char* argv[] = { "-on_error_attach_debugger", "gdb", "-start_in_debugger" };
+char** argvv = (char**)argv;
+Opm::petsc::petsc handle( &argc, &argvv, NULL, "help" );
+
+using Opm::petsc::matrix;
+using Opm::petsc::vector;
+
+static void have_public_types() {
+    typename Opm::petsc::matrix::scalar scalar;
+    typename Opm::petsc::matrix::size_type size_type;
+
+    /*
+     * Ignore "unused variable" warnings
+     */
+    (void) scalar;
+    (void) size_type;
+}
+
+BOOST_AUTO_TEST_CASE(test_petscvector_coverage) {
+    have_public_types();
+}
+
+const matrix::size_type row_ind[] = { 0, 1, 2, 3, 4 };
+const matrix::size_type col_ind[] = { 0, 1, 5, 2, 3 };
+const matrix::scalar values[] = {
+    10.0, 0, 0, 0, 0, 5.72,
+    0.2, 0, 0, 0, 0, 0,
+    0, 0, 4.2, 0, 0, 0,
+    0, 0, 0, 3.4, 0, 0,
+    0, 0, 3.14, 0, 0, 0,
+    0, 0, 0, 0, 0, 0 };
+
+const matrix::size_type csr_rows[] = { 0, 2, 3, 4, 5, 6, 6 };
+const matrix::size_type csr_cols[] = { 0, 5, 0, 2, 3, 2 };
+const matrix::scalar csr_vals[] = { 10.0, 5.72, 0.2, 4.2, 3.4, 3.14 };
+const matrix::scalar csr_vals_m2[] = { 20.0, 11.44, 0.4, 8.4, 6.8, 6.28 };
+const matrix::scalar csr_vals_zero[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+
+const matrix::scalar spmv_vals[] = { 117.961, 2.0, 0.84, 14.28, 0.628, 0.0 };
+
+const matrix::size_type row_ind_trans[] = { 0, 0, 2, 2, 3, 5 };
+const matrix::size_type col_ind_trans[] = { 0, 1, 2, 4, 3, 0 };
+const matrix::scalar values_trans[] = { 10.0, 0.2, 0, 0, 0, 0,
+                                        0, 0, 0, 0, 0, 0,
+                                        0, 0, 4.2, 0, 3.4, 0,
+                                        0, 0, 0, 3.14, 0, 0,
+                                        0, 0, 0, 0, 0, 0,
+                                        5.72, 0, 0, 0, 0, 0 };
+
+BOOST_AUTO_TEST_CASE(test_compare_builder_raw_petsc) {
+    /* ensure ownership transfer and copy construction works as intended by
+     * building from raw PETSc functions
+     */
+
+    Mat mat_petsc;
+    MatCreate( PETSC_COMM_WORLD, &mat_petsc );
+    MatSetSizes( mat_petsc, PETSC_DECIDE, PETSC_DECIDE, 10, 10 );
+    MatSetFromOptions( mat_petsc );
+    MatSetUp( mat_petsc );
+    MatSetValue( mat_petsc, 1, 1, 2.3, INSERT_VALUES );
+    MatAssemblyBegin( mat_petsc, MAT_FINAL_ASSEMBLY );
+    MatAssemblyEnd( mat_petsc, MAT_FINAL_ASSEMBLY );
+    matrix mtx( mat_petsc );
+
+    matrix::builder builder( 10, 10 );
+    builder.insert( 1, 1, 2.3 );
+    matrix builder_mtx( builder );
+
+    BOOST_CHECK( identical( builder_mtx, mtx ) );
+}
+
+BOOST_AUTO_TEST_CASE(test_matrix_copies) {
+    matrix::builder builder( 10, 10 );
+    builder.insert( 1, 1, 2.3 );
+
+    matrix mtx( builder );
+    matrix copy( mtx );
+
+    matrix::builder builder_copy( builder );
+    matrix builder_copy_mtx( builder_copy );
+
+    BOOST_CHECK( identical( mtx, copy ) );
+    BOOST_CHECK( identical( builder_copy_mtx, mtx ) );
+    BOOST_CHECK( identical( builder_copy_mtx, copy ) );
+}
+
+BOOST_AUTO_TEST_CASE(test_matrix_move) {
+    matrix::builder builder( 10, 10 );
+    builder.insert( 1, 1, 2.3 );
+
+    matrix mtx( builder );
+    matrix moved( std::move( builder ) );
+
+    BOOST_CHECK( identical( moved, mtx ) );
+}
+
+/*
+ * A convenient way to build a matrix (to avoid repetition). Creates a
+ * CSR-style matrix from the constant arrays
+ */
+static matrix get_csr_matrix( const matrix::scalar* vals ) {
+    std::vector< matrix::scalar > csr_val_vec;
+    std::vector< matrix::size_type > csr_row_vec;
+    std::vector< matrix::size_type > csr_col_vec;
+    for( int i = 0; i < 6; ++i ) {
+        csr_val_vec.push_back( vals[ i ] );
+        csr_col_vec.push_back( csr_cols[ i ] );
+        csr_row_vec.push_back( csr_rows[ i ] );
+    }
+    csr_row_vec.push_back( csr_rows[ 6 ] );
+
+    matrix::builder csr_builder( 6, 6 );
+    csr_builder.insert( csr_val_vec, csr_row_vec, csr_col_vec );
+
+    return csr_builder;
+}
+
+BOOST_AUTO_TEST_CASE(test_matrixbuilder) {
+    auto mtx = get_csr_matrix( csr_vals );
+
+    matrix::builder direct_builder( 6, 6 );
+    direct_builder.insert( 0, 0, 10.0 );
+    direct_builder.insert( 0, 5, 5.72 );
+    direct_builder.insert( 1, 0, 0.2 );
+    direct_builder.insert( 2, 2, 4.2 );
+    direct_builder.insert( 3, 3, 3.4 );
+    direct_builder.insert( 4, 2, 3.14 );
+
+    auto dmtx = direct_builder.commit();
+
+    BOOST_CHECK( identical( mtx, dmtx ) );
+}
+
+BOOST_AUTO_TEST_CASE(test_matrix_arithmetic) {
+    auto base_matrix = get_csr_matrix( csr_vals );
+    auto matrix_m2 = get_csr_matrix( csr_vals_m2 );
+    auto base_matrix_copy = base_matrix;
+    auto matrix_zero = get_csr_matrix( csr_vals_zero );
+    vector zero_vector( 6, 0.0 );
+    vector base_vector( csr_vals, 6 );
+    vector spmv_vector( spmv_vals, 6 );
+
+    BOOST_CHECK( identical( matrix_m2, base_matrix * 2 ) );
+    BOOST_CHECK( identical( matrix_m2, base_matrix + base_matrix ) );
+    BOOST_CHECK( identical( matrix_zero, base_matrix - base_matrix ) );
+
+    BOOST_CHECK( identical( base_matrix, base_matrix + matrix_zero ) );
+    /* base_matrix * matrix_zero is NOT guaranteed to be structurally identical
+     * to matrix_zero, therefore this check cannot be done. This is a petsc
+     * detail may be relaxed in the future.
+     * BOOST_CHECK( identical( matrix_zero, base_matrix * matrix_zero ) );
+     */
+    BOOST_CHECK( identical( matrix_zero, base_matrix * 0 ) );
+
+    BOOST_CHECK( zero_vector == zero_vector * base_matrix );
+
+    /*
+     * Unfortunately, vector comparison suffers from the same. It is a bitwise
+     * equality test, therefore rounding errors are not accounted for and
+     * things that would otherwise be equal are not
+     * BOOST_CHECK( spmv_vector == base_matrix * base_vector );
+     */
+}
+
+BOOST_AUTO_TEST_CASE(test_petscvector_transpose) {
+    std::vector< matrix::scalar > val_vec;
+    for( int i = 0; i < 6*6; ++i ) {
+        val_vec.push_back( values[ i ] );
+    }
+    matrix source( val_vec, 6, 6 );
+    matrix inplace_transposed = source;
+
+    auto transposed = transpose( source );
+    auto double_transposed = transpose( transposed );
+    inplace_transposed.transpose();
+
+    BOOST_CHECK( identical( double_transposed, source ) );
+    BOOST_CHECK( identical( transposed, inplace_transposed ) );
+}

--- a/tests/test_petscvector.cpp
+++ b/tests/test_petscvector.cpp
@@ -1,0 +1,127 @@
+#include <config.h>
+
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscvector.hpp>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+#define BOOST_TEST_MODULE MatrixTest
+#define BOOST_TEST_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+int argc = 0;
+char** argv = 0;
+Opm::petsc::petsc handle( &argc, &argv, NULL, "help" );
+
+template< class ForwardIterator, class T >
+static inline void iota( ForwardIterator first, ForwardIterator last, T value, T step ) {
+    while(first != last) { 
+        *first++ = value;
+        value += step;
+    }
+}
+
+template< typename T >
+static inline std::vector< T > range( T begin, T end, T step = T( 1 ) ) {
+    using namespace std;
+
+    std::vector< T > x( ( end - begin ) / step );
+    /* if std::iota is available, the function defined above shouldn't be
+     * compiled in and std::iota should be used
+     */
+    iota( x.begin(), x.end(), begin, step );
+    return x;
+}
+
+static void have_public_types() {
+    typename Opm::petsc::vector::scalar scalar;
+    typename Opm::petsc::vector::size_type size_type;
+
+    /*
+     * Ignore "unused variable" warnings
+     */
+    (void) scalar;
+    (void) size_type;
+}
+
+BOOST_AUTO_TEST_CASE(test_petscvector_coverage) {
+    /* Test that the required public types are exposed.
+     *
+     * Will provide compile error if not
+     */
+    have_public_types();
+}
+
+BOOST_AUTO_TEST_CASE(test_petscvector_constructors) {
+    using Opm::petsc::vector;
+
+    /* Create reference vector petsc styles. */
+    Vec vec_petsc;
+    VecCreate( PETSC_COMM_WORLD, &vec_petsc );
+    VecSetSizes( vec_petsc, PETSC_DECIDE, 10 );
+    VecSetFromOptions( vec_petsc );
+
+    /* ownership transferring constructor */
+    vector vector_petsc( vec_petsc );
+
+    /* test copy constructor */
+    auto vector_copy = vector( vector_petsc );
+
+    vector vector_size( 10 );
+    vector vector_size_elems( 10, 0.0 );
+
+    /* construction from std::vector */
+    std::vector< vector::scalar > std_vec( 10, 0.0 );
+    auto stdidx = range( 0, 10 );
+    vector vector_from_stdvec( std_vec );
+    vector vector_from_stdidx( std_vec, stdidx );
+
+    /* construct from raw arrays */
+    double vals[] = { 0.0, 1.0, 2.0, 3.0, 4.0 };
+    int idx[] = { 0, 1, 2, 3, 4 };
+    vector vector_from_array( vals, 5 );
+    vector vector_from_idx( vals, idx, 5 );
+
+    BOOST_CHECK( vector_copy == vector_petsc );
+    BOOST_CHECK( vector_from_stdvec == vector_from_stdidx );
+    BOOST_CHECK( vector_from_array == vector_from_idx );
+
+    BOOST_CHECK( !( vector_copy != vector_petsc ) );
+    BOOST_CHECK( !( vector_from_stdvec != vector_from_stdidx ) );
+    BOOST_CHECK( !( vector_from_array != vector_from_idx ) );
+}
+
+BOOST_AUTO_TEST_CASE(test_petscvector_arithmetic) {
+    using Opm::petsc::vector;
+
+
+    vector vec1( range( 0.0, 10.0 ) );
+    vector vec_add_target( range( 2.0, 12.0 ) );
+    auto vec_add = vec1 + 2;
+    auto vec_sub = vec_add_target - 2;
+
+    vector vec_mul_target( range( 0.0, 30.0, 3.0 ) );
+    auto vec_mul = vec1 * 3;
+    auto vec_div = vec_mul_target / 3;
+
+    BOOST_CHECK( vec_add == vec_add_target );
+    BOOST_CHECK( vec_sub == vec1 );
+    BOOST_CHECK( vec_mul == vec_mul_target );
+    BOOST_CHECK( vec_div == vec1 );
+}
+
+BOOST_AUTO_TEST_CASE(test_petscvector_functional) {
+    using Opm::petsc::vector;
+
+    vector vec1( range( 0.0, 10.0 ) );
+    vector vec2( range( 0.0, 20.0, 2.0 ) );
+
+    BOOST_CHECK( ( vec1 * vec2 ) == 570.0 );
+    BOOST_CHECK( Opm::petsc::max( vec1 ) ==  9.0 );
+    BOOST_CHECK( Opm::petsc::min( vec1 ) ==  0.0 );
+    BOOST_CHECK( Opm::petsc::sum( vec1 ) == 45.0 );
+}


### PR DESCRIPTION
This branch assumes https://github.com/OPM/opm-core/pull/722 has been merged, so it currently includes the changes.

Implements support and test for PETSc matrices. The commit itself should be fairly self-explanatory.

Please note that operator== is not supported for matrices as MatEqual behaviour is peculiar - it does not check for value equality as you might expect, but rather structural AND bitwise equality. Therefore, the more communicative name identical was chosen for comparison. Unfortunately this makes testing a little bit harder.