### PR TITLE
BlackoilState: added forgotten rv variable to equal method.

### DIFF
--- a/opm/core/simulator/BlackoilState.cpp
+++ b/opm/core/simulator/BlackoilState.cpp
@@ -39,5 +39,8 @@ BlackoilState::equals(const SimulatorState& other,
     equal = equal && SimulatorState::vectorApproxEqual(this->gasoilratio(),
                                                        that->gasoilratio(),
                                                        epsilon);
+    equal = equal && SimulatorState::vectorApproxEqual(this->rv(),
+                                                       that->rv(),
+                                                       epsilon);
     return equal;
 }


### PR DESCRIPTION
Maybe it was intended to not compare the rv states. It seems like a bug though. 