### PR TITLE
Method advance for SimulatorTimers.

### DIFF
--- a/opm/core/simulator/AdaptiveSimulatorTimer.hpp
+++ b/opm/core/simulator/AdaptiveSimulatorTimer.hpp
@@ -46,6 +46,9 @@ namespace Opm
         /// \brief advance time by currentStepLength
         AdaptiveSimulatorTimer& operator++ ();
 
+        /// \brief advance time by currentStepLength
+        void advance() { this->operator++ (); }
+
         /// \brief provide and estimate for new time step size
         void provideTimeStepEstimate( const double dt_estimate );
 

--- a/opm/core/simulator/SimulatorTimer.hpp
+++ b/opm/core/simulator/SimulatorTimer.hpp
@@ -98,6 +98,9 @@ namespace Opm
         /// Next step.
         SimulatorTimer& operator++();
 
+        /// Next step.
+        void advance() { this->operator++(); }
+
         /// Return true if op++() has been called numSteps() times.
         bool done() const;
 

--- a/opm/core/simulator/SimulatorTimer.hpp
+++ b/opm/core/simulator/SimulatorTimer.hpp
@@ -95,10 +95,10 @@ namespace Opm
         /// Note: if done(), it is an error to call report().
         void report(std::ostream& os) const;
 
-        /// Next step.
+        /// advance time by currentStepLength
         SimulatorTimer& operator++();
 
-        /// Next step.
+        /// advance time by currentStepLength
         void advance() { this->operator++(); }
 
         /// Return true if op++() has been called numSteps() times.

--- a/opm/core/simulator/SimulatorTimerInterface.hpp
+++ b/opm/core/simulator/SimulatorTimerInterface.hpp
@@ -75,6 +75,9 @@ namespace Opm
         /// beginning of the current time step [s].
         virtual double simulationTimeElapsed() const = 0;
 
+        /// advance timer to the next time step
+        virtual void advance() = 0 ;
+
         /// Return true if timer indicates that simulation of timer interval is finished
         virtual bool done() const = 0;
 

--- a/opm/core/simulator/SimulatorTimerInterface.hpp
+++ b/opm/core/simulator/SimulatorTimerInterface.hpp
@@ -75,7 +75,7 @@ namespace Opm
         /// beginning of the current time step [s].
         virtual double simulationTimeElapsed() const = 0;
 
-        /// advance timer to the next time step
+        /// advance time by currentStepLength
         virtual void advance() = 0 ;
 
         /// Return true if timer indicates that simulation of timer interval is finished


### PR DESCRIPTION
This is the interface method for the previously used operator++ which cannot be made virtual since the return type differs. 
