### PR TITLE
PVT classes: implement temperature dependent viscosity

### DIFF
--- a/opm/core/props/pvt/PvtDead.cpp
+++ b/opm/core/props/pvt/PvtDead.cpp
@@ -123,13 +123,20 @@ namespace Opm
             double tempInvB = b_[regionIdx](p[i]);
             double tempInvBmu = inverseBmu_[regionIdx](p[i]);
             output_mu[i] = tempInvB / tempInvBmu;
+
+            if (oilvisctTables_ != 0) {
+                // TODO: temperature dependence
+                OPM_THROW(std::logic_error,
+                          "temperature dependent viscosity as a function of z "
+                          "is not yet implemented!");
+            }
         }
     }
 
     void PvtDead::mu(const int n,
                      const int* pvtTableIdx,
                      const double* p,
-                     const double* /*T*/,
+                     const double* T,
                                const double* /*r*/,
                                double* output_mu,
                                double* output_dmudp,
@@ -143,6 +150,24 @@ namespace Opm
                 output_mu[i] = tempInvB / tempInvBmu;
                 output_dmudp[i] = (tempInvBmu * b_[regionIdx].derivative(p[i])
                                  - tempInvB * inverseBmu_[regionIdx].derivative(p[i])) / (tempInvBmu * tempInvBmu);
+
+                if (oilvisctTables_ != 0) {
+                    // temperature dependence of the oil phase
+                    DeckRecordConstPtr viscrefRecord = viscrefKeyword_->getRecord(regionIdx);
+                    double pRef = viscrefRecord->getItem("REFERENCE_PRESSURE")->getSIDouble(0);
+                    double muRef = b_[regionIdx](pRef)/inverseBmu_[regionIdx](pRef);
+
+                    double muOilvisct = (*oilvisctTables_)[regionIdx].evaluate("Viscosity", T[i]);
+                    double alpha = muOilvisct/muRef;
+
+                    output_mu[i] *= alpha;
+                    output_dmudp[i] *= alpha;
+                    output_dmudr[i] *= alpha;
+
+                    // TODO (?): derivative of oil viscosity w.r.t. temperature.
+                    // probably requires a healthy portion of if-spaghetti
+                }
+
             }
             std::fill(output_dmudr, output_dmudr + n, 0.0);
 
@@ -151,7 +176,7 @@ namespace Opm
     void PvtDead::mu(const int n,
                      const int* pvtTableIdx,
                      const double* p,
-                     const double* /*T*/,
+                     const double* T,
                                const double* /*r*/,
                                const PhasePresence* /*cond*/,
                                double* output_mu,
@@ -167,6 +192,23 @@ namespace Opm
                 output_dmudp[i] = (tempInvBmu * b_[regionIdx].derivative(p[i])
                                  - tempInvB * inverseBmu_[regionIdx].derivative(p[i]))
                                  / (tempInvBmu * tempInvBmu);
+
+                if (oilvisctTables_ != 0) {
+                    // temperature dependence of the oil phase
+                    DeckRecordConstPtr viscrefRecord = viscrefKeyword_->getRecord(regionIdx);
+                    double pRef = viscrefRecord->getItem("REFERENCE_PRESSURE")->getSIDouble(0);
+                    double muRef = b_[regionIdx](pRef)/inverseBmu_[regionIdx](pRef);
+
+                    double muOilvisct = (*oilvisctTables_)[regionIdx].evaluate("Viscosity", T[i]);
+                    double alpha = muOilvisct/muRef;
+
+                    output_mu[i] *= alpha;
+                    output_dmudp[i] *= alpha;
+                    output_dmudr[i] *= alpha;
+
+                    // TODO (?): derivative of oil viscosity w.r.t. temperature.
+                    // probably requires a healthy portion of if-spaghetti
+                }
             }
             std::fill(output_dmudr, output_dmudr + n, 0.0);
 

--- a/opm/core/props/pvt/PvtDead.hpp
+++ b/opm/core/props/pvt/PvtDead.hpp
@@ -44,7 +44,11 @@ namespace Opm
     class PvtDead : public PvtInterface
     {
     public:
-        PvtDead() {};
+        PvtDead()
+        {
+            // by default, specify no temperature dependence of the PVT properties
+            oilvisctTables_ = 0;
+        }
 
         void initFromOil(const std::vector<Opm::PvdoTable>& pvdoTables);
         void initFromGas(const std::vector<Opm::PvdgTable>& pvdgTables);
@@ -150,6 +154,15 @@ namespace Opm
                           const double* z,
                           double* output_R,
                           double* output_dRdp) const;
