### PR TITLE
Add default producer BHP control when not given in deck.

### DIFF
--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -601,10 +601,14 @@ namespace Opm
                                               w_);
                 }
 
-                if (ok && productionProperties.hasProductionControl(WellProducer::BHP)) {
+                if (ok) {
+                    // Always append a BHP control.
+                    // If no explicit BHP control given, use a 1 atm control.
+                    const bool has_explicit_limit = productionProperties.hasProductionControl(WellProducer::BHP);
+                    const double bhp_limit = has_explicit_limit ? productionProperties.BHPLimit : unit::convert::from(1.0, unit::atm);
                     control_pos[WellsManagerDetail::ProductionControl::BHP] = well_controls_get_num(w_->ctrls[well_index]);
                     ok = append_well_controls(BHP,
-                                              productionProperties.BHPLimit , 
+                                              bhp_limit,
                                               NULL,
                                               well_index,
                                               w_);

--- a/tests/test_wellsmanager.cpp
+++ b/tests/test_wellsmanager.cpp
@@ -176,7 +176,8 @@ void check_controls_epoch1( struct WellControls ** ctrls) {
 void check_controls_epoch3( struct WellControls ** ctrls) {
     // The new producer
     const struct WellControls * ctrls1 = ctrls[1];
-    BOOST_CHECK_EQUAL( 5 , well_controls_get_num(ctrls1));
+    // Note: controls include default (1 atm) BHP control.
+    BOOST_CHECK_EQUAL( 6 , well_controls_get_num(ctrls1));
 }
 
 


### PR DESCRIPTION
When no BHP limit is given for a producer, a BHP control is added anyway, with a limit of 1 atm.

This should solve issue OPM/opm-parser#441.
