### PR TITLE
AdaptiveTimeStepping: improvements.

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping.hpp
@@ -74,7 +74,6 @@ namespace Opm {
         typedef std::unique_ptr< TimeStepControlInterface > TimeStepControlType;
 
         TimeStepControlType timeStepControl_; //!< time step control object
-        const double initial_fraction_;       //!< fraction to take as a guess for initial time interval
         const double restart_factor_;         //!< factor to multiply time step with when solver fails to converge
         const double growth_factor_;          //!< factor to multiply time step when solver recovered from failed convergence
         const double max_time_step_;          //!< maximal allowed time step size

--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -34,7 +34,6 @@ namespace Opm {
 
     AdaptiveTimeStepping::AdaptiveTimeStepping( const parameter::ParameterGroup& param )
         : timeStepControl_()
-        , initial_fraction_( param.getDefault("solver.initialfraction", double(0.25) ) )
         , restart_factor_( param.getDefault("solver.restartfactor", double(0.1) ) )
         , growth_factor_( param.getDefault("solver.growthfactor", double(1.25) ) )
           // default is 1 year, convert to seconds
@@ -100,8 +99,11 @@ namespace Opm {
 
         // init last time step as a fraction of the given time step
         if( last_timestep_ < 0 ) {
-            last_timestep_ = initial_fraction_ * timestep;
+            last_timestep_ = restart_factor_ * timestep;
         }
+
+        // TODO
+        // take change in well state into account
 
         // create adaptive step timer with previously used sub step size
         AdaptiveSimulatorTimer substepTimer( simulatorTimer, last_timestep_, max_time_step_ );
@@ -207,7 +209,7 @@ namespace Opm {
 
 
         // store max of the small time step for next reportStep
-        last_timestep_ = substepTimer.maxStepLength();
+        last_timestep_ = substepTimer.averageStepLength();
         if( timestep_verbose_ )
         {
             substepTimer.report( std::cout );


### PR DESCRIPTION
removed initial_fraction, we use restart factor instead and one parameter less. 

Also, to suggest the time step for the next report interval we use the average of all timesteps used in this report interval. This seems to be a little bit less aggressive. 
