### PR TITLE
Ported initStateEquil to using the GridHelpers.

### DIFF
--- a/opm/core/grid/GridHelpers.cpp
+++ b/opm/core/grid/GridHelpers.cpp
@@ -1,3 +1,23 @@
+/*
+  Copyright 2014, 2015 Dr. Markus Blatt - HPC-Simulation-Software & Services.
+  Copyright 2014 Statoil AS
+  Copyright 2015 NTNU
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
 #include "config.h"
 #include <opm/core/grid/GridHelpers.hpp>
 namespace Opm
@@ -72,6 +92,16 @@ int faceTag(const UnstructuredGrid& grid,
 SparseTableView cell2Faces(const UnstructuredGrid& grid)
 {
     return SparseTableView(grid.cell_faces, grid.cell_facepos, numCells(grid));
+}
+
+SparseTableView face2Vertices(const UnstructuredGrid& grid)
+{
+    return SparseTableView(grid.face_nodes, grid.face_nodepos, numFaces(grid));
+}
+
+const double* vertexCoordinates(const UnstructuredGrid& grid, int index)
+{
+    return grid.node_coordinates+dimensions(grid)*index;
 }
 
 double cellVolume(const UnstructuredGrid& grid, int cell_index)

--- a/opm/core/grid/GridHelpers.hpp
+++ b/opm/core/grid/GridHelpers.hpp
@@ -1,6 +1,7 @@
 /*
-  Copyright 2014 Dr. Markus Blatt - HPC-Simulation-Software & Services
+  Copyright 2014, 2015 Dr. Markus Blatt - HPC-Simulation-Software & Services
   Copyright 2014 Statoil AS
+  Copyright 2015
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -202,9 +203,33 @@ struct Cell2FacesTraits<UnstructuredGrid>
     typedef SparseTableView Type;
 };
 
+/// \brief Maps the grid type to the associated type of the face to vertices mapping.
+///
+/// Provides a type named Type.
+/// \tparam T The type of the grid.
+template<class T>
+struct Face2VerticesTraits
+{
+};
+
+template<>
+struct Face2VerticesTraits<UnstructuredGrid>
+{
+    typedef SparseTableView Type;
+};
+
 /// \brief Get the cell to faces mapping of a grid.
 Cell2FacesTraits<UnstructuredGrid>::Type 
 cell2Faces(const UnstructuredGrid& grid);
+
+/// \brief Get the face to vertices mapping of a grid.
+Face2VerticesTraits<UnstructuredGrid>::Type 
+face2Vertices(const UnstructuredGrid& grid);
+
+/// \brief Get the coordinates of a vertex of the grid.
+/// \param grid The grid the vertex is part of.
+/// \param index The index identifying the vertex.
+const double* vertexCoordinates(const UnstructuredGrid& grid, int index);
 
 class FaceCellsProxy
 {

--- a/opm/core/simulator/initStateEquil_impl.hpp
+++ b/opm/core/simulator/initStateEquil_impl.hpp
@@ -541,10 +541,8 @@ namespace Opm
                 // imposes the requirement that cell centroids are all
                 // within this vertical span.  That requirement is not
                 // checked.
-                typename UgGridHelpers::Cell2FacesTraits<Grid>::Type
-                    cell2Faces = UgGridHelpers::cell2Faces(G);
-                typename UgGridHelpers::Face2VerticesTraits<Grid>::Type
-                    faceVertices = UgGridHelpers::face2Vertices(G);
+                auto cell2Faces = UgGridHelpers::cell2Faces(G);
+                auto faceVertices = UgGridHelpers::face2Vertices(G);
 
                 for (typename CellRange::const_iterator
                          ci = cells.begin(), ce = cells.end();

--- a/opm/core/simulator/initStateEquil_impl.hpp
+++ b/opm/core/simulator/initStateEquil_impl.hpp
@@ -553,7 +553,7 @@ namespace Opm
                          fi != fe;
                          ++fi)
                     {
-                        for (auto i = faceVertices[*fi].begin(), e=faceVertices[*fi].end();
+                        for (auto i = faceVertices[*fi].begin(), e = faceVertices[*fi].end();
                              i != e; ++i)
                         {
                             const double z = UgGridHelpers::vertexCoordinates(G, *i)[nd-1];


### PR DESCRIPTION
Currently the keyword EQUIL is not supported by the fully implicit blackoil simulator when using CpGrid. This commit is a first step towards this as it makes the implementation generic.
