### PR TITLE
FindCXX11Features.cmake: check for the c++-2011 "final" specifier

### DIFF
--- a/cmake/Modules/FindCXX11Features.cmake
+++ b/cmake/Modules/FindCXX11Features.cmake
@@ -3,6 +3,7 @@
 #
 # Sets the follwing variable:
 #
+# HAVE_FINAL                       True if the compiler supports the "final" quantifier
 # HAVE_TYPE_TRAITS                 True if the <type_traits> header is available and implements sufficient functionality
 # HAVE_SHARED_PTR                  True if std::shared_ptr is available
 # HAVE_UNIQUE_PTR                  True if std::unique_ptr is available
@@ -69,6 +70,22 @@ endif (CXX_STD0X_FLAGS AND CXX_STDLIB_FLAGS)
 
 # perform tests
 include(CheckCXXSourceCompiles)
+
+# the "final" method specifier
+CHECK_CXX_SOURCE_COMPILES("
+struct Base {
+  virtual void foo() = 0;
+};
+struct Derived : public Base {
+  virtual void foo() final {};
+};
+
+int main()
+{
+    return 0;
+}
+"  HAVE_FINAL
+)
 
 # std::is_convertible, std::is_base_of
 CHECK_CXX_SOURCE_COMPILES("

--- a/cmake/Modules/opm-material-prereqs.cmake
+++ b/cmake/Modules/opm-material-prereqs.cmake
@@ -5,6 +5,7 @@
 set (opm-material_CONFIG_VAR
 	HAVE_MPI
 	HAVE_VALGRIND
+	HAVE_FINAL
 	)
 
 # dependencies


### PR DESCRIPTION
this keyword is quite useful to avoid mistakes during development because the compiler will complain if it sees a method marked as 'final' which has not been declared 'virtual' in a base class...