### PR TITLE
Makes BlackoilPropertiesFromDeck copyable.

### DIFF
--- a/opm/core/props/BlackoilPropertiesFromDeck.hpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck.hpp
@@ -259,7 +259,7 @@ namespace Opm
         RockFromDeck rock_;
         std::vector<int> cellPvtRegionIdx_;
         BlackoilPvtProperties pvt_;
-        std::unique_ptr<SaturationPropsInterface> satprops_;
+        std::shared_ptr<SaturationPropsInterface> satprops_;
         mutable std::vector<double> B_;
         mutable std::vector<double> dB_;
         mutable std::vector<double> R_;

--- a/opm/core/simulator/BlackoilState.hpp
+++ b/opm/core/simulator/BlackoilState.hpp
@@ -56,11 +56,10 @@ namespace Opm
         const std::vector<double>& rv () const {return rv_ ; }
 
     private:
-        std::vector<double> surfvol_;
-        std::vector<double> gor_   ;
-        std::vector<double> rv_ ;
+        std::vector<double> surfvol_; // no entries = no cells * no phases
+        std::vector<double> gor_   ;  // no entries = no cells
+        std::vector<double> rv_ ;     // no entries = no cells
     };
-
 } // namespace Opm
 
 

--- a/opm/core/simulator/SimulatorState.hpp
+++ b/opm/core/simulator/SimulatorState.hpp
@@ -17,7 +17,7 @@ namespace Opm
 
         virtual void init(const UnstructuredGrid& g, int num_phases);
 
-        virtual void init(int number_of_cells, int number_of_phases, int num_phases);
+        virtual void init(int number_of_cells, int number_of_faces, int num_phases);
         
         enum ExtremalSat { MinSat, MaxSat };
 
@@ -57,10 +57,15 @@ namespace Opm
                             double epsilon = 1e-8) const;
     private:
         int num_phases_;
+        /// \brief pressure per cell.
         std::vector<double> press_ ;
+        /// \brief temperature per cell.
         std::vector<double> temp_  ;
+        /// \brief pressure per face.
         std::vector<double> fpress_;
+        /// \brief The fluxes at the faces.
         std::vector<double> flux_  ;
+        /// \brief The saturation of each phase per cell.
         std::vector<double> sat_   ;
 
     protected:


### PR DESCRIPTION
We need this for the parallel sim_fibo_ad_cp, where we will need to point to the same parts in two copies without duplicating data.
