### PR TITLE
Reviewed PETSc support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,12 +71,21 @@ macro (sources_hook)
 			)
 	endif (NOT SuiteSparse_FOUND)
 
-	if (NOT PETSC_FOUND)
-		list (REMOVE_ITEM opm-core_SOURCES
-			${PROJECT_SOURCE_DIR}/${opm-core_DIR}/core/linalg/call_petsc.c
-			${PROJECT_SOURCE_DIR}/${opm-core_DIR}/core/linalg/LinearSolverPetsc.cpp
-			)
-	endif (NOT PETSC_FOUND)
+    if (NOT PETSC_FOUND)
+        list (REMOVE_ITEM opm-core_SOURCES
+            ${PROJECT_SOURCE_DIR}/${opm-core_DIR}/core/linalg/petscvector.cpp
+            ${PROJECT_SOURCE_DIR}/${opm-core_DIR}/core/linalg/petscmatrix.cpp
+            ${PROJECT_SOURCE_DIR}/${opm-core_DIR}/core/linalg/petscsolver.cpp
+            ${PROJECT_SOURCE_DIR}/${opm-core_DIR}/core/linalg/petsc.cpp
+            )
+
+		list (REMOVE_ITEM tests_SOURCES
+            ${PROJECT_SOURCE_DIR}/tests/test_petscmixins.cpp
+            ${PROJECT_SOURCE_DIR}/tests/test_petscvector.cpp
+            ${PROJECT_SOURCE_DIR}/tests/test_petscmatrix.cpp
+            ${PROJECT_SOURCE_DIR}/tests/test_petscsolver.cpp
+            )
+    endif (NOT PETSC_FOUND)
 	if ((NOT MPI_FOUND) OR (NOT DUNE_ISTL_FOUND))
 		list (REMOVE_ITEM tests_SOURCES
 			${PROJECT_SOURCE_DIR}/tests/test_parallel_linearsolver.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -53,6 +53,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/core/linalg/LinearSolverPetsc.cpp
 	opm/core/linalg/petscvector.cpp
 	opm/core/linalg/petscmatrix.cpp
+	opm/core/linalg/petscsolver.cpp
 	opm/core/linalg/petsc.cpp
 	opm/core/linalg/call_umfpack.c
 	opm/core/linalg/sparse_sys.c
@@ -175,6 +176,7 @@ list (APPEND TEST_SOURCE_FILES
 	tests/test_petscmixins.cpp
 	tests/test_petscvector.cpp
 	tests/test_petscmatrix.cpp
+	tests/test_petscsolver.cpp
 	tests/test_sparsetable.cpp
 	tests/test_velocityinterpolation.cpp
 	tests/test_quadratures.cpp
@@ -310,6 +312,8 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/linalg/petscmixins.hpp
 	opm/core/linalg/petscvector.hpp
 	opm/core/linalg/petscmatrix.hpp
+	opm/core/linalg/petscsolver.hpp
+	opm/core/linalg/petscsolver_impl.hpp
 	opm/core/linalg/blas_lapack.h
 	opm/core/linalg/call_umfpack.h
 	opm/core/linalg/sparse_sys.h

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -51,6 +51,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/core/linalg/LinearSolverIstl.cpp
 	opm/core/linalg/LinearSolverUmfpack.cpp
 	opm/core/linalg/LinearSolverPetsc.cpp
+	opm/core/linalg/petscvector.cpp
 	opm/core/linalg/petsc.cpp
 	opm/core/linalg/call_umfpack.c
 	opm/core/linalg/sparse_sys.c
@@ -171,6 +172,7 @@ list (APPEND TEST_SOURCE_FILES
 	tests/test_parallelistlinformation.cpp
 	tests/test_sparsevector.cpp
 	tests/test_petscmixins.cpp
+	tests/test_petscvector.cpp
 	tests/test_sparsetable.cpp
 	tests/test_velocityinterpolation.cpp
 	tests/test_quadratures.cpp
@@ -304,6 +306,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/linalg/ParallelIstlInformation.hpp
 	opm/core/linalg/petsc.hpp
 	opm/core/linalg/petscmixins.hpp
+	opm/core/linalg/petscvector.hpp
 	opm/core/linalg/blas_lapack.h
 	opm/core/linalg/call_umfpack.h
 	opm/core/linalg/sparse_sys.h

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -52,6 +52,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/core/linalg/LinearSolverUmfpack.cpp
 	opm/core/linalg/LinearSolverPetsc.cpp
 	opm/core/linalg/petscvector.cpp
+	opm/core/linalg/petscmatrix.cpp
 	opm/core/linalg/petsc.cpp
 	opm/core/linalg/call_umfpack.c
 	opm/core/linalg/sparse_sys.c
@@ -173,6 +174,7 @@ list (APPEND TEST_SOURCE_FILES
 	tests/test_sparsevector.cpp
 	tests/test_petscmixins.cpp
 	tests/test_petscvector.cpp
+	tests/test_petscmatrix.cpp
 	tests/test_sparsetable.cpp
 	tests/test_velocityinterpolation.cpp
 	tests/test_quadratures.cpp
@@ -307,6 +309,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/linalg/petsc.hpp
 	opm/core/linalg/petscmixins.hpp
 	opm/core/linalg/petscvector.hpp
+	opm/core/linalg/petscmatrix.hpp
 	opm/core/linalg/blas_lapack.h
 	opm/core/linalg/call_umfpack.h
 	opm/core/linalg/sparse_sys.h

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -170,6 +170,7 @@ list (APPEND TEST_SOURCE_FILES
 	tests/test_nonuniformtablelinear.cpp
 	tests/test_parallelistlinformation.cpp
 	tests/test_sparsevector.cpp
+	tests/test_petscmixins.cpp
 	tests/test_sparsetable.cpp
 	tests/test_velocityinterpolation.cpp
 	tests/test_quadratures.cpp
@@ -302,6 +303,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/linalg/LinearSolverPetsc.hpp
 	opm/core/linalg/ParallelIstlInformation.hpp
 	opm/core/linalg/petsc.hpp
+	opm/core/linalg/petscmixins.hpp
 	opm/core/linalg/blas_lapack.h
 	opm/core/linalg/call_umfpack.h
 	opm/core/linalg/sparse_sys.h

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -51,6 +51,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/core/linalg/LinearSolverIstl.cpp
 	opm/core/linalg/LinearSolverUmfpack.cpp
 	opm/core/linalg/LinearSolverPetsc.cpp
+	opm/core/linalg/petsc.cpp
 	opm/core/linalg/call_umfpack.c
 	opm/core/linalg/sparse_sys.c
 	opm/core/pressure/CompressibleTpfa.cpp
@@ -300,6 +301,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/linalg/LinearSolverUmfpack.hpp
 	opm/core/linalg/LinearSolverPetsc.hpp
 	opm/core/linalg/ParallelIstlInformation.hpp
+	opm/core/linalg/petsc.hpp
 	opm/core/linalg/blas_lapack.h
 	opm/core/linalg/call_umfpack.h
 	opm/core/linalg/sparse_sys.h

--- a/opm/core/linalg/petsc.cpp
+++ b/opm/core/linalg/petsc.cpp
@@ -1,0 +1,29 @@
+#include <opm/core/linalg/petsc.hpp>
+
+namespace Opm {
+namespace Petsc {
+
+Petsc::Petsc(
+        int* argc,
+        char*** argv,
+        const char* file,
+        const char* help ) {
+
+    PetscInitialize( argc, argv, file, help );
+}
+
+Petsc::~Petsc() {
+    PetscFinalize();
+}
+
+MPI_Comm Petsc::comm() {
+    /* Slight hack to get things working. This sets the communicator used when
+     * constructing new objects - however, this should be configurable. When full
+     * petsc support is figured out this will be modifiable, possibly through
+     * some configuration option or a set_comm function.
+     */
+    return PETSC_COMM_WORLD;
+}
+
+}
+}

--- a/opm/core/linalg/petsc.hpp
+++ b/opm/core/linalg/petsc.hpp
@@ -1,0 +1,33 @@
+#ifndef OPM_PETSC_H
+#define OPM_PETSC_H
+
+/*
+ * This file introduces the Opm::petsc namespace for petsc support, as well as
+ * a RAII helper class to manage the lifetime of the petsc database and MPI
+ * use.
+ */
+
+#define PETSC_CLANGUAGE_CXX 1 //For CHKERRXX macro
+#include <petsc.h>
+
+namespace Opm {
+namespace Petsc {
+
+/*
+ * Initialize this class at the start of your program, and pass argc and argv
+ * from main, then forget about it. This object must be alive before any other
+ * petsc feature is used.
+ */
+
+class Petsc {
+    public:
+        Petsc( int* argc, char*** argv, const char* file, const char* help );
+        ~Petsc();
+
+        static MPI_Comm comm();
+};
+
+}
+}
+
+#endif //OPM_PETSC_H

--- a/opm/core/linalg/petscmatrix.cpp
+++ b/opm/core/linalg/petscmatrix.cpp
@@ -1,0 +1,738 @@
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscvector.hpp>
+#include <opm/core/linalg/petscmatrix.hpp>
+
+
+#include <algorithm>
+#include <cassert>
+#include <memory>
+#include <utility>
+#include <vector>
+
+template< typename T = Opm::Petsc::Matrix::size_type, typename U >
+static inline std::vector< T > range( U begin, U end ) {
+
+    std::vector< T > x( end - begin );
+
+    T value( 0 );
+    auto first = x.begin();
+    const auto last = x.end();
+
+    while( first != last ) {
+        *first++ = value++;
+    }
+
+    return x;
+}
+
+namespace Opm {
+namespace Petsc {
+
+/*
+ * Trivial translation between the strongly typed enum and the
+ * implicit-convertible MatStructure enum.
+ */
+static inline MatStructure
+nz_structure( Matrix::nonzero_pattern x ) {
+    switch( x ) {
+        case Matrix::nonzero_pattern::different:
+            return DIFFERENT_NONZERO_PATTERN;
+
+        case Matrix::nonzero_pattern::subset:
+            return SUBSET_NONZERO_PATTERN;
+
+        case Matrix::nonzero_pattern::same:
+            return SAME_NONZERO_PATTERN;
+    }
+
+    assert( false );
+    /* To silence non-void without return statement warning. This should never
+     * be reached anyways, and is a sure error.
+     */
+    throw;
+}
+
+static inline Mat default_matrix() {
+    /* Meant to be used by other constructors. */
+    Mat x;
+    MatCreate( Petsc::comm(), &x );
+    MatSetFromOptions( x );
+
+    return x;
+}
+
+static inline Mat copy_Matrix( Mat x ) {
+    Mat y;
+    auto err = MatConvert( x, MATSAME, MAT_INITIAL_MATRIX, &y );
+    std::unique_ptr< _p_Mat, deleter< _p_Mat > > result( y ); CHKERRXX( err );
+
+    return result.release();
+}
+
+static inline
+Mat sized_matrix( Matrix::size_type rows, Matrix::size_type cols ) {
+    std::unique_ptr< _p_Mat, deleter< _p_Mat > > result( default_matrix() );
+    auto err = MatSetSizes( result.get(),
+            PETSC_DECIDE, PETSC_DECIDE,
+            rows, cols );
+    CHKERRXX( err );
+
+    return result.release();
+}
+
+Matrix::Matrix( Mat x ) : uptr< Mat >( x ) {}
+
+Matrix::Matrix( const Matrix& x ) : uptr< Mat >( copy_Matrix( x ) ) {}
+
+/*
+ * These constructors are unfortunately slightly complex as full C++11 support
+ * isn't available.
+ *
+ * In C++11 lingo this is basically using a delegating constructor to Matrix(
+ * Matrix&& ) where Matrix has using uptr::uptr set, i.e. the inherited
+ * constructor. This is complicated further by the
+ * implicit-conversion-to-pointer support, which means that just passing
+ * Matrix& to a constructor could trigger the implicit cast, which happens to
+ * be a valid uptr constructor.
+ *
+ * However, the correct behaviour can be ensured by casting. We know that no
+ * classes actually add any fields to the parent class, and we know (by
+ * convention) that it's the parent class that handles ownership. This means
+ * that simply upcasting the pointer to pick the right constructor overload is
+ * sufficient, relying on that constructor to handle ownership. Some complexity
+ * is (necessarily so) added by move semantics, but the benefit here is
+ * obvious.
+ */
+Matrix::Matrix( Matrix&& x ) :
+    uptr< Mat >( std::move( static_cast< uptr< Mat >& >( x ) ) )
+{}
+
+Matrix& Matrix::operator=( const Matrix& rhs ) {
+    Matrix rhs_copy( rhs );
+    this->swap( rhs_copy );
+    return *this;
+}
+
+Matrix& Matrix::operator=( Matrix&& rhs ) {
+    this->swap( rhs );
+    return *this;
+}
+
+Matrix::Matrix( const std::vector< Matrix::scalar >& values,
+                Matrix::size_type rows,
+                Matrix::size_type cols ) :
+        uptr< Mat >( sized_matrix( rows, cols ) )
+{
+    /* this is a very specific load to create a dense Matrix */
+    MatSetType( this->ptr(), MATSEQDENSE );
+
+    auto err = MatSeqDenseSetPreallocation( this->ptr(), NULL );
+    CHKERRXX( err );
+
+    const auto indices = range( 0, std::max( rows, cols ) );
+
+    err = MatSetValues( this->ptr(),
+                    rows, indices.data(),
+                    cols, indices.data(),
+                    values.data(), INSERT_VALUES );
+    CHKERRXX( err );
+
+    err = MatAssemblyBegin( this->ptr(), MAT_FINAL_ASSEMBLY );
+    CHKERRXX( err );
+    err = MatAssemblyEnd( this->ptr(), MAT_FINAL_ASSEMBLY );
+    CHKERRXX( err );
+}
+
+Matrix::size_type Matrix::rows() const {
+    PetscInt x;
+    auto err = MatGetSize( this->ptr(), &x, NULL ); CHKERRXX( err );
+    return x;
+}
+
+Matrix::size_type Matrix::cols() const {
+    PetscInt x;
+    auto err = MatGetSize( this->ptr(), NULL, &x ); CHKERRXX( err );
+    return x;
+}
+
+Matrix& Matrix::operator*=( Matrix::scalar rhs ) {
+    auto err = MatScale( this->ptr(), rhs ); CHKERRXX( err );
+    return *this;
+}
+
+Matrix& Matrix::operator/=( Matrix::scalar rhs ) {
+    return *this *= ( 1 / rhs );
+}
+
+Matrix& Matrix::operator+=( const Matrix& rhs ) {
+    return this->axpy( rhs, 1, nonzero_pattern::different );
+}
+
+Matrix& Matrix::operator-=( const Matrix& rhs ) {
+    return this->axpy( rhs, -1, nonzero_pattern::different );
+}
+
+Matrix& Matrix::operator*=( const Matrix& rhs ) {
+    return this->multiply( rhs );
+}
+
+Matrix operator*( Matrix lhs, Matrix::scalar rhs ) {
+    return lhs *= rhs;
+}
+
+Matrix operator*( Matrix::scalar lhs, Matrix rhs ) {
+    return rhs *= lhs;
+}
+
+Matrix operator/( Matrix lhs, Matrix::scalar rhs ) {
+    return lhs /= rhs;
+}
+
+Matrix operator+( Matrix lhs, const Matrix& rhs ) {
+    return lhs += rhs;
+}
+
+Matrix operator-( Matrix lhs, const Matrix& rhs ) {
+    return lhs -= rhs;
+}
+
+Matrix operator*( const Matrix& lhs, const Matrix& rhs ) {
+    return multiply( lhs, rhs );
+}
+
+Vector operator*( const Matrix& lhs, const Vector& rhs ) {
+    return multiply( lhs, rhs );
+}
+
+Vector operator*( const Vector& lhs, const Matrix& rhs ) {
+    return multiply( rhs, lhs );
+}
+
+bool identical( const Matrix& lhs, const Matrix& rhs ) {
+    /* Comparing a Matrix to itself means they're obviously identical */
+    if( lhs.ptr() == rhs.ptr() ) return true;
+
+    /* PETSc throws an exception if matrices are of different sizes. Because
+     * two matrices of different sizes -cannot- be equal, we check this first
+     */
+    PetscInt row_lhs, col_lhs, row_rhs, col_rhs;
+    auto err = MatGetSize( lhs, &row_lhs, &col_lhs ); CHKERRXX( err );
+    err = MatGetSize( rhs, &row_rhs, &col_rhs ); CHKERRXX( err );
+
+    if( row_lhs != row_rhs ) return false;
+    if( col_lhs != col_rhs ) return false;
+
+    /* MatEqual also considers structure when testing for equality. See:
+     * http://lists.mcs.anl.gov/pipermail/petsc-users/2015-January/024059.html
+     */
+    PetscBool eq;
+    err = MatEqual( lhs, rhs, &eq ); CHKERRXX( err );
+    return eq;
+}
+
+Matrix& Matrix::axpy(
+        const Matrix& x,
+        Matrix::scalar a,
+        Matrix::nonzero_pattern nz ) {
+
+    auto err = MatAXPY( this->ptr(), a, x, nz_structure( nz ) );
+    CHKERRXX( err );
+
+    return *this;
+}
+
+Matrix& Matrix::xpy( const Matrix& x, Matrix::nonzero_pattern nz ) {
+    return this->axpy( x, 1, nz );
+}
+
+Matrix& Matrix::multiply( const Matrix& x ) {
+    auto err = MatMatMult( this->ptr(), x,
+            MAT_REUSE_MATRIX, PETSC_DEFAULT, NULL );
+    CHKERRXX( err );
+
+    return *this;
+}
+
+Matrix& Matrix::transpose() {
+    Mat handle = this->ptr();
+    auto err = MatTranspose( handle, MAT_REUSE_MATRIX, &handle );
+    CHKERRXX( err );
+
+    return *this;
+}
+
+Matrix& Matrix::hermitian_transpose() {
+    auto handle = this->ptr();
+    auto err = MatHermitianTranspose( handle,
+            MAT_REUSE_MATRIX, &handle );
+    CHKERRXX( err );
+
+    return *this;
+}
+
+Matrix multiply( const Matrix& rhs, const Matrix& lhs, Matrix::scalar fill ) {
+    Mat x;
+    MatMatMult( rhs, lhs, MAT_INITIAL_MATRIX, fill, &x );
+
+    return Matrix( x );
+}
+
+Vector multiply( const Matrix& lhs, const Vector& rhs ) {
+    Vec x;
+    auto err = VecDuplicate( rhs, &x ); CHKERRXX( err );
+    MatMult( lhs, rhs, x );
+    return Vector( x );
+}
+
+Matrix transpose( const Matrix& rhs ) {
+    Mat x;
+    MatTranspose( rhs, MAT_INITIAL_MATRIX, &x );
+    return Matrix( x );
+}
+
+Matrix hermitian_transpose( Matrix rhs ) {
+    return rhs.hermitian_transpose();
+}
+
+Matrix::Builder::Builder( Matrix::size_type rows, Matrix::size_type cols )
+    : Matrix( sized_matrix( rows, cols ) )
+{
+
+    /*
+     * This is an awkward case - we haven't been given much preallocation
+     * information to use, so we guess. Using the Builder without setting
+     * proper preallocation may be considered an error in the future.
+     */
+
+    /* first, to avoid overflow, rescale the Matrix dimensions to 1% of its
+     * size. If the Matrix is smaller than 10x10 (unlikely, except for test
+     * cases), just set the new dimensions to 1.
+     */
+    const int m = std::max( 1, rows / 10 );
+    const int n = std::max( 1, cols / 10 );
+
+    /*
+     * Guess nonzeros per row in the diagonal portion of the Matrix. Consider
+     * the Matrix
+     * A | B | C
+     * --+---+---
+     * D | E | F
+     * --+---+---
+     * G | H | I
+     *
+     * Where the letters are sub matrices. The diagonal portion are the
+     * matrices A, E and I.
+     */
+
+    /*
+     * Per row in the diagonal portion we're again assuming 1% fill -of the 1%
+     * Matrix-, i.e. for a 100k row Matrix, we're assuming 10 nonzeros per row.
+     * Falling back to a minimum of 1. We're assuming we have the same number
+     * off the diagonal as well.
+     */
+    const int nnz_on_diag = std::max( 1, ( m * n ) / 100 );
+
+    auto err = MatSeqAIJSetPreallocation( this->ptr(),
+            2 * nnz_on_diag, NULL );
+    CHKERRXX( err );
+
+    err = MatMPIAIJSetPreallocation( this->ptr(),
+            nnz_on_diag, NULL,
+            nnz_on_diag, NULL );
+
+    CHKERRXX( err );
+}
+
+Matrix::Builder::Builder(
+        Matrix::size_type rows,
+        Matrix::size_type cols,
+        const std::vector< Matrix::size_type >& nnz_per_row )
+    : Matrix( sized_matrix( rows, cols ) )
+{
+
+    assert( nnz_per_row.size() == rows );
+
+    auto err = MatSeqAIJSetPreallocation( this->ptr(),
+            /*ignored*/ 0,
+            nnz_per_row.data() );
+    CHKERRXX( err );
+
+    /* Some shenanigans to minimise communication during Matrix assembly.
+     *
+     * It is now sufficient to extract information for the parts that will end
+     * up belonging to this processor. In the worst case - the sequential one -
+     * it ends up being one full array copy.
+     */
+
+    Matrix::size_type begin, end;
+    MatGetOwnershipRange( this->ptr(), &begin, &end );
+
+    std::vector< Matrix::size_type > nnz_diag(
+            nnz_per_row.begin() + begin,
+            nnz_per_row.begin() + end );
+
+    /*
+     * This scheme overcommits local memory by a factor of 2 - that is, if the
+     * nnz_per_row Vector is precise, preallocation will allocate exactly twice
+     * the memory, because it assumes as many nonzeros per row in the
+     * off-diagonals as in the diagonals. If this assumption does not hold and
+     * you want less memory strain, use a different constructor and give it
+     * more information.
+     */
+    err = MatMPIAIJSetPreallocation( this->ptr(),
+            /* ignored */ 0, nnz_diag.data(),
+            /* ignored */ 0, nnz_diag.data() );
+
+    CHKERRXX( err );
+}
+
+Matrix::Builder::Builder(
+        Matrix::size_type rows,
+        Matrix::size_type cols,
+        const std::vector< Matrix::size_type >& nnz_on_diag,
+        const std::vector< Matrix::size_type >& nnz_off_diag )
+    : Matrix( sized_matrix( rows, cols ) )
+{
+
+    assert( nnz_on_diag.size() == nnz_off_diag.size() );
+
+    /* nnz_per_row[ i ] = nnz_on_diag[ i ] + nnz_off_diag[ i ]; */
+    std::vector< Matrix::size_type > nnz_per_row( nnz_on_diag.size() );
+    std::transform( nnz_on_diag.begin(), nnz_on_diag.end(),
+            nnz_off_diag.begin(), nnz_per_row.begin(),
+            std::plus< Matrix::size_type >() );
+
+    /*
+     * We calculate the sequential version's nonzero-per-row by simply
+     * zip-summing the on- and off-diag Vectors
+     */
+    auto err = MatSeqAIJSetPreallocation( this->ptr(),
+            /*ignored*/ 0,
+            nnz_per_row.data() );
+    CHKERRXX( err );
+
+    /* Set only the local values to reduce communication */
+    Matrix::size_type offset;
+    MatGetOwnershipRange( this->ptr(), &offset, NULL );
+
+    err = MatMPIAIJSetPreallocation( this->ptr(),
+            /* ignored */ 0, nnz_on_diag.data() + offset,
+            /* ignored */ 0, nnz_off_diag.data() + offset );
+
+    CHKERRXX( err );
+}
+
+static inline Mat copy_Builder( Mat x ) {
+    /*
+     * We know this is supposed to end up in another Builder, but we must still
+     * use MAT_FINAL_ASSEMBLY, because the operations MatDuplicate and MatCopy
+     * won't work unless the Matrix is fully assembled. As in the similar
+     * Matrix functions, this uses std::unique_ptr to provide exception safety.
+     */
+    auto err = MatAssemblyBegin( x, MAT_FINAL_ASSEMBLY );
+    CHKERRXX( err );
+    err = MatAssemblyEnd( x, MAT_FINAL_ASSEMBLY );
+    CHKERRXX( err );
+
+    Mat y;
+    err = MatDuplicate( x, MAT_COPY_VALUES, &y );
+    std::unique_ptr< _p_Mat, deleter< _p_Mat > > result( y );
+    CHKERRXX( err );
+    err = MatCopy( x, y, DIFFERENT_NONZERO_PATTERN ); CHKERRXX( err );
+
+    return result.release();
+}
+
+/*
+ * More casting fun! See the comments of Matrix::Matrix for reasoning.
+ *
+ * These constructors rely on Matrix to deal with ownership etc., so we really
+ * only concern ourselves with ensuring well-definedness and a consistent,
+ * correct state. We know that these constructors will result in other
+ * Builders, so in the case of moves we do not have to actually assemble the
+ * Matrix properly - rather, flushing it is sufficient to handle the case where
+ * Accumulators are mixed with Inserters.
+ *
+ * Builder copies uses the helper function copy_Builder, as a Matrix must be
+ * fully assembled before duplicate+copy can be used. However, at that point we
+ * know that the copy has been performed and that we have a new Matrix handle,
+ * so we just use the take-ownership-of-raw-pointer constructor.
+ *
+ * Since all these constructors rely on Matrix::Matrix for ownership, it is
+ * sufficient to call that constructor and cast to Matrix& + move
+ *
+ * On top of all of this we're hit by the (ugly) case of too-perfect
+ * forwarding, which would again be resolved slightly by delegating
+ * constructors. In most cases, the Builders are non-const references passed to
+ * eachother, and std::forward would pick the wrong overload in these cases,
+ * giving it to the move constructor. We fix (workaround, rather) this by also
+ * offering a non-const copy constructor. It is a brute-force approach, and
+ * works because it "only" gives three more overloads.
+ */
+Matrix::Builder::Builder( const Matrix::Builder& x ) :
+    Matrix( copy_Builder( x.ptr() ) )
+{}
+
+Matrix::Builder::Builder( Matrix::Builder& x ) :
+    Matrix( copy_Builder( x.ptr() ) )
+{}
+
+Matrix::Builder::Builder( Matrix::Builder&& x ) :
+    Matrix( std::move( static_cast< Matrix& >( x.flush() ) ) )
+{}
+
+Matrix::Builder::Builder( const Matrix::Builder::Accumulator& x ) :
+    Matrix( copy_Builder( x.ptr() ) )
+{}
+Matrix::Builder::Builder( Matrix::Builder::Accumulator& x ) :
+    Matrix( copy_Builder( x.ptr() ) )
+{}
+Matrix::Builder::Builder( Matrix::Builder::Accumulator&& x ) :
+    Matrix( std::move( static_cast< Matrix& >( x.flush() ) ) )
+{}
+
+Matrix::Builder::Builder( const Matrix::Builder::Inserter& x ) :
+    Matrix( copy_Builder( x.ptr() ) )
+{}
+Matrix::Builder::Builder( Matrix::Builder::Inserter& x ) :
+    Matrix( copy_Builder( x.ptr() ) )
+{}
+Matrix::Builder::Builder( Matrix::Builder::Inserter&& x ) :
+    Matrix( std::move( static_cast< Matrix& >( x.flush() ) ) )
+{}
+
+void Matrix::Builder::at(
+        Matrix::size_type row,
+        Matrix::size_type col,
+        Matrix::scalar value,
+        InsertMode mode ) {
+
+    const size_type rows[] = { row };
+    const size_type cols[] = { col };
+    const scalar vals[] = { value };
+
+    auto err = MatSetValues( this->ptr(),
+            1, rows,
+            1, cols,
+            vals, mode ); CHKERRXX( err );
+}
+
+void Matrix::Builder::at(
+        const std::vector< Matrix::scalar >& nonzeros,
+        const std::vector< Matrix::size_type >& row_indices,
+        const std::vector< Matrix::size_type >& col_indices,
+        InsertMode mode ) {
+
+    assert( nonzeros.size() == col_indices.size() );
+
+    for( unsigned int i = 0; i < row_indices.size() - 1; ++i ) {
+        /* the difference between two consecutive elements are the indices in
+         * the col&nonzero Vectors where the current row i is stored
+         */
+        const auto row_entries = row_indices[ i + 1 ] - row_indices[ i ];
+
+        /* empty row - skip ahead */
+        if( !row_entries ) continue;
+
+        /* MatSetValues takes an array */
+        const Matrix::size_type row_index[] = { Matrix::size_type( i ) };
+
+        /* offset to start insertion from */
+        const auto offset = row_indices[ i ];
+
+        const auto err = MatSetValues( this->ptr(),
+                1, row_index,
+                row_entries, col_indices.data() + offset,
+                nonzeros.data() + offset, mode );
+
+        CHKERRXX( err );
+    }
+}
+
+void Matrix::Builder::row(
+        Matrix::size_type row,
+        const std::vector< Matrix::scalar >& values,
+        Matrix::size_type begin,
+        InsertMode mode ) {
+
+    const auto indices = range( begin, size_type( begin + values.size() ) );
+
+    this->row( row, indices, values, mode );
+}
+
+void Matrix::Builder::row(
+        Matrix::size_type row,
+        const std::vector< Matrix::size_type >& indices,
+        const std::vector< Matrix::scalar >& values,
+        InsertMode mode ) {
+
+    /* MatSetValues takes an array */
+    const Matrix::size_type row_index[] = { row };
+
+    const auto err = MatSetValues( this->ptr(),
+            1, row_index,
+            indices.size(), indices.data(),
+            values.data(), mode );
+
+    CHKERRXX( err );
+}
+
+Matrix commit( const Matrix::Builder& x ) {
+    /*
+     * This is a peculiar case. So commit (and copy) doesn't actually -change-
+     * the Builder, but it does require mutability. The flush method calls
+     * MatAssemble from PETSc which flushes the caches and sets up the Matrix
+     * structure. However, this is an implementation detail, and the object
+     * that the Builder exposes is oblivious to this. We use the const_cast
+     * trick to -appear- immutable, while we need mutability to flush our
+     * caches.
+     *
+     * This is ok because the -visible- object does not change, and is for all
+     * intents and purposes still const
+     */
+    const_cast< Matrix::Builder& >( x ).assemble();
+
+    /* Ensure we call Matrix( const Matrix& ). If we call Matrix( const
+     * Builder& ) we would end up in a loop, because the Matrix( Builder& )
+     * copy constructor must also ensure that commit is called.
+     */
+    return Matrix( static_cast< const Matrix& >( x ) );
+}
+
+Matrix commit( Matrix::Builder&& x ) {
+    x.assemble();
+    return static_cast< Matrix&& >( x );
+}
+
+Matrix::Builder& Matrix::Builder::assemble() {
+    auto err = MatAssemblyBegin( this->ptr(), MAT_FINAL_ASSEMBLY );
+    CHKERRXX( err );
+    err = MatAssemblyEnd( this->ptr(), MAT_FINAL_ASSEMBLY );
+    CHKERRXX( err );
+
+    return *this;
+}
+
+Matrix::Builder& Matrix::Builder::flush() {
+    auto err = MatAssemblyBegin( this->ptr(), MAT_FLUSH_ASSEMBLY );
+    CHKERRXX( err );
+    err = MatAssemblyEnd( this->ptr(), MAT_FLUSH_ASSEMBLY );
+    CHKERRXX( err );
+
+    return *this;
+}
+
+Matrix::Builder::Accumulator::Accumulator(
+        Matrix::size_type rows,
+        Matrix::size_type cols ) :
+    Matrix::Builder( rows, cols )
+{}
+
+Matrix::Builder::Accumulator::Accumulator(
+        Matrix::size_type rows,
+        Matrix::size_type cols,
+        const std::vector< Matrix::size_type >& nonzeros ) :
+    Matrix::Builder( rows, cols, nonzeros )
+{}
+
+Matrix::Builder::Accumulator::Accumulator(
+        Matrix::size_type rows,
+        Matrix::size_type cols,
+        const std::vector< Matrix::size_type >& ondiag,
+        const std::vector< Matrix::size_type >& offdiag ) :
+    Matrix::Builder( rows, cols, ondiag, offdiag )
+{}
+
+
+Matrix::Builder::Accumulator& Matrix::Builder::Accumulator::add(
+        Matrix::size_type x,
+        Matrix::size_type y,
+        Matrix::scalar val ) {
+
+    this->at( x, y, val, ADD_VALUES );
+    return *this;
+}
+
+Matrix::Builder::Accumulator& Matrix::Builder::Accumulator::add(
+        const std::vector< scalar >& nonzeros,
+        const std::vector< size_type >& row_indices,
+        const std::vector< size_type >& col_indices ) {
+
+    this->at( nonzeros, row_indices, col_indices, ADD_VALUES );
+    return *this;
+}
+
+Matrix::Builder::Accumulator& Matrix::Builder::Accumulator::add_row(
+        size_type row,
+        const std::vector< scalar >& values,
+        size_type begin ) {
+    this->row( row, values, begin, ADD_VALUES );
+    return *this;
+}
+
+Matrix::Builder::Accumulator& Matrix::Builder::Accumulator::add_row(
+        size_type row,
+        const std::vector< size_type >& cols,
+        const std::vector< scalar >& vals ) {
+    this->row( row, cols, vals, ADD_VALUES );
+    return *this;
+}
+
+Matrix::Builder::Inserter::Inserter(
+        Matrix::size_type rows,
+        Matrix::size_type cols ) :
+    Matrix::Builder( rows, cols )
+{}
+
+Matrix::Builder::Inserter::Inserter(
+        Matrix::size_type rows,
+        Matrix::size_type cols,
+        const std::vector< Matrix::size_type >& nonzeros ) :
+    Matrix::Builder( rows, cols, nonzeros )
+{}
+
+Matrix::Builder::Inserter::Inserter(
+        Matrix::size_type rows,
+        Matrix::size_type cols,
+        const std::vector< Matrix::size_type >& ondiag,
+        const std::vector< Matrix::size_type >& offdiag ) :
+    Matrix::Builder( rows, cols, ondiag, offdiag )
+{}
+
+
+Matrix::Builder::Inserter& Matrix::Builder::Inserter::insert(
+        Matrix::size_type x,
+        Matrix::size_type y,
+        Matrix::scalar val ) {
+
+    this->at( x, y, val, INSERT_VALUES );
+    return *this;
+}
+
+Matrix::Builder::Inserter& Matrix::Builder::Inserter::insert(
+        const std::vector< scalar >& nonzeros,
+        const std::vector< size_type >& row_indices,
+        const std::vector< size_type >& col_indices ) {
+
+    this->at( nonzeros, row_indices, col_indices, INSERT_VALUES );
+    return *this;
+}
+
+Matrix::Builder::Inserter& Matrix::Builder::Inserter::insert_row(
+        size_type row,
+        const std::vector< scalar >& values,
+        size_type begin ) {
+    this->row( row, values, begin, INSERT_VALUES );
+    return *this;
+}
+
+Matrix::Builder::Inserter& Matrix::Builder::Inserter::insert_row(
+        size_type row,
+        const std::vector< size_type >& cols,
+        const std::vector< scalar >& vals ) {
+    this->row( row, cols, vals, INSERT_VALUES );
+    return *this;
+}
+
+}
+}

--- a/opm/core/linalg/petscmatrix.hpp
+++ b/opm/core/linalg/petscmatrix.hpp
@@ -1,0 +1,665 @@
+#ifndef OPM_PETSCMATRIX_H
+#define OPM_PETSCMATRIX_H
+
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscmixins.hpp>
+
+
+#include <petscmat.h>
+
+#include <memory>
+#include <vector>
+
+namespace Opm {
+namespace Petsc {
+
+class Vector;
+
+template<>
+struct deleter< _p_Mat >
+{ void operator()( Mat x ) { MatDestroy( &x ); } };
+
+/// @brief PETSc Matrix object
+///
+/// This object is mostly structurally immutable, that is, once it is
+/// constructed its nonzero pattern cannot be modified except through
+/// Matrix arithmetic-assignment operations. To construct a new Matrix,
+/// please see the Matrix::Builder class.
+///
+/// Matrix is implicitly convertible to Mat, so it can be used directly in
+/// PETSc functions. However, I do not recommend this for other things than
+/// development and debugging - if some feature is needed from the Vector,
+/// consider implementing it in the library.
+
+class Matrix : public uptr< Mat > {
+    public:
+        typedef PetscScalar scalar;
+        typedef PetscInt size_type;
+
+        class Builder;
+
+        enum class nonzero_pattern { different, subset, same };
+
+        Matrix() = delete;
+
+        /// @brief Acquire ownership of a raw PETSc handle
+        Matrix( Mat );
+        /// @brief Copy constructor.
+        Matrix( const Matrix& );
+        /// @brief Copy constructor.
+        Matrix( Matrix&& );
+
+        /// @brief  Construct a (dense) Matrix from std::vector
+        /// Interprets the Vector as a logical rows*columns 2D array.
+        /// \param[in] Vector       Logically 2D std::vector to copy from
+        /// \param[in] rows         Number of rows
+        /// \param[in] columns      Number of columns
+        Matrix( const std::vector< scalar >&, size_type, size_type );
+
+        Matrix& operator=( const Matrix& );
+        Matrix& operator=( Matrix&& );
+
+        /// @brief Get number of rows.
+        /// \param[out] size    Number of rows in the Matrix
+        size_type rows() const;
+        /// @brief Get number of cols.
+        /// \param[out] size    Number of columns in the Matrix
+        size_type cols() const;
+
+        /// @brief Scalar multiplication, A = cA.
+        /// \param[in] scalar   Value to scale with
+        Matrix& operator*=( scalar );
+        /// @brief Inverse scalar multiplication (division)
+        /// \param[in] scalar   Value to scale with
+        Matrix& operator/=( scalar );
+
+        /// @brief  Matrix addition, A + B.
+        ///         Equivalent to axpy( x, 1, different ). If you know your
+        ///         matrices have identical nonzero patterns, consider
+        ///         using axpy instead
+        /// \param[in] Matrix   Matrix to add
+        Matrix& operator+=( const Matrix& );
+        /// @brief      Matrix subtraction, A - B.
+        ///             Equivalent to axpy( x, -1, different ). If you know
+        ///             your matrices have identical nonzero patterns,
+        ///             consider using axpy instead.
+        /// \param[in] Matrix   Matrix to add
+        Matrix& operator-=( const Matrix& );
+
+        /// @brief  A *= B, where A and B are matrices
+        /// Equivalent to multiply( B );
+        /// \param[in] B        The Matrix B
+        Matrix& operator*=( const Matrix& );
+
+        /* these currently do not have to be friends (since Matrix is
+         * implicitly convertible to Mat), but they are for least possible
+         * surprise
+         */
+        friend Matrix operator*( Matrix, scalar );
+        friend Matrix operator*( scalar, Matrix );
+        friend Matrix operator/( Matrix, scalar );
+
+        friend Matrix operator+( Matrix, const Matrix& );
+        friend Matrix operator-( Matrix, const Matrix& );
+        /// @brief  C = A * B
+        /// Equivalent to multiply( A, B )
+        /// \param[in] A    The Matrix A
+        /// \param[in] B    The Matrix B
+        /// \return    C    The Matrix C
+        friend Matrix operator*( const Matrix&, const Matrix& );
+
+        /// @brief  y = Ax, Matrix-Vector multiplication
+        /// Equivalent to multiply( A, x )
+        friend Vector operator*( const Matrix&, const Vector& );
+        friend Vector operator*( const Vector&, const Matrix& );
+
+        /// @brief Tests if two matrices are identical.
+        ///
+        ///         This also checks Matrix structure, so two identical
+        ///         sparse matrices with different nonzero structure but
+        ///         with explicit zeros will evaluate to false
+        friend bool identical( const Matrix&, const Matrix& );
+
+        /// @brief A += aB
+        /// \param[in] B        The Matrix B
+        /// \param[in] alpha    The constant alpha
+        /// \param[in] pattern  The nonzero pattern relationship
+        Matrix& axpy( const Matrix&, scalar, nonzero_pattern );
+
+        /// @brief  A += B.
+        /// Equivalent to axpy( Matrix, 1, pattern )
+        /// \param[in] Matrix   The Matrix X
+        /// \param[in] alpha    The constant alpha
+        /// \param[in] pattern  The nonzero pattern relationship
+        Matrix& xpy( const Matrix&, nonzero_pattern );
+
+        /// @brief  A *= B.
+        ///         Assumes, if sparse, that A and B have the same nonzero pattern
+        /// \param[in] B        The Matrix B
+        Matrix& multiply( const Matrix& );
+
+        /// @brief  A *= B
+        ///         Assumes, if sparse, that A and B have the same nonzero pattern
+        /// \param[in] B        The Matrix B
+        /// \param[in] fill     The nonzero fill ratio
+        /// nnz(C)/( nnz(A) + nnz(B) )
+        Matrix& multiply( const Matrix&, scalar fill );
+
+        /// @brief In-place transposes the Matrix, A <- A^T
+        Matrix& transpose();
+
+        /// @brief In-place hermitian transposes the Matrix, A <- A^H
+        Matrix& hermitian_transpose();
+
+    private:
+        Matrix( size_type, size_type );
+};
+
+/// @brief  Matrix-Matrix multiplication.
+///         This is similar to operator*, but with more flexibility as you
+///         can tune the fill. The expected fill ratio of the multiplication
+///         C = A * B is nonzero(C)/(nonzero(A)+nonzero(B)).
+///
+///         Defaults to letting PETSc decide.
+///         If experimenting, using PETSc's -info option can print the correct
+///         ratio (under fill ratio)
+/// \param[in] A    Matrix A (left-hand side)
+/// \param[in] B    Matrix B (right-hand side)
+/// \param[in] fill (Optional) Matrix fill ratio
+Matrix multiply( const Matrix&, const Matrix&, Matrix::scalar = PETSC_DECIDE );
+
+/// @brief y = Ax, Matrix-Vector multiplication.
+/// \param[in] A    The Matrix
+/// \param[in] x    The Vector
+/// \return    y    The result Vector
+Vector multiply( const Matrix&, const Vector& );
+
+/// @brief A^T
+/// \param[in]  A   Matrix
+/// \return     A^T The transposed Matrix A
+Matrix transpose( const Matrix& );
+/// @brief A^H
+/// \param[in]  A   Matrix
+/// \return     A^H The hermetian transposed Matrix A
+Matrix hermitian_transpose( Matrix );
+
+/// @brief  Non-fully constructed Matrix
+///         See \see { Matrix::Builder::Inserter Matrix::Builder::Accumulator }
+///         for the implementations of this concept.
+///
+///         The motivation behind this class is to explicitly separate the
+///         Matrix construction and assembly phase from a ready-to-use
+///         Matrix. This provides static and tools that prevents possibly
+///         ill-formed code from compiling, as well as giving the
+///         and user more information regarding intent.
+///
+///         The general procedure is:
+///         #1: determine dimensions of the Matrix.
+///         #2: construct a Matrix::Builder with these dimensions. This is
+///             unchangeable once the Builder is created.
+///         #3: set non-zero coordinates in the Matrix, possibly with a
+///             value. See Matrix::Builder::insert.
+///         #4: construct the completed Matrix either by returning the
+///             Builder, passing it to Matrix' constructor or by calling
+///             commit() on the Builder.
+///         In code, this would be:
+///         \code{.cpp}
+///         Matrix create_Matrix( const Grid& grid ) {
+///             auto dim = grid.dimensions();
+///             Matrix::Builder::Inserter Builder( dim, dim );
+///
+///             for( auto g : grid ) {
+///                 /* perform passes over your data and determine nonzero
+///                  * coordinates in the Matrix
+///                  */
+///                 Builder.insert( g.x, g.y );
+///                 Builder.insert( g.y, g.x, g.val() );
+///             }
+///
+///         // move constructor - will reuse the Builders' resources
+///         return Builder;
+///         }
+///         \endcode
+///
+///         Please note that to achieve performance you have to provide
+///         information on the Matrix' nonzero pattern and call the
+///         approperiate constructor. In many cases this means an extra
+///         pass over your data, but it can result in massive speedup in
+///         in Matrix allocation.
+
+class Matrix::Builder : private Matrix {
+    /*
+     * This is more of a "namespace" class and implementation detail rather
+     * than something to be exposed. All constructors are private, so it is
+     * obviously not meant to be instantiated by some user. See the Inserter
+     * and Accumulator classes which are user-facing.
+     */
+    public:
+        class Accumulator;
+        class Inserter;
+
+        typedef Matrix::scalar scalar;
+        typedef Matrix::size_type size_type;
+    private:
+        /// @internal
+        /// @copydoc Matrix::Builder::Accumulator( size_type, size_type )
+        /// @endinternal
+        Builder( size_type, size_type );
+
+        /// @internal
+        /// @copydoc Matrix::Builder::Accumulator( size_type,
+        ///                                        const std::vector< size_type >& )
+        /// @endinternal
+        Builder( size_type, size_type, const std::vector< size_type >& );
+
+        /// @internal
+        /// @copydoc Matrix::Builder::Accumulator( size_type, size_type,
+        ///     const std::vector< size_type >&,
+        ///     const std::vector< size_type >& )
+        /// @endinternal
+        Builder(    size_type, size_type,
+                    const std::vector< size_type >&,
+                    const std::vector< size_type >& );
+
+        /// @internal
+        /// @copydoc Matrix::Builder::Accumulator( const Accumulator& )
+        /// @endinternal
+        Builder( const Builder& );
+        Builder( Builder& );
+        Builder( Builder&& );
+
+        Builder( const Accumulator& );
+        Builder( Accumulator& );
+        Builder( Accumulator&& );
+
+        Builder( const Inserter& );
+        Builder( Inserter& );
+        Builder( Inserter&& );
+
+        /*
+         * I don't actually want to support operator= for PETSc types, but they
+         * are defined nevertheless out of necessity. A pattern that emerges in
+         * plenty of OPM code already is an init() separate from the
+         * constructor. This raises the need of a "default" constructor, but
+         * this is out of the question for Builders. A workaround is to
+         * construct a zero-sized Matrix and later move-assign into that
+         * object.
+         *
+         * The obvious solution to this is to rewrite the (broken) code, but as
+         * operator= is provided as a temporary measure. The use of this
+         * operator is highly discouraged.
+         */
+
+        Builder& operator=( Builder&& rhs ) {
+            static_cast< Matrix& >( *this ) = std::move( static_cast< Matrix& >( rhs ) );
+            return *this;
+        }
+
+        /// @internal
+        /// @brief  Insert a single value.
+        /// Defaults to 0.
+        /// \param[in] row      The row to insert at
+        /// \param[in] col      The col to insert at
+        /// \param[in] value    (Optional) the value to insert.
+        /// @endinternal
+        void at( size_type, size_type, scalar, InsertMode );
+
+        /// @internal
+        /// @brief  Insert a full (sub)Matrix in CSR format.
+        ///         This is more efficient than inserting single values.
+        ///         If the (sub)Matrix sets some value previously set,
+        ///         that value will be overwritten by the value in the
+        ///         latest call.
+        ///
+        ///         This might in the future be superseded by a stricter CSR type
+        ///
+        ///         The row indices Vector is of length rows+1, and with a
+        ///         [begin,end) pattern.
+        /// \param[in] nonzero     The CSR nonzero Vector
+        /// \param[in] row_indices The CSR rowindices Vector
+        /// \param[in] col_indices The CSR colindices Vector
+        /// @endinternal
+        void at(    const std::vector< scalar >& nonzeros,
+                    const std::vector< size_type >& row_indices,
+                    const std::vector< size_type >& col_indices,
+                    InsertMode );
+
+        /// @internal
+        /// @brief  Insert a row into the Matrix.
+        ///         Inserts from [begin, begin + vec.size())
+        ///         This does not overwrite anything beyond vec.size()
+        /// \param[in] row      Row to insert
+        /// \param[in] values   Values to insert
+        /// \param[in] begin    Where in the row to start insertion
+        /// @endinternal
+        void row(   size_type,
+                    const std::vector< scalar >&,
+                    size_type,
+                    InsertMode );
+
+        /// @internal
+        /// @brief  Insert a row into the Matrix at specific indices.
+        ///         This does not overwrite anything not touched by the column
+        ///         indices Vector. Values must be equal in size to columns.
+        /// \param[in] row      Row to insert
+        /// \param[in] columns  Vector of column indices to insert
+        /// \param[in] values   Values to insert
+        /// @endinternal
+        void row(   size_type,
+                    const std::vector< size_type >&,
+                    const std::vector< scalar >&,
+                    InsertMode );
+
+        /// @internal
+        /// Assembles the Matrix to a finalized state, where no more elements
+        /// can be added.
+        /// @endinternal
+        Builder& assemble();
+        /// @internal
+        /// Flushes the cache, making it possible to mix add and insert
+        /// operations.
+        /// @endinternal
+        Builder& flush();
+
+        friend class Matrix;
+        friend Matrix commit( const Builder& );
+        friend Matrix commit( Builder&& );
+};
+
+/// @brief  Commit the currently built structure into a completed Matrix.
+///         This copies the currently built structure and returns a
+///         completed, ready-to-use Matrix. Ideal for when several matrices
+///         have identical submatrices.
+Matrix commit( const Matrix::Builder& );
+
+/// @brief  Commit the currently built structure into a completed Matrix.
+///         This moves the currently built structure and returns a
+///         completed, ready-to-use Matrix, and leaves the builder in a valid,
+///         but unspecified state. Do not use the builder after move-commit has
+///         been performed.
+Matrix commit( Matrix::Builder&& );
+
+
+/*
+ * The inheritance here is an implementation detail only. It handles nifty
+ * things such as the commit method and removes the need for explicit
+ * constructors, which is nice. the Builder class is a shared implementation
+ * and namespace only. This applies to the Inserter too.
+ */
+/// @brief Accumulating Matrix Builder, i.e. A[n,m] += v
+///
+/// This Builder class sets by values and submatrices by accumulation, and is
+/// primarily intended for incremental construction as a staging area. Ideally
+/// you should construct your system through Matrix operations, but sometimes
+/// that solution is infeasible.
+///
+/// All operations supported by this Builder perform a += on the cell(s) in
+/// question. Obviously, by giving it a negative value it would become a -=.
+///
+/// Use commit() or pass the object as an argument to Matrix' to finalize the
+/// Matrix when it is ready for use.
+class Matrix::Builder::Accumulator : public Matrix::Builder {
+    private:
+        friend class Matrix::Builder::Inserter;
+        friend class Matrix::Builder;
+
+    public:
+        typedef Matrix::scalar scalar;
+        typedef Matrix::size_type size_type;
+
+        /*
+         * GCC4.4 does not support inheriting constructors (but it is a C++11
+         * feature), so we have to go through the (tedious) job of declaring
+         * them ourselves. Their implementation, however, is derived from
+         * Matrix::Builder, so it should simply be forwarding calls.
+         *
+         * The entire multiple inheritance shenanigans will disappear once
+         * the full C++11 standard can be used.
+         */
+
+        /* We derive copy and move constructors from Builder::Builder by
+         * performing a combined forward-and-cast to its constructor
+         */
+        template< typename T >
+        Accumulator( T&& x ) : Builder( std::forward< T >( x ) ) {}
+
+        /// @brief  Constructor.
+        ///         PETSc has to know the dimensions of the Matrix
+        ///         beforehand, so a default constructor is not provided.
+        ///         This constructor performs a guess on nonzeros (for
+        ///         preallocation) and is likely to be inefficient. If
+        ///         you can provide more information regarding nonzero
+        ///         pattern, please use a different constructor.
+        /// \param[in] rows Number of rows
+        /// \param[in] cols Number of columns
+        Accumulator( size_type, size_type );
+
+        /// @brief  Nonzeros per row hinted constructor
+        ///         Suggest the number of nonzeros per row, where each
+        ///         index in the Vector corresponds to that row, i.e.
+        ///         vec[ 0 ] => row 0. Consider the Matrix
+        ///             0 0 1 0
+        ///             2 3 0 0
+        ///             0 0 0 0
+        ///             4 0 0 0
+        ///         The ideal constructor would then be
+        ///         Builder( 4, 4, { 1, 2, 0, 1 } );
+        /// \param[in] rows     Number of rows
+        /// \param[in] cols     Number of columns
+        /// \param[in] nonzeros Nonzeros per row.
+        Accumulator( size_type, size_type, const std::vector< size_type >& );
+
+        /// @brief  Nonzeros on/off diagonal hinted constructor
+        ///         Suggest the (average) number of nonzeros on and off the
+        ///         diagonal portion of the Matrix. Consider the Matrix
+        ///
+        ///             A | B | C
+        ///             --+---+---
+        ///             D | E | F
+        ///             --+---+---
+        ///             G | H | I
+        ///
+        ///         Where the letters are sub matrices. The diagonal
+        ///         portion are the matrices A, E and I. Please refer to
+        ///         the PETSc documentation for a slightly more elaborate
+        ///         example: http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/Mat/MatMPIAIJSetPreallocation.html
+        ///
+        ///         This function is currently not MPI aware, so if you
+        ///         want MPI aware allocation, determining which process
+        ///         owns which subMatrix and only give it those coordinates,
+        ///         must be handled by the user.
+        ///
+        /// \param[in] rows     Number of rows.
+        /// \param[in] cols     Number of columns.
+        /// \param[in] diag     Vector of nonzeros per row on the diagonal
+        ///                     portion.
+        /// \param[in] offdiag  Vector of nonzeros per row on the
+        ///                      off-diagonal portion of the Matrix.
+        Accumulator(    size_type, size_type,
+                        const std::vector< size_type >&,
+                        const std::vector< size_type >& );
+
+        /// @brief  Insert a single value.
+        /// Defaults to 0.
+        /// \param[in] row      The row to insert at
+        /// \param[in] col      The col to insert at
+        /// \param[in] value    (Optional) the value to insert.
+        Accumulator& add( size_type, size_type, scalar = scalar() );
+
+        /// @brief  Insert a full (sub)Matrix in CSR format.
+        ///         This is more efficient than inserting single values.
+        ///         If the (sub)Matrix sets some value previously set,
+        ///         that value will be overwritten by the value in the
+        ///         latest call.
+        ///
+        ///         This might in the future be superseded by a stricter CSR type
+        ///
+        ///         The row indices Vector is of length rows+1, and with a
+        ///         [begin,end) pattern.
+        /// \param[in] nonzero     The CSR nonzero Vector
+        /// \param[in] row_indices The CSR rowindices Vector
+        /// \param[in] col_indices The CSR colindices Vector
+        Accumulator& add(  const std::vector< scalar >& nonzeros,
+                const std::vector< size_type >& row_indices,
+                const std::vector< size_type >& col_indices );
+
+        /// @brief  Insert a row into the Matrix.
+        ///         Inserts from [begin, begin + vec.size())
+        ///         This does not overwrite anything beyond vec.size()
+        /// \param[in] row      Row to insert
+        /// \param[in] values   Values to insert
+        /// \param[in] begin    Where in the row to start insertion
+        Accumulator& add_row( size_type,
+                const std::vector< scalar >&,
+                size_type = 0 );
+
+        /// @brief  Insert a row into the Matrix at specific indices.
+        ///         This does not overwrite anything not touched by the column
+        ///         indices Vector. Values must be equal in size to columns.
+        /// \param[in] row      Row to insert
+        /// \param[in] columns  Vector of column indices to insert
+        /// \param[in] values   Values to insert
+        Accumulator& add_row( size_type,
+                    const std::vector< size_type >&,
+                    const std::vector< scalar >& );
+};
+/// @brief Inserting Matrix Builder, i.e. A[n,m] = v
+///
+/// This Builder class sets by values and submatrices by insertion. It is the
+/// preferred method of building matrices, however, Matrix::Builder::Accumulator
+/// is provided if your problem requires an accumulating staging area.
+///
+/// All operations supported by this Builder perform an assignment on the
+/// cell(s) in question. Repeated insertions in the same cell turns into the
+/// value set last.
+///
+/// Use commit() or pass the object as an argument to Matrix' to finalize the
+/// Matrix when it is ready for use.
+
+class Matrix::Builder::Inserter : public Matrix::Builder {
+    private:
+        friend class Matrix::Builder::Accumulator;
+        friend class Matrix::Builder;
+
+    public:
+        typedef Matrix::scalar scalar;
+        typedef Matrix::size_type size_type;
+
+        template< typename T >
+        Inserter( T&& x ) : Builder( std::forward< T >( x ) ) {}
+
+        /*
+         * GCC4.4 does not support inheriting constructors (but it is a C++11
+         * feature), so we have to go through the (tedious) job of declaring
+         * them ourselves. Their implementation, however, is derived from
+         * Matrix::Builder, so it should simply be forwarding calls.
+         *
+         * The entire multiple inheritance shenanigans will disappear once
+         * the full C++11 standard can be used.
+         */
+
+        /// @brief  Constructor.
+        ///         PETSc has to know the dimensions of the Matrix
+        ///         beforehand, so a default constructor is not provided.
+        ///         This constructor performs a guess on nonzeros (for
+        ///         preallocation) and is likely to be inefficient. If
+        ///         you can provide more information regarding nonzero
+        ///         pattern, please use a different constructor.
+        /// \param[in] rows Number of rows
+        /// \param[in] cols Number of columns
+        Inserter( size_type, size_type );
+
+        /// @brief  Nonzeros per row hinted constructor
+        ///         Suggest the number of nonzeros per row, where each
+        ///         index in the Vector corresponds to that row, i.e.
+        ///         vec[ 0 ] => row 0. Consider the Matrix
+        ///             0 0 1 0
+        ///             2 3 0 0
+        ///             0 0 0 0
+        ///             4 0 0 0
+        ///         The ideal constructor would then be
+        ///         Builder( 4, 4, { 1, 2, 0, 1 } );
+        /// \param[in] rows     Number of rows
+        /// \param[in] cols     Number of columns
+        /// \param[in] nonzeros Nonzeros per row.
+        Inserter( size_type, size_type, const std::vector< size_type >& );
+
+        /// @brief  Nonzeros on/off diagonal hinted constructor
+        ///         Suggest the (average) number of nonzeros on and off the
+        ///         diagonal portion of the Matrix. Consider the Matrix
+        ///
+        ///             A | B | C
+        ///             --+---+---
+        ///             D | E | F
+        ///             --+---+---
+        ///             G | H | I
+        ///
+        ///         Where the letters are sub matrices. The diagonal
+        ///         portion are the matrices A, E and I. Please refer to
+        ///         the PETSc documentation for a slightly more elaborate
+        ///         example: http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/Mat/MatMPIAIJSetPreallocation.html
+        ///
+        ///         This function is currently not MPI aware, so if you
+        ///         want MPI aware allocation, determining which process
+        ///         owns which subMatrix and only give it those coordinates,
+        ///         must be handled by the user.
+        ///
+        /// \param[in] rows     Number of rows.
+        /// \param[in] cols     Number of columns.
+        /// \param[in] diag     Vector of nonzeros per row on the diagonal
+        ///                     portion.
+        /// \param[in] offdiag  Vector of nonzeros per row on the
+        ///                      off-diagonal portion of the Matrix.
+        Inserter(       size_type, size_type,
+                        const std::vector< size_type >&,
+                        const std::vector< size_type >& );
+
+        /// @brief  Insert a single value.
+        /// Defaults to 0.
+        /// \param[in] row      The row to insert at
+        /// \param[in] col      The col to insert at
+        /// \param[in] value    (Optional) the value to insert.
+        Inserter& insert( size_type, size_type, scalar = scalar() );
+
+        /// @brief  Insert a full (sub)Matrix in CSR format.
+        ///         This is more efficient than inserting single values.
+        ///         If the (sub)Matrix sets some value previously set,
+        ///         that value will be overwritten by the value in the
+        ///         latest call.
+        ///
+        ///         This might in the future be superseded by a stricter CSR type
+        ///
+        ///         The row indices Vector is of length rows+1, and with a
+        ///         [begin,end) pattern.
+        /// \param[in] nonzero     The CSR nonzero Vector
+        /// \param[in] row_indices The CSR rowindices Vector
+        /// \param[in] col_indices The CSR colindices Vector
+        Inserter& insert(   const std::vector< scalar >& nonzeros,
+                            const std::vector< size_type >& row_indices,
+                            const std::vector< size_type >& col_indices );
+
+        /// @brief  Insert a row into the Matrix.
+        ///         Inserts from [begin, begin + vec.size())
+        ///         This does not overwrite anything beyond vec.size()
+        /// \param[in] row      Row to insert
+        /// \param[in] values   Values to insert
+        /// \param[in] begin    Where in the row to start insertion
+        Inserter& insert_row(   size_type,
+                                const std::vector< scalar >&,
+                                size_type = 0 );
+
+        /// @brief  Insert a row into the Matrix at specific indices.
+        ///         This does not overwrite anything not touched by the column
+        ///         indices Vector. Values must be equal in size to columns.
+        /// \param[in] row      Row to insert
+        /// \param[in] columns  Vector of column indices to insert
+        /// \param[in] values   Values to insert
+        Inserter& insert_row(   size_type,
+                                const std::vector< size_type >&,
+                                const std::vector< scalar >& );
+};
+
+}
+}
+
+#endif //OPM_PETSCMATRIX_H

--- a/opm/core/linalg/petscmixins.hpp
+++ b/opm/core/linalg/petscmixins.hpp
@@ -1,0 +1,79 @@
+#ifndef OPM_PETSC_MIXINS_H
+#define OPM_PETSC_MIXINS_H
+
+#include <memory>
+
+namespace Opm {
+namespace petsc {
+
+/*
+ * Deleters are implemented in the same files that declares the class they're
+ * to delete, i.e. petscvector.hpp for vector deleter.
+ */
+template< typename T > struct deleter;
+
+/*
+ * petsc typedefs its handles from _p_Vec* (etc) to Vec. It is certainly nicer
+ * to, in the class declaration, declare the type you -actually- want exposed,
+ * so we use a template trick to remove the pointer part of the type and infer
+ * the underlying type. This is done by first declaring a shell template class,
+ * to introduce the symbol, then specialise for a pointer type. Notice that
+ * uptr is only forward declared and never gets an implementation - this is by
+ * design, so that we get compiler errors in case it is used wrong.
+ */
+template< typename T > class uptr;
+
+/*
+ * Here we take the pointer typedef, e.g. Vec and Mat, and strip the pointer so
+ * that unique_ptr can use them. This avoids double indirection, making sure
+ * the uptr mixin provides no extra overhead.
+ */
+template< typename T >
+class uptr< T* > : private std::unique_ptr< T, deleter< T > > {
+    private:
+        typedef T* pointer;
+        typedef std::unique_ptr< T, deleter< T > > base;
+
+    public:
+        /*
+         * We only want a specific subset of constructors, and generally not
+         * other methods.  The reasoning here is that avoiding direct pointer
+         * access makes code easier to change in the future and less reliant on
+         * actual implementation.
+         */
+
+        uptr< T* >( uptr< T* >&& );
+        uptr< T* >( T* );
+
+        using base::operator=;
+
+        operator pointer() const;
+
+    protected:
+        inline pointer ptr() const;
+};
+
+/*
+ * Implementations
+ */
+
+template< typename T>
+uptr< T* >::uptr( uptr< T* >&& x ) : base( std::move( x ) ) {}
+
+template< typename T>
+uptr< T* >::uptr( T* x ) : base( x ) {}
+
+template< typename T >
+uptr< T* >::operator uptr< T* >::pointer() const {
+    return this->ptr();
+}
+
+template< typename T >
+T* uptr< T* >::ptr() const {
+    return this->get();
+}
+
+}
+}
+
+#endif //OPM_PETSC_MIXINS_H

--- a/opm/core/linalg/petscmixins.hpp
+++ b/opm/core/linalg/petscmixins.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 
 namespace Opm {
-namespace petsc {
+namespace Petsc {
 
 /*
  * Deleters are implemented in the same files that declares the class they're
@@ -45,13 +45,82 @@ class uptr< T* > : private std::unique_ptr< T, deleter< T > > {
         uptr< T* >( uptr< T* >&& );
         uptr< T* >( T* );
 
-        using base::operator=;
-
         operator pointer() const;
 
     protected:
         inline pointer ptr() const;
+
+        void swap( uptr& );
 };
+
+/*
+ * GCC4.4 does not support explicit conversion operators, so we implement the
+ * feature manually for the cases that might need them (see: petscsolver.cpp
+ * and convergence_report.
+ *
+ * In order to implement explicit operator bool() support, public inherit from
+ * this and imlpement the function explicit_boolean_test( const your_type& ):
+ *
+ * class new_type : explicit_bool_conversion< new_type > {};
+ * explicit_boolean_test( const new_type& x ) { return x.is_true(); }
+ *
+ * Obviously, explicit_boolean_test must be a visible symbol.
+ */
+class bool_base {
+    public:
+        operator bool() const = delete;
+        void unsupported_comparison_between_types() const {};
+
+    protected:
+        bool_base() = default;
+        bool_base( const bool_base& ) = default;
+        bool_base& operator=( const bool_base& ) = default;
+};
+
+template< typename T >
+class explicit_bool_conversion : private bool_base {
+    public:
+        operator bool() const {
+            return explicit_boolean_test( static_cast< const T& >( *this ) ) ?
+                &bool_base::unsupported_comparison_between_types : false;
+        }
+};
+
+/*
+ * Works like Haskell's newtype keyword, i.e. constructs a new type "alias".
+ * This is particularly useful in combination with overloading and will in most
+ * cases give simpler, cleaner and easier-to-read code.
+ *
+ * The newtype mixin creates a thin, typed layer (which compiles to zero
+ * overhead). The obvious use case is to carry semantics along with data. e.g.
+ * passing the newtype "age" instead of a raw int.
+ *
+ * For ease of implementation it only supports read-only data, i.e. once the
+ * type is set it is not possible to update the data, as the only access to it
+ * is implicit conversion. Meant for primary types.
+ *
+ * We offer the macro mknewtype( typename, basetype ) for ease of creation.
+ * Since we want to use the constructor from newtype and C++11 support in
+ * GCC4.4 haven't got inheriting constructors (using Base::Base;), we must
+ * implement "all" constructors manually.
+ */
+
+template< typename T >
+class newtype {
+    public:
+        template< typename U > newtype( U&& t );
+        operator T() const;
+
+    private:
+        T data;
+};
+
+#define mknewtype( name, basetype )                         \
+struct name : public Opm::Petsc::newtype< basetype > {      \
+    template< typename T > name( T&& t ) :                  \
+        Opm::Petsc::newtype< basetype >(                    \
+                std::forward< T >( t ) ) {}                 \
+}
 
 /*
  * Implementations
@@ -71,6 +140,46 @@ uptr< T* >::operator uptr< T* >::pointer() const {
 template< typename T >
 T* uptr< T* >::ptr() const {
     return this->get();
+}
+
+template< typename T >
+void uptr< T* >::swap( uptr< T* >& rhs ) {
+    this->std::unique_ptr< T, deleter< T > >::swap( rhs );
+}
+
+template< typename T >
+template< typename U >
+newtype< T >::newtype( U&& x ) : data( std::forward< U >( x ) ) {}
+
+template< typename T >
+newtype< T >::operator T() const {
+    return this->data;
+}
+
+template < typename T >
+bool operator==( const explicit_bool_conversion< T >& lhs, bool b) {
+    return b == static_cast< bool >( lhs );
+}
+
+template < typename T >
+bool operator==( bool b, const explicit_bool_conversion< T >& rhs ) {
+    return b == static_cast< bool >( rhs );
+}
+
+template < typename T, typename U >
+bool operator==( const explicit_bool_conversion< T >& lhs,
+        const explicit_bool_conversion< U >& rhs ) {
+
+    lhs.unsupported_comparison_between_types();
+    return false;
+}
+
+template < typename T, typename U >
+bool operator!=( const explicit_bool_conversion< T >& lhs,
+        const explicit_bool_conversion< U >& rhs ) {
+
+    lhs.unsupported_comparison_between_types();
+    return false;
 }
 
 }

--- a/opm/core/linalg/petscsolver.cpp
+++ b/opm/core/linalg/petscsolver.cpp
@@ -1,0 +1,156 @@
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscmatrix.hpp>
+#include <opm/core/linalg/petscsolver.hpp>
+#include <opm/core/linalg/petscvector.hpp>
+#include <opm/core/utility/ErrorMacros.hpp>
+
+namespace Opm {
+namespace Petsc {
+
+static inline SNES default_Solver() {
+    SNES x;
+    SNESCreate( Petsc::comm(), &x );
+    SNESSetFromOptions( x );
+
+    return x;
+}
+
+Solver::Solver() : uptr< SNES >( default_Solver() ) {}
+
+template<>
+Solver::Convergence_report< KSPConvergedReason > Solver::converged() const {
+    KSPConvergedReason x;
+    KSPGetConvergedReason( *this, &x );
+    return Convergence_report< KSPConvergedReason >( x, KSPConvergedReasons[ x ] );
+}
+
+template<>
+Solver::Convergence_report< SNESConvergedReason > Solver::converged() const {
+    SNESConvergedReason x;
+    SNESGetConvergedReason( *this, &x );
+    return Convergence_report< SNESConvergedReason >( x, SNESConvergedReasons[ x ] );
+}
+
+Vector Solver::operator()( const Matrix& A, const Vector& b ) {
+
+    Vec raw_x;
+    auto err = VecDuplicate( b, &raw_x );
+    CHKERRXX( err );
+
+    Vector x( raw_x );
+
+    /* The PC Matrix defaults to the system Matrix */
+    Mat pc_operator = A;
+    PetscBool pcop_set;
+
+    err = KSPGetOperatorsSet( *this, NULL, &pcop_set ); CHKERRXX( err );
+    if( pcop_set ) {
+        /* if the preconditioner operator has been set from elsewhere - make
+         * sure we don't overwrite it.
+         * 
+         * We do as suggested by PETSc documentation,
+         * http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/KSP/KSPSetOperators.html
+         */
+        err = KSPGetOperators( *this, NULL, &pc_operator );
+        CHKERRXX( err );
+    }
+
+    err = KSPSetOperators( *this, A, pc_operator ); CHKERRXX( err );
+
+    err = KSPSolve( *this, b, x ); CHKERRXX( err );
+
+    if( this->converged< KSPConvergedReason >() ) return x;
+
+    OPM_THROW( std::runtime_error, this->converged< KSPConvergedReason >() );
+}
+
+Solver::operator PC() const {
+    PC x;
+    KSPGetPC( *this, &x );
+    return x;
+}
+
+Solver::operator KSP() const {
+    KSP x;
+    SNESGetKSP( this->ptr(), &x );
+    return x;
+}
+
+Solver& Solver::set() {
+    return *this;
+}
+
+Solver& Solver::set( Pc_type type ) {
+    auto err = PCSetType( *this, type ); CHKERRXX( err );
+    return *this;
+}
+
+Solver& Solver::set( Ksp_type type ) {
+    auto err = KSPSetType( *this, type ); CHKERRXX( err );
+    return *this;
+}
+
+Solver& Solver::set( Snes_type type ) {
+    auto err = SNESSetType( *this, type ); CHKERRXX( err );
+    return *this;
+}
+
+Solver& Solver::set( const Matrix& B ) {
+    Mat ksp_operator;
+    auto err = KSPGetOperators( *this, &ksp_operator, NULL ); CHKERRXX( err );
+    err = PetscObjectReference( (PetscObject)ksp_operator ); CHKERRXX( err );
+    err = KSPSetOperators( *this, ksp_operator, B ); CHKERRXX( err );
+    return *this;
+}
+
+Solver& Solver::set( const Solver::Linear_tolerance& tol ) {
+    auto err = KSPSetTolerances( *this,
+            tol.relative_tolerance,
+            tol.absolute_tolerance,
+            tol.divergence_tolerance,
+            tol.maximum_iterations );
+    CHKERRXX( err );
+    return *this;
+}
+
+Solver::Linear_tolerance::Linear_tolerance() :
+    relative_tolerance( PETSC_DEFAULT ),
+    absolute_tolerance( PETSC_DEFAULT ),
+    divergence_tolerance( PETSC_DEFAULT ),
+    maximum_iterations( PETSC_DEFAULT )
+{}
+
+Solver::Linear_tolerance::Linear_tolerance(
+        Solver::real rtol,
+        Solver::real atol,
+        Solver::real dtol,
+        Solver::size_type maxit ) :
+    relative_tolerance( rtol ),
+    absolute_tolerance( atol ),
+    divergence_tolerance( dtol ),
+    maximum_iterations( maxit )
+{}
+
+Solver::Nonlinear_tolerance::Nonlinear_tolerance() :
+    relative_tolerance( PETSC_DEFAULT ),
+    absolute_tolerance( PETSC_DEFAULT ),
+    solution_change_tolerance( PETSC_DEFAULT ),
+    maximum_iterations( PETSC_DEFAULT ),
+    maximum_function_evals( PETSC_DEFAULT )
+{}
+
+Solver::Nonlinear_tolerance::Nonlinear_tolerance(
+        Solver::real rtol,
+        Solver::real atol,
+        Solver::real stol,
+        Solver::size_type maxit,
+        Solver::size_type maxf ) :
+    relative_tolerance( rtol ),
+    absolute_tolerance( atol ),
+    solution_change_tolerance( stol ),
+    maximum_iterations( maxit ),
+    maximum_function_evals( maxf )
+{}
+
+}
+}

--- a/opm/core/linalg/petscsolver.hpp
+++ b/opm/core/linalg/petscsolver.hpp
@@ -1,0 +1,317 @@
+#ifndef OPM_PETSCSOLVER_H
+#define OPM_PETSCSOLVER_H
+
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscmixins.hpp>
+
+namespace Opm {
+namespace Petsc {
+
+class Vector;
+class Matrix;
+
+template<>
+struct deleter< _p_SNES >
+{ void operator()( SNES x ) { SNESDestroy( &x ); } };
+
+/// @brief Unified handle for PETSc preconditioner, krylov subspace methods
+///     and nonlinear solvers.
+///
+///     PETSc solvers are arranged in a hierarchy, where krylov subspace method
+///     solvers (from now on ksp or KSP) uses preconditioners (pc or PC), and
+///     ksp is again used by non-linear solvers (snes or SNES).
+///
+///     Two interfaces are offered: a plain use-once function that constructs
+///     solver, sets the parameters, solves the problem and returns the
+///     solution vector and a context handle object interface that breaks up
+///     this process into multiple steps and gives you slightly more control
+///     over component or context reuse. In most cases you should prefer the
+///     function call over reusing context, but for certain applications this
+///     is infeasible.
+///
+///     There are two general uses:
+///         #1: designing a new problem solution
+///         #2: setting "permanent" parameters for the solvers once the optimal
+///             solution has been found through profiling and testing.
+///
+///     For case #1 you generally only want the default constructor or the
+///     plain functional interface. Consider solving the linear system Ax = b:
+///     \code{.cpp}
+///     auto x = Opm::petsc::solve( A, b );
+///     \endcode
+///     Various configurations are now just fetched from the PETSc option
+///     database, which in turn is built from command line options, which
+///     should be handled from argv to the Opm::petsc::petsc class. The
+///     benefit of developing this way is that it is quick and easy to change
+///     various parameters such as ksp algorithm, Matrix layout and tolerances.
+///     Should you for some reason perfer using a solver context handle,
+///     construct the solver and use operator() once all options has been set.
+///
+///     \code{.cpp}
+///     Opm::petsc::solver handle;
+///     /* set options */
+///     auto x = handle( A, b );
+///     \endcode
+///     Again, when developing your algorithm I recommend setting as few
+///     options as possible directly on the handle, but rather through command
+///     line options.
+///
+///     For case #2, when the optimal parameters have been determined, you
+///     should consider setting (and documenting!) the ideal options for the
+///     current problem. While not necessary, it enables you and others to use
+///     the options database for tuning different problems without interfering
+///     with your configuration, as well as providing a form of documentation
+///     and experience for the problem at hand. To set various parameters, use
+///     the solver::set() family of methods (if using the context handle) or by
+///     adding the parameters to your call to solve.
+///
+///     All options can be set with the solver::set() method. This is
+///     overloaded based on the -type- of the parameter, and not by name, and
+///     repeated calls can be chained. This is easier explained with example
+///     code:
+///     \code{.cpp}
+///     Opm::Petsc::Solver::Ksp_type linalg( "cg" ); // conjugate gradient
+///     Opm::Petsc::Solver::Pc_type precond( "ilu" ); // ILU(0) preconditioner
+///     auto op = get_precond_operator();
+///
+///     // functional:
+///     auto xf = Opm::Petsc::solve( A, b, linalg, precond, op );
+///
+///     // call-on-object:
+///     Opm::Petsc::Solver handle;
+///     handle.set( linalg ).
+///            set( precond ).
+///            set( op );
+///
+///     auto xo = handle( A, b );
+///
+///     // idiomatically, with args constructed as they are passed:
+///     auto xi = Opm::Petsc::solve( A, b,
+///         Opm::Petsc::Solver::Ksp_type( "gmres" ),
+///         Opm::Petsc::Solver::Pc_type( "sor" ) );
+///     \endcode
+///
+///     Please note that the order of calls to set or the order of arguments,
+///     except for A and b, is irrelevant. Both these solutions are equivalent.
+///
+///     The operator() was chosen so that you can do a "partial application" of
+///     options determined from somewhere else, and then return the correct
+///     "function" to call. Again, illustrated by a code example:
+///
+///     \code{.cpp}
+///     Opm::Petsc::Solver determine_ideal_algorithm() {
+///         Opm::Petsc::Solver handle;
+///         /* black magic that determines if gmres or cg is the best */
+///         switch( rand() % 2 ) {
+///             case 0:
+///                 return handle.set( Solver::Ksp_type( "cg" ) );
+///             case 1:
+///                 return handle.set( Solver::Ksp_type( "gmres" ) );
+///         }
+///
+///         return handle;
+///     }
+///
+///     int fun() {
+///         auto A = get_Matrix();
+///         auto b = get_vec();
+///
+///         auto linsolve = determine_ideal_algorithm();
+///         auto x = linsolve( A, b );
+///     }
+///     \endcode
+///
+///     On behaviour: By default, the operator/Matrix for the preconditioner is
+///     A, unless some other operator has been given.
+///
+///     The solver handle is implicitly convertible to the PETSc types SNES,
+///     KSP and PC, so you can directly call PETSc functions with this object.
+///     I do, however, not recommend this in production code - rather, if it is
+///     an option that needs setting it should be implemented through here.
+
+class Solver : public uptr< SNES > {
+    public:
+        struct Linear_tolerance;
+        struct Nonlinear_tolerance;
+
+        template< typename T >
+        struct Convergence_report;
+
+        /// @brief Alias for PetscReal, typically a (long) double
+        typedef PetscReal real;
+        /// @brief Alias for PetscScalar, typically a (long) double
+        typedef PetscScalar scalar;
+        /// @brief Alias for PetscInt, typically a long integer
+        typedef PetscInt size_type;
+
+        /// @brief Constructor
+        Solver();
+
+        /*
+         * Make type aliases for the algorithm name strings
+         * This is used to explicitly set what algorithm to use for various
+         * parts of the numerical process (preconditioning, linear and
+         * non-linear part, respectively)
+         *
+         * This macro is defined in petscmixins.hpp
+         */
+        /// @brief  Type alias for PCType, typically const char*
+        ///         The pc_type alias is used to set preconditioner algorithm
+        ///         in the solver.
+        mknewtype( Pc_type, PCType );
+        /// @brief  Type alias for KSPType, typically const char*
+        ///         The ksp_type alias is used to set linear solver (krylov
+        ///         subspace method) algorithm in the solver.
+        mknewtype( Ksp_type, KSPType );
+        /// @brief  Type alias for SNESType, typically const char*
+        ///         The snes_type alias is used to set the nonlinear algorithm
+        ///         in the solver.
+        mknewtype( Snes_type, SNESType );
+
+        operator PC() const;
+        operator KSP() const;
+
+        Solver& set( const Linear_tolerance& );
+        Solver& set( const Nonlinear_tolerance& );
+
+        /// @brief Set operator to use for the preconditioner
+        Solver& set( const Matrix& );
+
+        /*
+         * petsc uses strings to set algorithm types. This was probably
+         * chosen because petsc supports ad-hoc adding new algorithms or
+         * implementations, which means you need a dynamic system for
+         * registering and addressing, and enums (which would've otherwise
+         * been the superiour choice) does not offer that. We could
+         * implement our own enums of algorithms we choose to support, but
+         * just using strings is fine too. However, in order to provide at
+         * least a bit of safety, we introduce new thin types over the
+         * different -kinds- of algorithms. To set, say, the conjugent
+         * gradient method, call solver.set( ksp_type( "cg" ) );
+         *
+         * An added benefit is that ksp_type( "cg" ); communicates intent a
+         * lot better than const char* = "cg";
+         */
+        /// @brief Set preconditioner algorithm
+        Solver& set( Pc_type );
+        /// @brief Set ksp algorithm
+        Solver& set( Ksp_type );
+        /// @brief Set non-linear algorithm
+        Solver& set( Snes_type );
+
+        //TODO: support initial guess by passing a vector&& which provides
+        //storage & gets returned by operator()
+
+        /*
+         * This trick to converts T& into const T& if it cannot find a suitable
+         * T& overload. Since the variadic set() perfectly forwards its
+         * arguments, we need a way to convert from T& to const T&.
+         *
+         * The problem occurs when, which is common, an object is declared as
+         * non-const in the enclosing scope. This is passed as T& to set, which
+         * is distinct from set( const T& ). This would again call the
+         * templated T&, leading to infinite recursion. Unless a suitable
+         * non-templated set( T& ) is defined, this one is called which
+         * attempts to find a const'd method.
+         *
+         */
+        template< typename T >
+        Solver& set( T& );
+
+        template< typename T, typename... Args >
+        Solver& set( T&&, Args&& ... );
+
+        /// @brief Solve the linear system Ax = b
+        /// \param[in]  A   The system Matrix
+        /// \param[in]  b   The system solution
+        /// \return     x   The augmenting vector
+        Vector operator()( const Matrix& A, const Vector& b );
+
+    private:
+        /* 
+         * base case for the variadic template params setter, this is a no-op.
+         * Should not be available to end-users, but must be available to
+         * solve().
+         */
+        Solver& set();
+
+        template< typename... Args >
+        friend Vector solve( const Matrix&, const Vector&, Args&& ... );
+
+        template< typename T >
+        Convergence_report< T > converged() const;
+};
+
+/// @brief  Solve the linear system Ax = b
+/// \param[in]  A       The system Matrix
+/// \param[in]  b       The system solution
+/// \param[in] args...  An arbitrary (possibly none) number of options
+/// \return     x       The augmenting vector
+template< typename... Args >
+Vector solve( const Matrix&, const Vector&, Args&& ... );
+
+/// @brief  Tolerance parameters for linear equations.
+///         A simple collection of relative tolerance, absolute tolerance,
+///         divergence tolerance and maximum iterations.
+struct Solver::Linear_tolerance {
+    Linear_tolerance();
+    Linear_tolerance( real, real, real, size_type );
+
+    Solver::real relative_tolerance;
+    Solver::real absolute_tolerance;
+    Solver::real divergence_tolerance;
+    Solver::size_type maximum_iterations;
+};
+
+/// @brief  Tolerance parameters for non-linear equations.
+///         A simple collection of relative tolerance, absolute tolerance,
+///         tolerance of the norm change between steps, maximum iterations and
+///         maximum function evaluations.
+struct Solver::Nonlinear_tolerance {
+    Nonlinear_tolerance();
+    Nonlinear_tolerance( real, real, real, size_type, size_type );
+
+    Solver::real relative_tolerance;
+    Solver::real absolute_tolerance;
+    Solver::real solution_change_tolerance;
+    Solver::size_type maximum_iterations;
+    Solver::size_type maximum_function_evals;
+};
+
+/// @brief  Solution convergence report.
+///         This simple struct reports whether or not the attempted solution
+///         converged. Is implicitly convertible to bool, so convergence can be
+///         tested with if( report ). Has std::ostream<< overload provided, but
+///         can be accessed directly if you want to generate your own messages
+///         log entries.
+template< typename T >
+struct Solver::Convergence_report :
+    public explicit_bool_conversion< Solver::Convergence_report< T > > {
+    // TODO: add iteration number? remove implicit T()-conversion?
+
+    T reason;
+    const char* description;
+
+    /* we want the implicit conversions, but we don't want (especially the
+     * bool case) to break type safety. Post C++11 this can be handled by
+     * marking the operator bool() explicit, but GCC only supports that
+     * after 4.5. A solution is to explicitly implement comparison
+     * operators for the convergence_report that will fail on anything but
+     * the desired case: if( converged ) {}
+     *
+     * For a reference on this, see:
+     * http://en.wikibooks.org/wiki/More_C++_Idioms/Safe_bool
+     */
+
+    Convergence_report( T, const char* );
+
+    operator T() const;
+    operator const char*() const;
+};
+
+}
+}
+
+#include <opm/core/linalg/petscsolver_impl.hpp>
+
+#endif //OPM_PETSCSOLVER_H

--- a/opm/core/linalg/petscsolver_impl.hpp
+++ b/opm/core/linalg/petscsolver_impl.hpp
@@ -1,0 +1,71 @@
+#ifndef OPM_PETSCSOLVER_IMPL
+#define OPM_PETSCSOLVER_IMPL
+
+#include <ostream>
+
+#include <opm/core/linalg/petscvector.hpp>
+#include <iostream>
+
+/*
+ * This file holds the implementations of the template functions and methods
+ * defined in petscsolver.hpp
+ */
+
+namespace Opm {
+namespace Petsc {
+
+template< typename T >
+bool explicit_boolean_test( const Solver::Convergence_report< T >& );
+
+template< typename T >
+Solver::Convergence_report< T >::Convergence_report( T r, const char* d ) :
+    reason( r ),
+    description( d )
+{}
+
+template< typename T >
+bool explicit_boolean_test( const Solver::Convergence_report< T >& x ) {
+    return x.reason > 0;
+}
+
+template< typename T >
+Solver::Convergence_report< T >::operator T() const {
+    return this->reason;
+}
+
+template< typename T >
+Solver::Convergence_report< T >::operator const char*() const {
+    return this->description;
+}
+
+template< typename T >
+Solver& Solver::set( T& head ) {
+    return this->set( static_cast< const T& >( head ) );
+}
+
+template< typename T, typename... Args >
+Solver& Solver::set( T&& head, Args&&... tail ) {
+    return this->set( std::forward< T >( head ) )
+        .set( std::forward< Args >( tail )... );
+}
+
+template< typename... Args >
+Vector solve( const Matrix& A, const Vector& b, Args&& ... args ) {
+    return Solver().set( std::forward< Args >( args )... )( A, b );
+}
+
+template< typename... Args >
+Vector solve( const Vector& b, Args&& ... args ) {
+    return Solver().set( std::forward< Args >( args )... )( b );
+}
+
+}
+}
+
+template< typename T >
+std::ostream& operator<<( std::ostream& stream,
+        const Opm::Petsc::Solver::Convergence_report< T >& report ) {
+    return stream << static_cast< const char* >( report );
+}
+
+#endif //OPM_PETSCSOLVER_IMPL

--- a/opm/core/linalg/petscvector.cpp
+++ b/opm/core/linalg/petscvector.cpp
@@ -1,0 +1,246 @@
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscvector.hpp>
+
+#include <cassert>
+#include <memory>
+#include <utility>
+
+#include <iostream>
+
+namespace Opm {
+namespace Petsc {
+
+static inline std::vector< Vector::size_type >
+range( Vector::size_type begin, Vector::size_type end ) {
+    using namespace std;
+
+    std::vector< Vector::size_type > x( end - begin );
+    /* with full C++11 support this can be replaced with a call to std::iota */
+
+    Vector::size_type value( 0 );
+    auto first = x.begin();
+    const auto last = x.end();
+
+    while( first != last ) {
+        *first++ = value++;
+    }
+
+    return x;
+}
+
+static inline Vec default_Vector() {
+    /* Meant to be used by other constructors. */
+    Vec x;
+    VecCreate( Petsc::comm(), &x );
+    VecSetFromOptions( x );
+
+    return x;
+}
+
+/* To provide exception safety, wrap the Vector handles in a manged
+ * (unique_ptr) object. While it looks a bit ugly, it is used basically only in
+ * a few functions, so it should be ok.
+ *
+ * Using delegating constructors (gcc4.7-4.8) would be better, so a future TODO
+ * is to remove these functions in favour of delegating constructors.
+ */
+
+static inline Vec copy_Vector( Vec x ) {
+    Vec y;
+    auto err = VecDuplicate( x, &y ); CHKERRXX( err );
+    std::unique_ptr< _p_Vec, deleter< _p_Vec > > result( y );
+    err = VecCopy( x, y ); CHKERRXX( err );
+
+    return result.release();
+}
+
+static inline Vec sized_Vector( Vector::size_type size ) {
+    std::unique_ptr< _p_Vec, deleter< _p_Vec > > result( default_Vector() );
+
+    auto err = VecSetSizes( result.get(), PETSC_DECIDE, size );
+    CHKERRXX( err );
+
+    return result.release();
+}
+
+static inline Vec set_Vector( const std::vector< Vector::scalar >& values,
+                            const std::vector< Vector::size_type >& indices ) {
+
+    assert( values.size() == indices.size() );
+
+    std::unique_ptr< _p_Vec, deleter< _p_Vec > >
+        result( sized_Vector( values.size() ) );
+
+    auto err = VecSetValues( result.get(), values.size(),
+            indices.data(), values.data(),
+            INSERT_VALUES );
+    CHKERRXX( err );
+
+    err = VecAssemblyBegin( result.get() ); CHKERRXX( err );
+    err = VecAssemblyEnd( result.get() ); CHKERRXX( err );
+
+    return result.release();
+
+}
+
+Vector::Vector( Vec x ) : uptr< Vec >( x ) {}
+
+Vector::Vector( const Vector& x ) : uptr< Vec >( copy_Vector( x ) ) {}
+
+Vector::Vector( Vector&& x ) : uptr< Vec >( std::move( x ) ) {}
+
+/*
+ * When we can move to full C++11 support, these should ideally be implemented
+ * with delegating constructors.
+ */
+
+Vector::Vector( Vector::size_type size ) : uptr< Vec >( sized_Vector( size ) ) {}
+
+Vector::Vector( Vector::size_type size, Vector::scalar x ) :
+        uptr< Vec >( sized_Vector( size ) )
+{
+    this->assign( x );
+}
+
+Vector::Vector( const std::vector< Vector::scalar >& values ) :
+    uptr< Vec >( set_Vector( values, range( 0, values.size() ) ) )
+{}
+
+Vector::Vector( const std::vector< Vector::scalar >& values,
+                const std::vector< Vector::size_type >& indexset ) :
+    uptr< Vec >( set_Vector( values, indexset ) )
+{}
+
+Vector::size_type Vector::size() const {
+    PetscInt x;
+    auto err = VecGetSize( this->ptr(), &x ); CHKERRXX( err );
+    return x;
+}
+
+void Vector::assign( Vector::scalar x ) {
+    auto err = VecSet( this->ptr(), x ); CHKERRXX( err );
+}
+
+Vector& Vector::operator+=( Vector::scalar rhs ) {
+    auto err = VecShift( this->ptr(), rhs ); CHKERRXX( err );
+    return *this;
+}
+
+Vector& Vector::operator-=( Vector::scalar rhs ) {
+    return *this += -rhs;
+}
+
+Vector& Vector::operator*=( Vector::scalar rhs ) {
+    auto err = VecScale( this->ptr(), rhs ); CHKERRXX( err );
+    return *this;
+}
+
+Vector& Vector::operator/=( Vector::scalar rhs ) {
+    return *this *= ( 1 / rhs );
+}
+
+Vector& Vector::operator+=( const Vector& rhs ) {
+    if( this->ptr() == rhs.ptr() ) {
+        /* adding something to itself is equivalent to *= 2.
+         * VecAXPY breaks if both arguments are the same, so this must be
+         * special-cased.
+         */
+        return *this *= 2;
+    }
+
+    auto err = VecAXPY( this->ptr(), 1, rhs ); CHKERRXX( err );
+    return *this;
+}
+
+Vector& Vector::operator-=( const Vector& rhs ) {
+    if( this->ptr() == rhs.ptr() ) {
+        this->assign( 0 );
+        return *this;
+    }
+
+    auto err = VecAXPY( this->ptr(), -1, rhs ); CHKERRXX( err );
+    return *this;
+}
+
+Vector operator+( Vector lhs, Vector::scalar rhs ) {
+    return lhs += rhs;
+}
+
+Vector operator-( Vector lhs, Vector::scalar rhs ) {
+    return lhs -= rhs;
+}
+
+Vector operator*( Vector lhs, Vector::scalar rhs ) {
+    return lhs *= rhs;
+}
+
+Vector operator/( Vector lhs, Vector::scalar rhs ) {
+    return lhs /= rhs;
+}
+
+Vector operator+( Vector lhs, const Vector& rhs ) {
+    return lhs += rhs;
+}
+
+Vector operator-( Vector lhs, const Vector& rhs ) {
+    return lhs -= rhs;
+}
+
+Vector::scalar operator*( const Vector& lhs, const Vector& rhs ) {
+    assert( lhs.size() == rhs.size() );
+
+    return dot( lhs, rhs );
+}
+
+bool Vector::operator==( const Vector& other ) const {
+    PetscBool eq;
+    VecEqual( this->ptr(), other, &eq );
+    return eq;
+}
+
+bool Vector::operator!=( const Vector& other ) const {
+    return !( *this == other );
+}
+
+inline void Vector::set( const Vector::scalar* values,
+        const Vector::size_type* indices,
+        Vector::size_type size ) {
+
+    /*
+     * TODO: reimplement this smarter, i.e. use setvalues and local updates if
+     * possible
+     */
+
+    auto err = VecSetValues( this->ptr(), size,
+            indices, values, INSERT_VALUES ); CHKERRXX( err );
+
+    err = VecAssemblyBegin( this->ptr() ); CHKERRXX( err );
+    err = VecAssemblyEnd( this->ptr() ); CHKERRXX( err );
+}
+
+Vector::scalar dot( const Vector& lhs, const Vector& rhs ) {
+    Vector::scalar x;
+    VecDot( lhs, rhs, &x );
+    return x;
+}
+
+Vector::scalar sum( const Vector& v ) {
+    Vector::scalar x;
+    auto err = VecSum( v, &x ); CHKERRXX( err );
+    return x;
+}
+
+Vector::scalar max( const Vector& v ) {
+    Vector::scalar x;
+    auto err = VecMax( v, NULL, &x ); CHKERRXX( err );
+    return x;
+}
+
+Vector::scalar min( const Vector& v ) {
+    Vector::scalar x;
+    auto err = VecMin( v, NULL, &x ); CHKERRXX( err );
+    return x;
+}
+
+}
+}

--- a/opm/core/linalg/petscvector.hpp
+++ b/opm/core/linalg/petscvector.hpp
@@ -1,0 +1,168 @@
+#ifndef OPM_PETSCVECTOR_H
+#define OPM_PETSCVECTOR_H
+
+/*
+ * C++ bindings to Petsc Vec.
+ *
+ * Provides an easy-to-use C++-esque implementation with no extra indirection
+ * for Petsc Vec. Slightly radical in design, but in spirit with Petsc: no
+ * direct memory access is allowed, and no iterators are provided. Due to the
+ * nature of Petsc there usually is no guarantee that the memory you want to
+ * access lives in your process. All interactions with the vector should happen
+ * through functions - possibly general higher-order functions at a later time.
+ *
+ * The idea is to get (some) of Petsc's power, but easier to use. Tested to
+ * without effort be able to use MPI. Supports arithmetic operators and should
+ * be easy to reason about. Lifetime is managed through unique_ptr for safety
+ * and simplicity - no need to implement custom assignment and move operators.
+ *
+ * Note that a default-constructed vector is NOT allowed. While this makes it
+ * slightly harder to use in a class (you most likely shouldn't anyways), it
+ * disallows more invalid states at compile-time.
+ *
+ * Also note that there are no set-methods for values. This is by design, but
+ * they might be added later if there is a need for it. Structurally, this
+ * leaves the vector immutable.
+ *
+ * Please note that all methods in the vector class only deal with it's
+ * structure. This is by design - everything needed to compute something about
+ * the vector is or will be provided as free functions, in order to keep
+ * responsibilities separate.
+ *
+ * The vector gives no guarantees for internal representation.
+ *
+ * TODO: When full C++11 support can be used, most constructors can be
+ * rewritten to use ineheriting constructors.
+ */
+
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscmixins.hpp>
+
+#include <petscvec.h>
+
+#include <vector>
+
+namespace Opm {
+namespace Petsc {
+
+    template<>
+    struct deleter< _p_Vec >
+    { void operator()( Vec x ) { VecDestroy( &x ); } };
+
+    /// @brief PETSc Vector object
+    ///
+    /// The Vector class mirrors some aspects of std::vector's interface, but
+    /// the implementation can be fully distributed, so there is no direct
+    /// memory or member access. The Vector may also be sparse.
+    ///
+    /// Vector is implicitly convertible to Vec, so it can be used directly in
+    /// PETSc functions. However, I do not recommend this for other things than
+    /// development and debugging - if some feature is needed from the Vector,
+    /// consider implementing it in the library.
+
+    class Vector : public uptr< Vec > {
+        public:
+            typedef PetscScalar scalar;
+            typedef PetscInt size_type;
+
+            using uptr< Vec >::operator=;
+
+            Vector() = delete;
+
+            /* This can in (full) C++11 be implemented with
+             * using uptr< Vec >::uptr; i.e. inheriting constructors. GCC4.4
+             * has no support for this, so we must implement the call
+             * ourselves.
+             */
+            /// @brief Acquire ownership of a raw PETSc handle
+            Vector( Vec );
+            /// @brief Copy constructor.
+            Vector( const Vector& );
+            /// @brief Move constrcutor.
+            Vector( Vector&& );
+
+            /// @brief Constructor. Does not populate the Vector with values.
+            /// \param[in] size     Number of elements
+            explicit Vector( size_type );
+            /// Constructor. Populate [0..n-1] with scalar. This is equivalent
+            /// Vector v( size ); v.assign( scalar );
+            /// \param[in]  size    Number of elements
+            /// \param[in]  scalar  Value to set
+            explicit Vector( size_type, scalar );
+
+            /// @brief Construct from std::vector.
+            /// \param[in] Vector   std::vector to copy from
+            Vector( const std::vector< scalar >& );
+            /// @brief Construct from std::vector at the indices provided by
+            /// indexset. Negative indices are ignored.
+            /// \param[in] Vector   std::vector to copy from
+            /// \param[in] indexset indices to assign values from the Vector.
+            Vector( const std::vector< scalar >&,
+                    const std::vector< size_type >& indexset );
+
+            /// @brief Get Vector size.
+            /// \param[out] size    Number of elements in the Vector
+            size_type size() const;
+
+            /// @brief Assign a value to all elements in the Vector.
+            /// \param[in] scalar  The value all elements will have
+            void assign( scalar );
+
+            /// @brief Add a value to all elements in the Vector.
+            /// \param[in] scalar   Value to add to all elements
+            Vector& operator+=( scalar );
+            /// @brief Subtract a value from all elements in the Vector.
+            /// \param[in] scalar   Value to subtract from all elements
+            Vector& operator-=( scalar );
+            /// @brief Scalar multiplication.
+            /// \param[in] scalar   Value to scale with
+            Vector& operator*=( scalar );
+            /// @brief Inverse scalar multiplication (division)
+            /// \param[in] scalar   Value to scale with
+            Vector& operator/=( scalar );
+
+            /// @brief Vector addition, x + y.
+            /// \param[in] Vector   Vector to add
+            Vector& operator+=( const Vector& );
+            /// @brief Vector subtraction, x - y.
+            /// \param[in] Vector   Vector to subtract
+            Vector& operator-=( const Vector& );
+
+            /* these currently do not have to be friends (since Vector is
+             * implicitly convertible), but they are for least possible
+             * surprise
+             */
+            friend Vector operator+( Vector, scalar );
+            friend Vector operator-( Vector, scalar );
+            friend Vector operator*( Vector, scalar );
+            friend Vector operator/( Vector, scalar );
+
+            friend Vector operator+( Vector, const Vector& );
+            friend Vector operator-( Vector, const Vector& );
+            friend scalar operator*( const Vector&, const Vector& );
+
+            /// @brief Equality check.
+            /// \param[out] eq  Returns true if equal, false if not
+            bool operator==( const Vector& ) const;
+            /// @brief Inequality check.
+            /// \param[out] eq  Returns false if equal, true if not
+            bool operator!=( const Vector& ) const;
+
+        private:
+            inline void set( const scalar*, const size_type*, size_type );
+    };
+
+    /// @brief Calculate the dot product of two Vectors
+    Vector::scalar dot( const Vector&, const Vector& );
+
+    /// @brief Calculate the sum of all values in the Vector
+    Vector::scalar sum( const Vector& );
+    /// @brief Find the biggest element in the Vector
+    Vector::scalar max( const Vector& );
+    /// @brief Find the smallest element in the Vector
+    Vector::scalar min( const Vector& );
+
+}
+}
+
+#endif //OPM_PETSCVECTOR_H

--- a/tests/test_petscmatrix.cpp
+++ b/tests/test_petscmatrix.cpp
@@ -1,0 +1,197 @@
+#include <config.h>
+
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscmatrix.hpp>
+#include <opm/core/linalg/petscvector.hpp>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+#define BOOST_TEST_MODULE MatrixTest
+#define BOOST_TEST_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+int argc = 0;
+const char* argv[] = { "-on_error_attach_debugger", "gdb", "-start_in_debugger" };
+char** argvv = (char**)argv;
+Opm::petsc::petsc handle( &argc, &argvv, NULL, "help" );
+
+using Opm::petsc::matrix;
+using Opm::petsc::vector;
+
+static void have_public_types() {
+    typename Opm::petsc::matrix::scalar scalar;
+    typename Opm::petsc::matrix::size_type size_type;
+
+    /*
+     * Ignore "unused variable" warnings
+     */
+    (void) scalar;
+    (void) size_type;
+}
+
+BOOST_AUTO_TEST_CASE(test_petscvector_coverage) {
+    have_public_types();
+}
+
+const matrix::size_type row_ind[] = { 0, 1, 2, 3, 4 };
+const matrix::size_type col_ind[] = { 0, 1, 5, 2, 3 };
+const matrix::scalar values[] = {
+    10.0, 0, 0, 0, 0, 5.72,
+    0.2, 0, 0, 0, 0, 0,
+    0, 0, 4.2, 0, 0, 0,
+    0, 0, 0, 3.4, 0, 0,
+    0, 0, 3.14, 0, 0, 0,
+    0, 0, 0, 0, 0, 0 };
+
+const matrix::size_type csr_rows[] = { 0, 2, 3, 4, 5, 6, 6 };
+const matrix::size_type csr_cols[] = { 0, 5, 0, 2, 3, 2 };
+const matrix::scalar csr_vals[] = { 10.0, 5.72, 0.2, 4.2, 3.4, 3.14 };
+const matrix::scalar csr_vals_m2[] = { 20.0, 11.44, 0.4, 8.4, 6.8, 6.28 };
+const matrix::scalar csr_vals_zero[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+
+const matrix::scalar spmv_vals[] = { 117.961, 2.0, 0.84, 14.28, 0.628, 0.0 };
+
+const matrix::size_type row_ind_trans[] = { 0, 0, 2, 2, 3, 5 };
+const matrix::size_type col_ind_trans[] = { 0, 1, 2, 4, 3, 0 };
+const matrix::scalar values_trans[] = { 10.0, 0.2, 0, 0, 0, 0,
+                                        0, 0, 0, 0, 0, 0,
+                                        0, 0, 4.2, 0, 3.4, 0,
+                                        0, 0, 0, 3.14, 0, 0,
+                                        0, 0, 0, 0, 0, 0,
+                                        5.72, 0, 0, 0, 0, 0 };
+
+BOOST_AUTO_TEST_CASE(test_compare_builder_raw_petsc) {
+    /* ensure ownership transfer and copy construction works as intended by
+     * building from raw PETSc functions
+     */
+
+    Mat mat_petsc;
+    MatCreate( PETSC_COMM_WORLD, &mat_petsc );
+    MatSetSizes( mat_petsc, PETSC_DECIDE, PETSC_DECIDE, 10, 10 );
+    MatSetFromOptions( mat_petsc );
+    MatSetUp( mat_petsc );
+    MatSetValue( mat_petsc, 1, 1, 2.3, INSERT_VALUES );
+    MatAssemblyBegin( mat_petsc, MAT_FINAL_ASSEMBLY );
+    MatAssemblyEnd( mat_petsc, MAT_FINAL_ASSEMBLY );
+    matrix mtx( mat_petsc );
+
+    matrix::builder builder( 10, 10 );
+    builder.insert( 1, 1, 2.3 );
+    matrix builder_mtx( builder );
+
+    BOOST_CHECK( identical( builder_mtx, mtx ) );
+}
+
+BOOST_AUTO_TEST_CASE(test_matrix_copies) {
+    matrix::builder builder( 10, 10 );
+    builder.insert( 1, 1, 2.3 );
+
+    matrix mtx( builder );
+    matrix copy( mtx );
+
+    matrix::builder builder_copy( builder );
+    matrix builder_copy_mtx( builder_copy );
+
+    BOOST_CHECK( identical( mtx, copy ) );
+    BOOST_CHECK( identical( builder_copy_mtx, mtx ) );
+    BOOST_CHECK( identical( builder_copy_mtx, copy ) );
+}
+
+BOOST_AUTO_TEST_CASE(test_matrix_move) {
+    matrix::builder builder( 10, 10 );
+    builder.insert( 1, 1, 2.3 );
+
+    matrix mtx( builder );
+    matrix moved( std::move( builder ) );
+
+    BOOST_CHECK( identical( moved, mtx ) );
+}
+
+/*
+ * A convenient way to build a matrix (to avoid repetition). Creates a
+ * CSR-style matrix from the constant arrays
+ */
+static matrix get_csr_matrix( const matrix::scalar* vals ) {
+    std::vector< matrix::scalar > csr_val_vec;
+    std::vector< matrix::size_type > csr_row_vec;
+    std::vector< matrix::size_type > csr_col_vec;
+    for( int i = 0; i < 6; ++i ) {
+        csr_val_vec.push_back( vals[ i ] );
+        csr_col_vec.push_back( csr_cols[ i ] );
+        csr_row_vec.push_back( csr_rows[ i ] );
+    }
+    csr_row_vec.push_back( csr_rows[ 6 ] );
+
+    matrix::builder csr_builder( 6, 6 );
+    csr_builder.insert( csr_val_vec, csr_row_vec, csr_col_vec );
+
+    return csr_builder;
+}
+
+BOOST_AUTO_TEST_CASE(test_matrixbuilder) {
+    auto mtx = get_csr_matrix( csr_vals );
+
+    matrix::builder direct_builder( 6, 6 );
+    direct_builder.insert( 0, 0, 10.0 );
+    direct_builder.insert( 0, 5, 5.72 );
+    direct_builder.insert( 1, 0, 0.2 );
+    direct_builder.insert( 2, 2, 4.2 );
+    direct_builder.insert( 3, 3, 3.4 );
+    direct_builder.insert( 4, 2, 3.14 );
+
+    auto dmtx = direct_builder.commit();
+
+    BOOST_CHECK( identical( mtx, dmtx ) );
+}
+
+BOOST_AUTO_TEST_CASE(test_matrix_arithmetic) {
+    auto base_matrix = get_csr_matrix( csr_vals );
+    auto matrix_m2 = get_csr_matrix( csr_vals_m2 );
+    auto base_matrix_copy = base_matrix;
+    auto matrix_zero = get_csr_matrix( csr_vals_zero );
+    vector zero_vector( 6, 0.0 );
+    vector base_vector( std::vector< vector::scalar >( csr_vals, csr_vals + 6 ) );
+    vector spmv_vector( std::vector< vector::scalar >( spmv_vals, spmv_vals + 6 ) );
+
+    BOOST_CHECK( identical( matrix_m2, base_matrix * 2 ) );
+    BOOST_CHECK( identical( matrix_m2, base_matrix + base_matrix ) );
+    BOOST_CHECK( identical( matrix_zero, base_matrix - base_matrix ) );
+
+    BOOST_CHECK( identical( base_matrix, base_matrix + matrix_zero ) );
+    /* base_matrix * matrix_zero is NOT guaranteed to be structurally identical
+     * to matrix_zero, therefore this check cannot be done. This is a petsc
+     * detail may be relaxed in the future.
+     * BOOST_CHECK( identical( matrix_zero, base_matrix * matrix_zero ) );
+     */
+    BOOST_CHECK( identical( matrix_zero, base_matrix * 0 ) );
+
+    BOOST_CHECK( zero_vector == zero_vector * base_matrix );
+
+    /*
+     * Unfortunately, vector comparison suffers from the same. It is a bitwise
+     * equality test, therefore rounding errors are not accounted for and
+     * things that would otherwise be equal are not
+     * BOOST_CHECK( spmv_vector == base_matrix * base_vector );
+     */
+}
+
+BOOST_AUTO_TEST_CASE(test_petscvector_transpose) {
+    std::vector< matrix::scalar > val_vec;
+    for( int i = 0; i < 6*6; ++i ) {
+        val_vec.push_back( values[ i ] );
+    }
+
+    matrix source( val_vec, 6, 6 );
+    matrix inplace_transposed = source;
+
+    auto transposed = transpose( source );
+    auto double_transposed = transpose( transposed );
+    inplace_transposed.transpose();
+
+    BOOST_CHECK( identical( double_transposed, source ) );
+    BOOST_CHECK( identical( transposed, inplace_transposed ) );
+}

--- a/tests/test_petscmatrix.cpp
+++ b/tests/test_petscmatrix.cpp
@@ -17,14 +17,14 @@
 int argc = 0;
 const char* argv[] = { "-on_error_attach_debugger", "gdb", "-start_in_debugger" };
 char** argvv = (char**)argv;
-Opm::petsc::petsc handle( &argc, &argvv, NULL, "help" );
+Opm::Petsc::Petsc handle( &argc, &argvv, NULL, "help" );
 
-using Opm::petsc::matrix;
-using Opm::petsc::vector;
+using Opm::Petsc::Matrix;
+using Opm::Petsc::Vector;
 
 static void have_public_types() {
-    typename Opm::petsc::matrix::scalar scalar;
-    typename Opm::petsc::matrix::size_type size_type;
+    Opm::Petsc::Matrix::scalar scalar;
+    Opm::Petsc::Matrix::size_type size_type;
 
     /*
      * Ignore "unused variable" warnings
@@ -33,13 +33,13 @@ static void have_public_types() {
     (void) size_type;
 }
 
-BOOST_AUTO_TEST_CASE(test_petscvector_coverage) {
+BOOST_AUTO_TEST_CASE(test_PetscVector_coverage) {
     have_public_types();
 }
 
-const matrix::size_type row_ind[] = { 0, 1, 2, 3, 4 };
-const matrix::size_type col_ind[] = { 0, 1, 5, 2, 3 };
-const matrix::scalar values[] = {
+const Matrix::size_type row_ind[] = { 0, 1, 2, 3, 4 };
+const Matrix::size_type col_ind[] = { 0, 1, 5, 2, 3 };
+const Matrix::scalar values[] = {
     10.0, 0, 0, 0, 0, 5.72,
     0.2, 0, 0, 0, 0, 0,
     0, 0, 4.2, 0, 0, 0,
@@ -47,17 +47,17 @@ const matrix::scalar values[] = {
     0, 0, 3.14, 0, 0, 0,
     0, 0, 0, 0, 0, 0 };
 
-const matrix::size_type csr_rows[] = { 0, 2, 3, 4, 5, 6, 6 };
-const matrix::size_type csr_cols[] = { 0, 5, 0, 2, 3, 2 };
-const matrix::scalar csr_vals[] = { 10.0, 5.72, 0.2, 4.2, 3.4, 3.14 };
-const matrix::scalar csr_vals_m2[] = { 20.0, 11.44, 0.4, 8.4, 6.8, 6.28 };
-const matrix::scalar csr_vals_zero[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+const Matrix::size_type csr_rows[] = { 0, 2, 3, 4, 5, 6, 6 };
+const Matrix::size_type csr_cols[] = { 0, 5, 0, 2, 3, 2 };
+const Matrix::scalar csr_vals[] = { 10.0, 5.72, 0.2, 4.2, 3.4, 3.14 };
+const Matrix::scalar csr_vals_m2[] = { 20.0, 11.44, 0.4, 8.4, 6.8, 6.28 };
+const Matrix::scalar csr_vals_zero[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
-const matrix::scalar spmv_vals[] = { 117.961, 2.0, 0.84, 14.28, 0.628, 0.0 };
+const Matrix::scalar spmv_vals[] = { 117.961, 2.0, 0.84, 14.28, 0.628, 0.0 };
 
-const matrix::size_type row_ind_trans[] = { 0, 0, 2, 2, 3, 5 };
-const matrix::size_type col_ind_trans[] = { 0, 1, 2, 4, 3, 0 };
-const matrix::scalar values_trans[] = { 10.0, 0.2, 0, 0, 0, 0,
+const Matrix::size_type row_ind_trans[] = { 0, 0, 2, 2, 3, 5 };
+const Matrix::size_type col_ind_trans[] = { 0, 1, 2, 4, 3, 0 };
+const Matrix::scalar values_trans[] = { 10.0, 0.2, 0, 0, 0, 0,
                                         0, 0, 0, 0, 0, 0,
                                         0, 0, 4.2, 0, 3.4, 0,
                                         0, 0, 0, 3.14, 0, 0,
@@ -69,32 +69,32 @@ BOOST_AUTO_TEST_CASE(test_compare_builder_raw_petsc) {
      * building from raw PETSc functions
      */
 
-    Mat mat_petsc;
-    MatCreate( PETSC_COMM_WORLD, &mat_petsc );
-    MatSetSizes( mat_petsc, PETSC_DECIDE, PETSC_DECIDE, 10, 10 );
-    MatSetFromOptions( mat_petsc );
-    MatSetUp( mat_petsc );
-    MatSetValue( mat_petsc, 1, 1, 2.3, INSERT_VALUES );
-    MatAssemblyBegin( mat_petsc, MAT_FINAL_ASSEMBLY );
-    MatAssemblyEnd( mat_petsc, MAT_FINAL_ASSEMBLY );
-    matrix mtx( mat_petsc );
+    Mat matpetsc;
+    MatCreate( PETSC_COMM_WORLD, &matpetsc );
+    MatSetSizes( matpetsc, PETSC_DECIDE, PETSC_DECIDE, 10, 10 );
+    MatSetFromOptions( matpetsc );
+    MatSetUp( matpetsc );
+    MatSetValue( matpetsc, 1, 1, 2.3, INSERT_VALUES );
+    MatAssemblyBegin( matpetsc, MAT_FINAL_ASSEMBLY );
+    MatAssemblyEnd( matpetsc, MAT_FINAL_ASSEMBLY );
+    Matrix mtx( matpetsc );
 
-    matrix::builder builder( 10, 10 );
+    Matrix::Builder::Inserter builder( 10, 10 );
     builder.insert( 1, 1, 2.3 );
-    matrix builder_mtx( builder );
+    auto builder_mtx = Opm::Petsc::commit( builder );
 
     BOOST_CHECK( identical( builder_mtx, mtx ) );
 }
 
-BOOST_AUTO_TEST_CASE(test_matrix_copies) {
-    matrix::builder builder( 10, 10 );
+BOOST_AUTO_TEST_CASE(test_Matrix_copies) {
+    Matrix::Builder::Inserter builder( 10, 10 );
     builder.insert( 1, 1, 2.3 );
 
-    matrix mtx( builder );
-    matrix copy( mtx );
+    auto mtx = commit( builder );
+    Matrix copy( mtx );
 
-    matrix::builder builder_copy( builder );
-    matrix builder_copy_mtx( builder_copy );
+    auto builder_copy = builder;
+    auto builder_copy_mtx = commit( builder_copy );
 
     BOOST_CHECK( identical( mtx, copy ) );
     BOOST_CHECK( identical( builder_copy_mtx, mtx ) );
@@ -102,23 +102,23 @@ BOOST_AUTO_TEST_CASE(test_matrix_copies) {
 }
 
 BOOST_AUTO_TEST_CASE(test_matrix_move) {
-    matrix::builder builder( 10, 10 );
+    Matrix::Builder::Inserter builder( 10, 10 );
     builder.insert( 1, 1, 2.3 );
 
-    matrix mtx( builder );
-    matrix moved( std::move( builder ) );
+    auto mtx = Opm::Petsc::commit( builder );
+    auto moved = Opm::Petsc::commit( std::move( builder ) );
 
     BOOST_CHECK( identical( moved, mtx ) );
 }
 
 /*
- * A convenient way to build a matrix (to avoid repetition). Creates a
- * CSR-style matrix from the constant arrays
+ * A convenient way to build a Matrix (to avoid repetition). Creates a
+ * CSR-style Matrix from the constant arrays
  */
-static matrix get_csr_matrix( const matrix::scalar* vals ) {
-    std::vector< matrix::scalar > csr_val_vec;
-    std::vector< matrix::size_type > csr_row_vec;
-    std::vector< matrix::size_type > csr_col_vec;
+static Matrix get_csr_matrix( const Matrix::scalar* vals ) {
+    std::vector< Matrix::scalar > csr_val_vec;
+    std::vector< Matrix::size_type > csr_row_vec;
+    std::vector< Matrix::size_type > csr_col_vec;
     for( int i = 0; i < 6; ++i ) {
         csr_val_vec.push_back( vals[ i ] );
         csr_col_vec.push_back( csr_cols[ i ] );
@@ -126,16 +126,16 @@ static matrix get_csr_matrix( const matrix::scalar* vals ) {
     }
     csr_row_vec.push_back( csr_rows[ 6 ] );
 
-    matrix::builder csr_builder( 6, 6 );
+    Matrix::Builder::Inserter csr_builder( 6, 6 );
     csr_builder.insert( csr_val_vec, csr_row_vec, csr_col_vec );
 
-    return csr_builder;
+    return Opm::Petsc::commit( csr_builder );
 }
 
 BOOST_AUTO_TEST_CASE(test_matrixbuilder) {
     auto mtx = get_csr_matrix( csr_vals );
 
-    matrix::builder direct_builder( 6, 6 );
+    Matrix::Builder::Inserter direct_builder( 6, 6 );
     direct_builder.insert( 0, 0, 10.0 );
     direct_builder.insert( 0, 5, 5.72 );
     direct_builder.insert( 1, 0, 0.2 );
@@ -143,9 +143,61 @@ BOOST_AUTO_TEST_CASE(test_matrixbuilder) {
     direct_builder.insert( 3, 3, 3.4 );
     direct_builder.insert( 4, 2, 3.14 );
 
-    auto dmtx = direct_builder.commit();
+    auto dmtx = Opm::Petsc::commit( direct_builder );
 
     BOOST_CHECK( identical( mtx, dmtx ) );
+}
+
+BOOST_AUTO_TEST_CASE(test_builder_methods_equivalence) {
+    Matrix::Builder::Inserter ins( 6, 6 );
+    Matrix::Builder::Accumulator add( 6, 6 );
+
+    ins.insert( 0, 0, 10.0 ).
+    insert( 0, 5, 5.72 ).
+    insert( 1, 0, 0.2 ).
+    insert( 2, 2, 4.2 ).
+    insert( 3, 3, 3.4 ).
+    insert( 4, 2, 3.14 );
+
+    /* build an identical Matrix, but with add. Notice that both += and -= are
+     * used, in the lines with two operations. They sum to the equivalent cell
+     * value
+     */
+    add.add( 0, 0, 10.0 ).
+    add( 0, 5, 5.72 ).
+    add( 1, 0, 0.1 ).add( 1, 0, 0.1 ).
+    add( 2, 2, 6.2 ).add( 2, 2, -2.0 ).
+    add( 3, 3, 3.4 ).
+    add( 4, 2, 3.14 );
+
+    auto from_ins = Opm::Petsc::commit( ins );
+    auto from_add = Opm::Petsc::commit( add );
+
+    BOOST_CHECK( identical( from_ins, from_add ) );
+}
+
+BOOST_AUTO_TEST_CASE(test_builder_conversion) {
+    Matrix::Builder::Inserter ins( 6, 6 );
+
+    ins.insert( 0, 0, 10.0 ).
+    insert( 0, 5, 5.72 ).
+    insert( 1, 0, 0.2 ).
+    insert( 4, 2, 3.14 );
+
+    Matrix::Builder::Accumulator accer( std::move( ins ) );
+
+    /* build an identical Matrix, but with add. Notice that both += and -= are
+     * used, in the lines with two operations. They sum to the equivalent cell
+     * value
+     */
+    accer.
+    add( 2, 2, 6.2 ).add( 2, 2, -2.0 ).
+    add( 3, 3, 3.4 );
+
+    auto from_add = Opm::Petsc::commit( accer );
+    auto reference_matrix = get_csr_matrix( csr_vals );
+
+    BOOST_CHECK( identical( from_add, reference_matrix ) );
 }
 
 BOOST_AUTO_TEST_CASE(test_matrix_arithmetic) {
@@ -153,9 +205,9 @@ BOOST_AUTO_TEST_CASE(test_matrix_arithmetic) {
     auto matrix_m2 = get_csr_matrix( csr_vals_m2 );
     auto base_matrix_copy = base_matrix;
     auto matrix_zero = get_csr_matrix( csr_vals_zero );
-    vector zero_vector( 6, 0.0 );
-    vector base_vector( std::vector< vector::scalar >( csr_vals, csr_vals + 6 ) );
-    vector spmv_vector( std::vector< vector::scalar >( spmv_vals, spmv_vals + 6 ) );
+    Vector zero_vector( 6, 0.0 );
+    Vector base_vector( std::vector< Vector::scalar >( csr_vals, csr_vals + 6 ) );
+    Vector spmv_vector( std::vector< Vector::scalar >( spmv_vals, spmv_vals + 6 ) );
 
     BOOST_CHECK( identical( matrix_m2, base_matrix * 2 ) );
     BOOST_CHECK( identical( matrix_m2, base_matrix + base_matrix ) );
@@ -163,16 +215,16 @@ BOOST_AUTO_TEST_CASE(test_matrix_arithmetic) {
 
     BOOST_CHECK( identical( base_matrix, base_matrix + matrix_zero ) );
     /* base_matrix * matrix_zero is NOT guaranteed to be structurally identical
-     * to matrix_zero, therefore this check cannot be done. This is a petsc
+     * to matrix_zero, therefore this check cannot be done. This is a Petsc
      * detail may be relaxed in the future.
-     * BOOST_CHECK( identical( matrix_zero, base_matrix * matrix_zero ) );
+     * BOOST_CHECK( identical( Matrix_zero, base_matrix * matrix_zero ) );
      */
     BOOST_CHECK( identical( matrix_zero, base_matrix * 0 ) );
 
     BOOST_CHECK( zero_vector == zero_vector * base_matrix );
 
     /*
-     * Unfortunately, vector comparison suffers from the same. It is a bitwise
+     * Unfortunately, Vector comparison suffers from the same. It is a bitwise
      * equality test, therefore rounding errors are not accounted for and
      * things that would otherwise be equal are not
      * BOOST_CHECK( spmv_vector == base_matrix * base_vector );
@@ -180,13 +232,13 @@ BOOST_AUTO_TEST_CASE(test_matrix_arithmetic) {
 }
 
 BOOST_AUTO_TEST_CASE(test_petscvector_transpose) {
-    std::vector< matrix::scalar > val_vec;
+    std::vector< Matrix::scalar > val_vec;
     for( int i = 0; i < 6*6; ++i ) {
         val_vec.push_back( values[ i ] );
     }
 
-    matrix source( val_vec, 6, 6 );
-    matrix inplace_transposed = source;
+    Matrix source( val_vec, 6, 6 );
+    Matrix inplace_transposed = source;
 
     auto transposed = transpose( source );
     auto double_transposed = transpose( transposed );

--- a/tests/test_petscmixins.cpp
+++ b/tests/test_petscmixins.cpp
@@ -6,7 +6,7 @@
 #if HAVE_DYNAMIC_BOOST_TEST
 #define BOOST_TEST_DYN_LINK
 #endif
-#define BOOST_TEST_MODULE MatrixTest
+#define BOOST_TEST_MODULE PetscMixinTest
 #define BOOST_TEST_MAIN
 
 #include <boost/test/unit_test.hpp>
@@ -20,14 +20,14 @@
  */
 
 namespace Opm {
-namespace petsc {
+namespace Petsc {
 template<> struct deleter< int > : std::default_delete< int > {};
 }
 }
 
 
-struct unique : public Opm::petsc::uptr< int* > {
-    typedef Opm::petsc::uptr< int* > base;
+struct unique : public Opm::Petsc::uptr< int* > {
+    typedef Opm::Petsc::uptr< int* > base;
     using base::operator=;
 
     unique( int* x ) : base( x ) {}
@@ -78,4 +78,83 @@ BOOST_AUTO_TEST_CASE( assignment ) {
      */
     unique captured = capture( cap );
     BOOST_CHECK( captured.get() == cap );
+}
+
+class ebc_test : public Opm::Petsc::explicit_bool_conversion< ebc_test > {};
+bool explicit_boolean_test( const ebc_test& ) {
+    return true;
+}
+
+BOOST_AUTO_TEST_CASE( explicit_bool_conversion_operator ) {
+    /*
+     * Since we do not yet have access to the C++11 explicit conversion
+     * operator keyword, we emulate it through the so-called safe bool idiom.
+     *
+     *  See: http://en.wikibooks.org/wiki/More_C++_Idioms/Safe_bool
+     *
+     *  This code tests the mixin and makes sure it behaves as expected.
+     *  Relies on CRTP, so every bool conversion class must implement the
+     *  following function overload: explicit_boolean_test( const class& )
+     *
+     *  Adding an automatic test for the case that is NOT supposed to compile
+     *  is unfortunately rather hard, so it is currently not covered by this
+     *  automatic test case.
+     */
+
+    ebc_test ebc;
+    BOOST_CHECK( ebc );
+    BOOST_CHECK( ebc == true );
+    BOOST_CHECK( ebc != false );
+
+    /*
+     * If this is uncommented, the test should not compile.
+     *
+     * ebc_test ebc1;
+     * int x = 0;
+     * BOOST_CHECK( ebc == x );
+     * BOOST_CHECK( ebc1 == ebc );
+     */
+}
+
+enum class returned_from { newtype, rawtype };
+
+struct age : public Opm::Petsc::newtype< int > {
+    /*
+     * Pre-C++11 support (using keyword works for GCC >= 4.8)
+     */
+    template< typename T >
+    age( T&& t ) : Opm::Petsc::newtype< int >(
+            std::forward< T >( t ) ) {}
+    /*
+     * C++11-version:
+     * using Opm::petsc::newtype< int >::newtype;
+     */
+};
+
+// Test the mknewtype macro too
+mknewtype( height, int );
+
+returned_from test_newtype( age x ) {
+    return returned_from::newtype;
+}
+
+returned_from test_newtype( height x ) {
+    return returned_from::newtype;
+}
+
+returned_from test_newtype( int x ) {
+    return returned_from::rawtype;
+}
+
+BOOST_AUTO_TEST_CASE( newtypes ) {
+    int integer = 0;
+    age x = 1;
+    age y( integer );
+    height z = 2;
+
+    BOOST_CHECK( test_newtype( integer ) == returned_from::rawtype );
+    BOOST_CHECK( test_newtype( x ) == returned_from::newtype );
+    BOOST_CHECK( test_newtype( y ) == returned_from::newtype );
+    BOOST_CHECK( test_newtype( z ) == returned_from::newtype );
+    BOOST_CHECK( test_newtype( height( x ) ) == returned_from::newtype );
 }

--- a/tests/test_petscmixins.cpp
+++ b/tests/test_petscmixins.cpp
@@ -1,0 +1,81 @@
+#include <config.h>
+
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscmixins.hpp>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+#define BOOST_TEST_MODULE MatrixTest
+#define BOOST_TEST_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+/*
+ * This file tests the correctness of the mixins. The benefit of doing this is
+ * that we can cleany verify the correctness of the semantics and operations
+ * provided by the mixins, without dealing with the details of specific
+ * classes. This means tests become smaller, and it will be obsolete to test
+ * that, say, the petsc::vector assignment operators works as intended.
+ */
+
+namespace Opm {
+namespace petsc {
+template<> struct deleter< int > : std::default_delete< int > {};
+}
+}
+
+
+struct unique : public Opm::petsc::uptr< int* > {
+    typedef Opm::petsc::uptr< int* > base;
+    using base::operator=;
+
+    unique( int* x ) : base( x ) {}
+    unique( unique&& x ) : base( std::move( x ) ) {}
+    unique( const unique& other ) : base( new int( *other.get() ) ) {}
+
+    const int* get() const { return this->ptr(); }
+};
+
+static unique capture( int* p ) {
+    return unique( p );
+}
+
+BOOST_AUTO_TEST_CASE( assignment ) {
+
+    int* p = new int( 3 );
+
+    unique orig( p );
+    /* Sanity check - if this fails, simply taking ownership of a pointer, none
+     * of the other tests can be verified
+     */
+    BOOST_CHECK( p == orig.get() );
+
+    /* Test move assignment operator from std::move */
+    /* This should call the move constructor (of moved) and make so that moved
+     * now is the owner of p. This can fail in two ways:
+     * #1: moved's internal pointer differs from the one it is supposed to get
+     * transferred(p)
+     * #2: both orig and moved holds ownership over p. If so, you should see a
+     * double free
+     */
+    unique moved = std::move( orig );
+    BOOST_CHECK( p );
+    BOOST_CHECK( p == moved.get() );
+
+    /* Copy the contents */
+    auto copied = moved;
+
+    /* These should now NOT be similar, i.e. copied should have a totally new
+     * pointer, but their -value- should remain equal
+     */
+    BOOST_CHECK( moved.get() != copied.get() );
+    BOOST_CHECK( *moved.get() == *copied.get() );
+
+    int* cap = new int( 5 );
+    /* Make sure move constructor is correctly called when returning the
+     * object by value
+     */
+    unique captured = capture( cap );
+    BOOST_CHECK( captured.get() == cap );
+}

--- a/tests/test_petscsolver.cpp
+++ b/tests/test_petscsolver.cpp
@@ -1,0 +1,49 @@
+#include <config.h>
+
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscvector.hpp>
+#include <opm/core/linalg/petscmatrix.hpp>
+#include <opm/core/linalg/petscsolver.hpp>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+#define BOOST_TEST_MODULE PetscSolverTest
+#define BOOST_TEST_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+using namespace Opm::Petsc;
+
+int argc = 0;
+char** argv = 0;
+Petsc handle( &argc, &argv, NULL, "help" );
+
+BOOST_AUTO_TEST_CASE( trivial ) {
+
+    Matrix::Builder::Inserter builder( 2, 2 );
+    builder.insert( 0, 0, 2 );
+    builder.insert( 1, 1, 2 );
+
+    // [ 2, 0 ] [ x1 ] = [ 2 ]
+    // [ 0, 2 ] [ x2 ] = [ 1 ]
+
+    Matrix A = commit( std::move( builder ) );
+
+    std::vector< Vector::scalar > vec( 2 );
+    vec[ 0 ] = 2; vec[ 1 ] = 1;
+
+    Vector b( vec );
+    vec[ 0 ] = 1; vec[ 1 ] = 0.5;
+    Vector result( vec );
+
+    auto x = solve( A, b );
+    auto y = solve( A, b, A );
+    auto z = solve( A, b, A,
+            Solver::Pc_type( "sor" ),
+            Solver::Ksp_type( "cg" ) );
+
+    BOOST_CHECK( x == y );
+    BOOST_CHECK( y == z );
+    BOOST_CHECK( z == result );
+}

--- a/tests/test_petscvector.cpp
+++ b/tests/test_petscvector.cpp
@@ -1,0 +1,117 @@
+#include <config.h>
+
+#include <opm/core/linalg/petsc.hpp>
+#include <opm/core/linalg/petscvector.hpp>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+#define BOOST_TEST_MODULE MatrixTest
+#define BOOST_TEST_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+int argc = 0;
+char** argv = 0;
+Opm::Petsc::Petsc handle( &argc, &argv, NULL, "help" );
+
+template< class ForwardIterator, class T >
+static inline void iota( ForwardIterator first, ForwardIterator last, T value, T step ) {
+    while(first != last) { 
+        *first++ = value;
+        value += step;
+    }
+}
+
+template< typename T >
+static inline std::vector< T > range( T begin, T end, T step = T( 1 ) ) {
+    std::vector< T > x( ( end - begin ) / step );
+    /* if std::iota is available, the function defined above shouldn't be
+     * compiled in and std::iota should be used
+     */
+    iota( x.begin(), x.end(), begin, step );
+    return x;
+}
+
+static void have_public_types() {
+    Opm::Petsc::Vector::scalar scalar;
+    Opm::Petsc::Vector::size_type size_type;
+
+    /*
+     * Ignore "unused variable" warnings
+     */
+    (void) scalar;
+    (void) size_type;
+}
+
+BOOST_AUTO_TEST_CASE(test_PetscVector_coverage) {
+    /* Test that the required public types are exposed.
+     *
+     * Will provide compile error if not
+     */
+    have_public_types();
+}
+
+BOOST_AUTO_TEST_CASE(test_PetscVector_constructors) {
+    using Opm::Petsc::Vector;
+
+    /* Create reference Vector Petsc styles. */
+    Vec vec_Petsc;
+    VecCreate( PETSC_COMM_WORLD, &vec_Petsc );
+    VecSetSizes( vec_Petsc, PETSC_DECIDE, 10 );
+    VecSetFromOptions( vec_Petsc );
+
+    /* ownership transferring constructor */
+    Vector Vector_Petsc( vec_Petsc );
+
+    /* test copy constructor */
+    auto Vector_copy = Vector( Vector_Petsc );
+
+    Vector Vector_size( 10 );
+    Vector Vector_size_elems( 10, 0.0 );
+
+    /* construction from std::vector */
+    std::vector< Vector::scalar > std_vec( 10, 0.0 );
+    auto stdidx = range( 0, 10 );
+    Vector Vector_from_stdvec( std_vec );
+    Vector Vector_from_stdidx( std_vec, stdidx );
+
+    BOOST_CHECK( Vector_copy == Vector_Petsc );
+    BOOST_CHECK( Vector_from_stdvec == Vector_from_stdidx );
+
+    BOOST_CHECK( !( Vector_copy != Vector_Petsc ) );
+    BOOST_CHECK( !( Vector_from_stdvec != Vector_from_stdidx ) );
+}
+
+BOOST_AUTO_TEST_CASE(test_PetscVector_arithmetic) {
+    using Opm::Petsc::Vector;
+
+
+    Vector vec1( range( 0.0, 10.0 ) );
+    Vector vec_add_target( range( 2.0, 12.0 ) );
+    auto vec_add = vec1 + 2;
+    auto vec_sub = vec_add_target - 2;
+
+    Vector vec_mul_target( range( 0.0, 30.0, 3.0 ) );
+    auto vec_mul = vec1 * 3;
+    auto vec_div = vec_mul_target / 3;
+
+    BOOST_CHECK( vec_add == vec_add_target );
+    BOOST_CHECK( vec_sub == vec1 );
+    BOOST_CHECK( vec_mul == vec_mul_target );
+    BOOST_CHECK( vec_div == vec1 );
+}
+
+BOOST_AUTO_TEST_CASE(test_PetscVector_functional) {
+    using Opm::Petsc::Vector;
+
+    Vector vec1( range( 0.0, 10.0 ) );
+    Vector vec2( range( 0.0, 20.0, 2.0 ) );
+
+    BOOST_CHECK( ( vec1 * vec2 ) == 570.0 );
+    BOOST_CHECK( Opm::Petsc::max( vec1 ) ==  9.0 );
+    BOOST_CHECK( Opm::Petsc::min( vec1 ) ==  0.0 );
+    BOOST_CHECK( Opm::Petsc::sum( vec1 ) == 45.0 );
+}


### PR DESCRIPTION
Hi,

These patches introduces a more thorough, robust and (hopefully) correct implementation of PETSc support in OPM, as well as remove the old and broken implementation.

They should mostly be documented and easy to understand, as well as introduce a much nicer way to do numerics in OPM. Hopefully this will overall improve reliability and performance in OPM, as well as provide us with some nice debugging and profiling tools.

Each commit's message should introduce what's added, so it will be slightly redundant to do it here. Changes & improvements & suggestions welcome!

TODO: conditional compilation of things related to HYPRE, CUDA, OpenCL and other PETSc third party libraries.
