### PR TITLE
Fix warnings (and small API change)

### DIFF
--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -1082,7 +1082,7 @@ void EclipseWriter::writeTimeStep(const SimulatorTimerInterface& timer,
     }
 
     {
-        ecl_rsthead_type rsthead_data = { 0 };
+        ecl_rsthead_type rsthead_data = {};
         rsthead_data.sim_time   = timer.currentPosixTime();
         rsthead_data.nactive    = numCells_;
         rsthead_data.nx         = cartesianSize_[0];

--- a/opm/core/io/eclipse/writeECLData.cpp
+++ b/opm/core/io/eclipse/writeECLData.cpp
@@ -119,7 +119,7 @@ namespace Opm
       rst_file = ecl_rst_file_open_write( filename );
 
     {
-      ecl_rsthead_type rsthead_data = { 0 };
+      ecl_rsthead_type rsthead_data = {};
       
       const int num_wells    = 0;
       const int niwelz       = 0;

--- a/opm/core/props/pvt/PvtLiveOil.cpp
+++ b/opm/core/props/pvt/PvtLiveOil.cpp
@@ -139,7 +139,7 @@ namespace Opm
     void PvtLiveOil::mu(const int n,
                         const int* pvtTableIdx,
                         const double* p,
-                        const double* T,
+                        const double* /*T*/,
                               const double* z,
                               double* output_mu) const
     {

--- a/opm/core/simulator/TimeStepControl.cpp
+++ b/opm/core/simulator/TimeStepControl.cpp
@@ -53,7 +53,7 @@ namespace Opm
     }
 
     double SimpleIterationCountTimeStepControl::
-    computeTimeStepSize( const double dt, const int iterations, const SimulatorState& state ) const
+    computeTimeStepSize( const double dt, const int iterations, const SimulatorState& /* state */ ) const
     {
         double dtEstimate = dt ;
 

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -327,7 +327,7 @@ namespace Opm
     {
         init(eclipseState, timeStep, UgGridHelpers::numCells(grid),
              UgGridHelpers::globalCell(grid), UgGridHelpers::cartDims(grid), 
-             UgGridHelpers::dimensions(grid), UgGridHelpers::beginCellCentroids(grid),
+             UgGridHelpers::dimensions(grid),
              UgGridHelpers::cell2Faces(grid), UgGridHelpers::beginFaceCentroids(grid),
              permeability);
 

--- a/opm/core/wells/WellsManager.hpp
+++ b/opm/core/wells/WellsManager.hpp
@@ -140,14 +140,13 @@ namespace Opm
 
 
     private:
-        template<class CC, class C2F, class FC>
+        template<class C2F, class FC>
         void init(const Opm::EclipseStateConstPtr eclipseState,
                   const size_t timeStep,
                   int num_cells,
                   const int* global_cell,
                   const int* cart_dims,
                   int dimensions,
-                  CC begin_cell_centroids,
                   const C2F& cell_to_faces,
                   FC begin_face_centroids,
                   const double* permeability);
@@ -158,12 +157,11 @@ namespace Opm
         void setupWellControls(std::vector<WellConstPtr>& wells, size_t timeStep,
                                std::vector<std::string>& well_names, const PhaseUsage& phaseUsage);
 
-        template<class C2F, class CC, class FC, class NTG>
+        template<class C2F, class FC, class NTG>
         void createWellsFromSpecs( std::vector<WellConstPtr>& wells, size_t timeStep,
                                    const C2F& cell_to_faces, 
                                    const int* cart_dims,
                                    FC begin_face_centroids, 
-                                   CC begin_cell_centroids,
                                    int dimensions,
                                    std::vector<std::string>& well_names,
                                    std::vector<WellData>& well_data,

--- a/opm/core/wells/WellsManager.hpp
+++ b/opm/core/wells/WellsManager.hpp
@@ -72,14 +72,13 @@ namespace Opm
         /// The permeability argument may be zero if the input contain
         /// well productivity indices, otherwise it must be given in
         /// order to approximate these by the Peaceman formula.
-        template<class CC, class F2C, class FC>
+        template<class F2C, class FC>
         WellsManager(const Opm::EclipseStateConstPtr eclipseState,
                      const size_t timeStep,
                      int num_cells,
                      const int* global_cell,
                      const int* cart_dims,
                      int dimensions,
-                     CC begin_cell_centroids,
                      const F2C& f2c,
                      FC begin_face_centroids,
                      const double* permeability);

--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -250,7 +250,7 @@ void WellsManager::createWellsFromSpecs(std::vector<WellConstPtr>& wells, size_t
     }
 }
 
-template <class CC, class C2F, class FC>
+template <class C2F, class FC>
 WellsManager::
 WellsManager(const Opm::EclipseStateConstPtr eclipseState,
              const size_t                    timeStep,
@@ -258,14 +258,13 @@ WellsManager(const Opm::EclipseStateConstPtr eclipseState,
              const int*                      global_cell,
              const int*                      cart_dims,
              int                             dimensions,
-             CC                              begin_cell_centroids,
              const C2F&                      cell_to_faces,
              FC                              begin_face_centroids,
              const double*                   permeability)
     : w_(0)
 {
     init(eclipseState, timeStep, number_of_cells, global_cell,
-         cart_dims, dimensions, begin_cell_centroids,
+         cart_dims, dimensions,
          cell_to_faces, begin_face_centroids, permeability);
 }
 

--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -100,12 +100,11 @@ getCubeDim(const C2F& c2f,
 
 namespace Opm
 {
-template<class C2F, class CC, class FC, class NTG>
+template<class C2F, class FC, class NTG>
 void WellsManager::createWellsFromSpecs(std::vector<WellConstPtr>& wells, size_t timeStep,
                                         const C2F& c2f,
                                         const int* cart_dims,
                                         FC begin_face_centroids,
-                                        CC begin_cell_centroids,
                                         int dimensions,
                                         std::vector<std::string>& well_names,
                                         std::vector<WellData>& well_data,
@@ -271,7 +270,7 @@ WellsManager(const Opm::EclipseStateConstPtr eclipseState,
 }
 
 /// Construct wells from deck.
-template <class CC, class C2F, class FC>
+template <class C2F, class FC>
 void
 WellsManager::init(const Opm::EclipseStateConstPtr eclipseState,
                    const size_t                    timeStep,
@@ -279,7 +278,6 @@ WellsManager::init(const Opm::EclipseStateConstPtr eclipseState,
                    const int*                      global_cell,
                    const int*                      cart_dims,
                    int                             dimensions,
-                   CC                              begin_cell_centroids,
                    const C2F&                      cell_to_faces,
                    FC                              begin_face_centroids,
                    const double*                   permeability)
@@ -327,7 +325,6 @@ WellsManager::init(const Opm::EclipseStateConstPtr eclipseState,
     createWellsFromSpecs(wells, timeStep, cell_to_faces,
                          cart_dims,
                          begin_face_centroids,
-                         begin_cell_centroids,
                          dimensions,
                          well_names, well_data, well_names_to_index,
                          pu, cartesian_to_compressed, permeability, ntg);

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -79,7 +79,7 @@ void verifyWellState(const std::string& rst_filename,
     BOOST_CHECK(well_conn_get_j(well_head) == well->getHeadJ());
 
     for (int j = 0; j < well_ts_get_size(well_ts); ++j) {
-      well_state_type * well_state = well_ts_iget_state(well_ts, j);
+      well_state = well_ts_iget_state(well_ts, j);
 
       //Verify welltype
       int ert_well_type = well_state_get_type(well_state);


### PR DESCRIPTION
This fixes warnings of various kinds, and removes an unneeded argument from the WellsManager constructor.

There are downstream consequences in opm-autodiff and opm-polymer, so companion PRs in those modules must be merged simultaneously with this one.