+
+        /// set the tables which specify the temperature dependence of the oil viscosity
+        void setOilvisctTables(const std::vector<Opm::OilvisctTable>& oilvisctTables,
+                               DeckKeywordConstPtr viscrefKeyword)
+        {
+            oilvisctTables_ = &oilvisctTables;
+            viscrefKeyword_ = viscrefKeyword;
+        }
+
     private:
         int getTableIndex_(const int* pvtTableIdx, int cellIdx) const
         {
@@ -163,6 +176,9 @@ namespace Opm
         std::vector<NonuniformTableLinear<double> > b_;
         std::vector<NonuniformTableLinear<double> > viscosity_;
         std::vector<NonuniformTableLinear<double> > inverseBmu_;
+
+        const std::vector<Opm::OilvisctTable>* oilvisctTables_;
+        DeckKeywordConstPtr viscrefKeyword_;
     };
 }
 

--- a/opm/core/props/pvt/PvtDeadSpline.cpp
+++ b/opm/core/props/pvt/PvtDeadSpline.cpp
@@ -36,7 +36,10 @@ namespace Opm
     //-------------------------------------------------------------------------
 
     PvtDeadSpline::PvtDeadSpline()
-    {}
+    {
+        // by default, specify no temperature dependence of the PVT properties
+        oilvisctTables_ = 0;
+    }
 
     void PvtDeadSpline::initFromOil(const std::vector<Opm::PvdoTable>& pvdoTables,
                                     int numSamples)
@@ -120,7 +123,7 @@ namespace Opm
     void PvtDeadSpline::mu(const int n,
                            const int* pvtTableIdx,
                            const double* p,
-                           const double* /*T*/,
+                           const double* T,
                            const double* /*r*/,
                            double* output_mu,
                            double* output_dmudp,
@@ -131,6 +134,23 @@ namespace Opm
             int regionIdx = getTableIndex_(pvtTableIdx, i);
             output_mu[i] = viscosity_[regionIdx](p[i]);
             output_dmudp[i] = viscosity_[regionIdx].derivative(p[i]);
+
+            if (oilvisctTables_ != 0) {
+                // temperature dependence of the oil phase
+                DeckRecordConstPtr viscrefRecord = viscrefKeyword_->getRecord(regionIdx);
+                double pRef = viscrefRecord->getItem("REFERENCE_PRESSURE")->getSIDouble(0);
+                double muRef = viscosity_[regionIdx](pRef);
+
+                double muOilvisct = (*oilvisctTables_)[regionIdx].evaluate("Viscosity", T[i]);
+                double alpha = muOilvisct/muRef;
+
+                output_mu[i] *= alpha;
+                output_dmudp[i] *= alpha;
+                output_dmudr[i] *= alpha;
+
+                // TODO (?): derivative of oil viscosity w.r.t. temperature.
+                // probably requires a healthy portion of if-spaghetti
+            }
         }
         std::fill(output_dmudr, output_dmudr + n, 0.0);
     }
@@ -138,7 +158,7 @@ namespace Opm
     void PvtDeadSpline::mu(const int n,
                            const int* pvtTableIdx,
                            const double* p,
-                           const double* /*T*/,
+                           const double* T,
                            const double* /*r*/,
                            const PhasePresence* /*cond*/,
                            double* output_mu,
@@ -151,6 +171,23 @@ namespace Opm
             int regionIdx = getTableIndex_(pvtTableIdx, i);
             output_mu[i] = viscosity_[regionIdx](p[i]);
             output_dmudp[i] = viscosity_[regionIdx].derivative(p[i]);
+
+            if (oilvisctTables_ != 0) {
+                // temperature dependence of the oil phase
+                DeckRecordConstPtr viscrefRecord = viscrefKeyword_->getRecord(regionIdx);
+                double pRef = viscrefRecord->getItem("REFERENCE_PRESSURE")->getSIDouble(0);
+                double muRef = viscosity_[regionIdx](pRef);
+
+                double muOilvisct = (*oilvisctTables_)[regionIdx].evaluate("Viscosity", T[i]);
+                double alpha = muOilvisct/muRef;
+
+                output_mu[i] *= alpha;
+                output_dmudp[i] *= alpha;
+                output_dmudr[i] *= alpha;
+
+                // TODO (?): derivative of oil viscosity w.r.t. temperature.
+                // probably requires a healthy portion of if-spaghetti
+            }
         }
         std::fill(output_dmudr, output_dmudr + n, 0.0);
     }

