### PR TITLE
AdaptiveTimeStepping: also catch ISTLError caused in AMG.

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -148,6 +148,10 @@ namespace Opm {
                 std::cerr << e.what() << std::endl;
                 // also catch linear solver not converged
             }
+            catch (const Dune::ISTLError& e) {
+                std::cerr << e.what() << std::endl;
+                // also catch errors in ISTL AMG that occur when time step is too large
+            }
 
             // (linearIterations < 0 means no convergence in solver)
             if( linearIterations >= 0 )


### PR DESCRIPTION
This happens when the time step is too large. A restart with smaller time step solves the problem. This is needed when Norne is run with AMG.