### PR TITLE
Fixes global reductions

### DIFF
--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -250,6 +250,7 @@ private:
     {
         auto& val=std::get<I>(values);
         val = std::get<I>(operators).localOperator()(val, std::get<I>(receivedValues));
+        computeGlobalReduction<I+1>(receivedValues, operators, values);
     }
     /// \brief TMP for computing the the local reduction on the DOF that the process owns.
     ///


### PR DESCRIPTION
Correctly compute the minimum and maximum values.

As there are no functors for computing the minimum and maximum,
we convert the std::max and std::min function pointers to
functors (which is not really nice.) Previously we were somehow
tricked into using std::greater and std::less, which of course do
return true or false and not what we need. Additionally, do more
excessive testing with different ranges.

This is a follow up to #728 that fixes some additional issues. Sorry for not finding this earlier.