--- a/opm/core/props/pvt/PvtDeadSpline.hpp
+++ b/opm/core/props/pvt/PvtDeadSpline.hpp
@@ -148,6 +148,15 @@ namespace Opm
                           const double* z,
                           double* output_R,
                           double* output_dRdp) const;
+
+        /// set the tables which specify the temperature dependence of the oil viscosity
+        void setOilvisctTables(const std::vector<Opm::OilvisctTable>& oilvisctTables,
+                               DeckKeywordConstPtr viscrefKeyword)
+        {
+            oilvisctTables_ = &oilvisctTables;
+            viscrefKeyword_ = viscrefKeyword;
+        }
+
     private:
         int getTableIndex_(const int* pvtTableIdx, int cellIdx) const
         {
@@ -160,6 +169,9 @@ namespace Opm
         // table per PVT region.
         std::vector<UniformTableLinear<double> > b_;
         std::vector<UniformTableLinear<double> > viscosity_;
+
+        const std::vector<Opm::OilvisctTable>* oilvisctTables_;
+        DeckKeywordConstPtr viscrefKeyword_;
     };
 
 }

--- a/opm/core/props/pvt/PvtLiveGas.cpp
+++ b/opm/core/props/pvt/PvtLiveGas.cpp
@@ -114,6 +114,9 @@ namespace Opm
             double inverseBMu = miscible_gas(p[i], z + num_phases_*i, getTableIndex_(pvtRegionIdx, i), 3, false);
 
             output_mu[i] = inverseB / inverseBMu;
+
+            // temperature dependence: Since E100 does not implement temperature
+            // dependence of gas viscosity, we skip it here as well...
         }
     }
 
@@ -162,6 +165,8 @@ namespace Opm
             output_dmudr[i] = (inverseBMu * dinverseBdr - inverseB * dinverseBmudr)
                               / (inverseBMu * inverseBMu);
 
+            // temperature dependence: Since E100 does not implement temperature
+            // dependence of gas viscosity, we skip it here as well...
         }
 
     }

--- a/opm/core/props/pvt/PvtLiveOil.cpp
+++ b/opm/core/props/pvt/PvtLiveOil.cpp
@@ -36,6 +36,9 @@ namespace Opm
     //-------------------------------------------------------------------------
     PvtLiveOil::PvtLiveOil(const std::vector<Opm::PvtoTable>& pvtoTables)
     {
+        // by default, specify no temperature dependence of the PVT properties
+        oilvisctTables_ = 0;
+
         int numTables = pvtoTables.size();
         saturated_oil_table_.resize(numTables);
         undersat_oil_tables_.resize(numTables);
@@ -136,7 +139,7 @@ namespace Opm
     void PvtLiveOil::mu(const int n,
                         const int* pvtTableIdx,
                         const double* p,
-                        const double* /*T*/,
+                        const double* T,
                               const double* z,
                               double* output_mu) const
     {
@@ -149,13 +152,20 @@ namespace Opm
 
             output_mu[i] = inverseB / inverseBMu; 
         }
+
+        if (oilvisctTables_ != 0) {
+            // TODO: temperature dependence
+            OPM_THROW(std::logic_error,
+                      "temperature dependent viscosity as a function of z "
+                      "is not yet implemented!");
+        }
     }
 
     /// Viscosity and its p and r derivatives as a function of p, T and r.
     void PvtLiveOil::mu(const int n,
                         const int* pvtTableIdx,
                         const double* p,
-                        const double* /*T*/,
+                        const double* T,
                                const double* r,
                                double* output_mu,
                                double* output_dmudp,
@@ -183,14 +193,32 @@ namespace Opm
                     output_dmudr[i] = (inverseBMu * dinverseBdr - inverseB * dinverseBmudr)
                                       / (inverseBMu * inverseBMu);
 
+                    if (oilvisctTables_ != 0) {
+                        // temperature dependence
+                        DeckRecordConstPtr viscrefRecord = viscrefKeyword_->getRecord(tableIdx);
+                        double pRef = viscrefRecord->getItem("REFERENCE_PRESSURE")->getSIDouble(0);
+                        double rsRef = viscrefRecord->getItem("REFERENCE_RS")->getSIDouble(0);
+                        double muRef = miscible_oil(pRef, rsRef, tableIdx, 3, 0)/miscible_oil(pRef, rsRef, tableIdx, 1, 0);
+
+                        double muOilvisct = (*oilvisctTables_)[tableIdx].evaluate("Viscosity", T[i]);
+                        double alpha = muOilvisct/muRef;
+
+                        output_mu[i] *= alpha;
+                        output_dmudp[i] *= alpha;
+                        output_dmudr[i] *= alpha;
+
+                        // TODO (?): derivative of oil viscosity w.r.t. temperature.
+                        // probably requires a healthy portion of if-spaghetti
+                    }
                 }
