### PR TITLE
Makes right hand side passed to linear solver consistent.

### DIFF
--- a/opm/core/linalg/LinearSolverIstl.cpp
+++ b/opm/core/linalg/LinearSolverIstl.cpp
@@ -196,7 +196,7 @@ namespace Opm
         Vector b(opA.getmat().N());
         std::copy(rhs, rhs+b.size(), b.begin());
         // Make rhs consistent in the parallel case
-        comm.copyOwnerToOverlap(b,b);
+        comm.copyOwnerToAll(b,b);
         // System solution
         Vector x(opA.getmat().M());
         x = 0.0;

--- a/opm/core/linalg/LinearSolverIstl.cpp
+++ b/opm/core/linalg/LinearSolverIstl.cpp
@@ -195,6 +195,8 @@ namespace Opm
                 // System RHS
         Vector b(opA.getmat().N());
         std::copy(rhs, rhs+b.size(), b.begin());
+        // Make rhs consistent in the parallel case
+        comm.copyOwnerToOverlap(b,b);
         // System solution
         Vector x(opA.getmat().M());
         x = 0.0;


### PR DESCRIPTION
Due to the size of the overlap layer and the discretization scheme
the rhs might not contain correct values for overlap cells. This
commit makes sure they are correct by an additional communication step.