### PR TITLE
summary output: use the EclipseState to determine the deck unit system

### DIFF
--- a/opm/core/io/OutputWriter.cpp
+++ b/opm/core/io/OutputWriter.cpp
@@ -47,12 +47,10 @@ private:
 /// Psuedo-constructor, can appear in template
 template <typename Format> unique_ptr <OutputWriter>
 create (const ParameterGroup& params,
-        std::shared_ptr <const Deck> deck,
         std::shared_ptr <const EclipseState> eclipseState,
         const Opm::PhaseUsage &phaseUsage,
         std::shared_ptr <const UnstructuredGrid> grid) {
     return unique_ptr <OutputWriter> (new Format (params,
-                                                  deck,
                                                   eclipseState,
                                                   phaseUsage,
                                                   grid->number_of_cells,
@@ -67,7 +65,6 @@ create (const ParameterGroup& params,
 /// to the list below!
 typedef map <const char*, unique_ptr <OutputWriter> (*)(
         const ParameterGroup&,
-        std::shared_ptr <const Deck> deck,
         std::shared_ptr <const EclipseState> eclipseState,
         const Opm::PhaseUsage &phaseUsage,
         std::shared_ptr <const UnstructuredGrid>)> map_t;
@@ -79,7 +76,6 @@ map_t FORMATS = {
 
 unique_ptr <OutputWriter>
 OutputWriter::create (const ParameterGroup& params,
-                      std::shared_ptr <const Deck> deck,
                       std::shared_ptr <const EclipseState> eclipseState,
                       const Opm::PhaseUsage &phaseUsage,
                       std::shared_ptr <const UnstructuredGrid> grid) {
@@ -97,7 +93,7 @@ OutputWriter::create (const ParameterGroup& params,
         // invoke the constructor for the type if we found the keyword
         // and put the pointer to this writer onto the list
         if (params.getDefault <bool> (name, false)) {
-            list->push_front (it->second (params, deck, eclipseState, phaseUsage, grid));
+            list->push_front (it->second (params, eclipseState, phaseUsage, grid));
         }
     }
 

--- a/opm/core/io/OutputWriter.hpp
+++ b/opm/core/io/OutputWriter.hpp
@@ -21,7 +21,6 @@
 #define OPM_OUTPUT_WRITER_HPP
 
 #include <memory>  // unique_ptr, shared_ptr
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/core/simulator/SimulatorTimerInterface.hpp>
 
 struct UnstructuredGrid;
@@ -108,7 +107,6 @@ public:
      */
     static std::unique_ptr <OutputWriter>
     create (const parameter::ParameterGroup& params,
-            std::shared_ptr <const Deck> deck,
             std::shared_ptr <const EclipseState> eclipseState,
             const Opm::PhaseUsage &phaseUsage,
             std::shared_ptr <const UnstructuredGrid> grid);

--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -449,8 +449,7 @@ public:
     // on the classes defined in the following.
 
     // add rate variables for each of the well in the input file
-    void addAllWells(Opm::DeckConstPtr deck,
-                     Opm::EclipseStateConstPtr eclipseState,
+    void addAllWells(Opm::EclipseStateConstPtr eclipseState,
                      const PhaseUsage& uses);
     void writeTimeStep(int writeStepIdx,
                        const SimulatorTimerInterface& timer,
@@ -994,8 +993,7 @@ void Summary::writeTimeStep(int writeStepIdx,
     ecl_sum_fwrite(ertHandle());
 }
 
-void Summary::addAllWells(Opm::DeckConstPtr deck,
-                          Opm::EclipseStateConstPtr eclipseState,
+void Summary::addAllWells(Opm::EclipseStateConstPtr eclipseState,
                           const PhaseUsage& uses)
 {
     eclipseState_ = eclipseState;
@@ -1174,7 +1172,7 @@ void EclipseWriter::writeInit(const SimulatorTimerInterface &timer)
                                                      eclGrid->getNX(),
                                                      eclGrid->getNY(),
                                                      eclGrid->getNZ()));
-    summary_->addAllWells(deck_, eclipseState_, phaseUsage_);
+    summary_->addAllWells(eclipseState_, phaseUsage_);
 }
 
 // implementation of the writeTimeStep method
@@ -1341,13 +1339,11 @@ void EclipseWriter::writeTimeStep(const SimulatorTimerInterface& timer,
 
 
 EclipseWriter::EclipseWriter(const parameter::ParameterGroup& params,
-                             Opm::DeckConstPtr deck,
                              Opm::EclipseStateConstPtr eclipseState,
                              const Opm::PhaseUsage &phaseUsage,
                              int numCells,
                              const int* compressedToCartesianCellIdx)
-    : deck_(deck)
-    , eclipseState_(eclipseState)
+    : eclipseState_(eclipseState)
     , numCells_(numCells)
     , compressedToCartesianCellIdx_(compressedToCartesianCellIdx)
     , gridToEclipseIdx_(numCells, int(-1) )

--- a/opm/core/io/eclipse/EclipseWriter.hpp
+++ b/opm/core/io/eclipse/EclipseWriter.hpp
@@ -65,7 +65,6 @@ public:
      *        binary files using ERT.
      */
     EclipseWriter(const parameter::ParameterGroup& params,
-                  Opm::DeckConstPtr deck,
                   Opm::EclipseStateConstPtr eclipseState,
                   const Opm::PhaseUsage &phaseUsage,
                   int numCells,
@@ -107,7 +106,6 @@ public:
     static ert_ecl_unit_enum convertUnitTypeErtEclUnitEnum(UnitSystem::UnitType unit);
 
 private:
-    Opm::DeckConstPtr deck_;
     Opm::EclipseStateConstPtr eclipseState_;
     int numCells_;
     std::array<int, 3> cartesianSize_;

--- a/opm/core/simulator/SimulatorOutput.cpp
+++ b/opm/core/simulator/SimulatorOutput.cpp
@@ -30,7 +30,6 @@ using namespace Opm;
 
 SimulatorOutputBase::SimulatorOutputBase (
         const parameter::ParameterGroup& params,
-        std::shared_ptr <const Deck> deck,
         std::shared_ptr <const EclipseState> eclipseState,
         const Opm::PhaseUsage &phaseUsage,
         std::shared_ptr <const UnstructuredGrid> grid,
@@ -46,7 +45,7 @@ SimulatorOutputBase::SimulatorOutputBase (
 
     // process parameters into a writer. we don't setup a new chain in
     // every timestep!
-    , writer_ (std::move (OutputWriter::create (params, deck, eclipseState, phaseUsage, grid)))
+    , writer_ (std::move (OutputWriter::create (params, eclipseState, phaseUsage, grid)))
 
     // always start from the first timestep
     , next_ (0) {

--- a/opm/core/simulator/SimulatorOutput.hpp
+++ b/opm/core/simulator/SimulatorOutput.hpp
@@ -56,7 +56,6 @@ protected:
      * need to pick them up from the object members.
      */
     SimulatorOutputBase (const parameter::ParameterGroup& p,
-                         std::shared_ptr <const Deck> deck,
                          std::shared_ptr <const EclipseState> eclipseState,
                          const Opm::PhaseUsage &phaseUsage,
                          std::shared_ptr <const UnstructuredGrid> grid,
@@ -146,7 +145,6 @@ private:
 template <typename Simulator>
 struct SimulatorOutput : public SimulatorOutputBase {
 	SimulatorOutput (const parameter::ParameterGroup& params,
-                     std::shared_ptr <const Deck> deck,
                      std::shared_ptr <const EclipseState> eclipseState,
                      const Opm::PhaseUsage &phaseUsage,
                      std::shared_ptr <const UnstructuredGrid> grid,
@@ -155,7 +153,7 @@ struct SimulatorOutput : public SimulatorOutputBase {
                      std::shared_ptr <const WellState> wellState,
                      std::shared_ptr <Simulator> sim)
         // send all other parameters to base class
-        : SimulatorOutputBase (params, deck, eclipseState, phaseUsage,
+        : SimulatorOutputBase (params, eclipseState, phaseUsage,
                                grid, timer, state, wellState)
 
         // store reference to simulator in derived class
@@ -171,7 +169,6 @@ struct SimulatorOutput : public SimulatorOutputBase {
      * the arguments passed exceeds the lifetime of this object.
      */
     SimulatorOutput (const parameter::ParameterGroup& params,
-                     const Deck& deck,
                      const EclipseState& eclipseState,
                      const Opm::PhaseUsage &phaseUsage,
                      const UnstructuredGrid& grid,
@@ -181,7 +178,6 @@ struct SimulatorOutput : public SimulatorOutputBase {
                      Simulator& sim)
         // send all other parameters to base class
         : SimulatorOutputBase (params,
-                               share_obj (deck),
                                share_obj (eclipseState),
                                phaseUsage,
                                share_obj (grid),

--- a/tests/test_EclipseWriteRFTHandler.cpp
+++ b/tests/test_EclipseWriteRFTHandler.cpp
@@ -136,7 +136,6 @@ std::shared_ptr<Opm::EclipseWriter> createEclipseWriter(std::shared_ptr<const Op
     const UnstructuredGrid &ourFinerUnstructuredGrid = *ourFineGridManagerPtr->c_grid();
 
     std::shared_ptr<Opm::EclipseWriter> eclipseWriter = std::make_shared<Opm::EclipseWriter>(params,
-                                                                                             deck,
                                                                                              eclipseState,
                                                                                              phaseUsage,
                                                                                              ourFinerUnstructuredGrid.number_of_cells,

--- a/tests/test_EclipseWriter.cpp
+++ b/tests/test_EclipseWriter.cpp
@@ -85,7 +85,6 @@ void createEclipseWriter(const char *deckString)
 
     Opm::PhaseUsage phaseUsage = Opm::phaseUsageFromDeck(deck);
     eclWriter.reset(new Opm::EclipseWriter(params,
-                                           deck,
                                            eclipseState,
                                            phaseUsage,
                                            ourFinerUnstructuredGrid.number_of_cells,

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -151,7 +151,6 @@ Opm::EclipseWriterPtr createEclipseWriter(Opm::DeckConstPtr deck,
   const Opm::PhaseUsage phaseUsage = Opm::phaseUsageFromDeck(deck);
 
   Opm::EclipseWriterPtr eclWriter(new Opm::EclipseWriter(params,
-                                                         deck,
                                                          eclipseState,
                                                          phaseUsage,
                                                          eclipseState->getEclipseGrid()->getCartesianSize(),


### PR DESCRIPTION
seems like the guy who added EclipseState::getDeckUnitSystem() suffers
from dementia...

note that the ugly `handleUnit_()` method is still required as long as a correct "unit name" ought to be supported. (the conversion itself could equally well be done using opm-parser's unit handling code...)