### PR TITLE
Prevents unsigned-signed-comparison warnings for container with signed size

### DIFF
--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -148,7 +148,7 @@ public:
         {
             OPM_THROW(std::runtime_error, "Trying to update owner mask without parallel information!");
         }
-        if( container.size()!= ownerMask_.size() )
+        if( static_cast<std::size_t>(container.size())!= ownerMask_.size() )
         {
             ownerMask_.resize(container.size(), 1.);
             for( auto i=indexSet_->begin(), end=indexSet_->end(); i!=end; ++i )


### PR DESCRIPTION
Well, you never know. There are containers that use a signed integer
for storing its size. This results in a warning about comparing signed with
unsigned integers. This commit prevents this by explicitly casting the size
to std::size_t.