+
     }
 
     /// Viscosity and its p and r derivatives as a function of p, T and r.
     void PvtLiveOil::mu(const int n,
                         const int* pvtTableIdx,
                         const double* p,
-                        const double* /*T*/,
+                        const double* T,
                                const double* r,
                                const PhasePresence* cond,
                                double* output_mu,
@@ -220,6 +248,24 @@ namespace Opm
                     output_dmudr[i] = (inverseBMu * dinverseBdr - inverseB * dinverseBmudr)
                                       / (inverseBMu * inverseBMu);
 
+
+                    if (oilvisctTables_ != 0) {
+                        // temperature dependence
+                        DeckRecordConstPtr viscrefRecord = viscrefKeyword_->getRecord(tableIdx);
+                        double pRef = viscrefRecord->getItem("REFERENCE_PRESSURE")->getSIDouble(0);
+                        double rsRef = viscrefRecord->getItem("REFERENCE_RS")->getSIDouble(0);
+                        double muRef = miscible_oil(pRef, rsRef, tableIdx, 3, 0)/miscible_oil(pRef, rsRef, tableIdx, 1, 0);
+
+                        double muOilvisct = (*oilvisctTables_)[tableIdx].evaluate("Viscosity", T[i]);
+                        double alpha = muOilvisct/muRef;
+
+                        output_mu[i] *= alpha;
+                        output_dmudp[i] *= alpha;
+                        output_dmudr[i] *= alpha;
+
+                        // TODO (?): derivative of oil viscosity w.r.t. temperature.
+                        // probably requires a healthy portion of if-spaghetti
+                    }
                 }
     }
 
@@ -645,5 +691,4 @@ namespace Opm
                 }
             }
         }
-
 } // namespace Opm

--- a/opm/core/props/pvt/PvtLiveOil.hpp
+++ b/opm/core/props/pvt/PvtLiveOil.hpp
@@ -142,6 +142,14 @@ namespace Opm
                           double* output_R,
                           double* output_dRdp) const;
 
+        /// set the tables which specify the temperature dependence of the oil viscosity
+        void setOilvisctTables(const std::vector<Opm::OilvisctTable>& oilvisctTables,
+                               DeckKeywordConstPtr viscrefKeyword)
+        {
+            oilvisctTables_ = &oilvisctTables;
+            viscrefKeyword_ = viscrefKeyword;
+        }
+
     private:
         int getTableIndex_(const int* pvtTableIdx, int cellIdx) const
         {
@@ -179,6 +187,9 @@ namespace Opm
         // store one table per PVT region.
         std::vector<std::vector<std::vector<double> > > saturated_oil_table_;
         std::vector<std::vector<std::vector<std::vector<double> > > > undersat_oil_tables_;
+
+        const std::vector<Opm::OilvisctTable>* oilvisctTables_;
+        DeckKeywordConstPtr viscrefKeyword_;
     };
 
 }


### PR DESCRIPTION
This implements a temperature dependency of the oil and water viscosities according to the Eclipse documentation. (gas does not depend on temperature in E100 for some reason and we don't have a gas composition yet, so we also can't do the E300 approach.) After quite a bit of head-banging, I decided that I did not want to change the APIs for the PVT properties (which is only required once an energy conservation equation is implemented), and that only the viscosities are considered for now, i.e. densities are a job for another month...