### PR TITLE
Cleans up PETSc detection

### DIFF
--- a/cmake/Modules/FindPETSc.cmake
+++ b/cmake/Modules/FindPETSc.cmake
@@ -43,10 +43,9 @@ find_library(PETSC_BLAS_LIBRARY
 
 # print message if there was still no blas found!
 if(NOT BLAS_FOUND AND NOT PETSC_BLAS_LIBRARY)
-  message(STATUS "BLAS not found but required for PETSC")
+  message(STATUS "BLAS not found but required for PETSc")
   return()
 endif()
-list(APPEND CMAKE_REQUIRED_LIBRARIES "${PETSC_BLAS_LIBRARY}")
 
 set(PETSC_LAPACK_LIBRARY "")
 find_package(LAPACK QUIET)
@@ -62,62 +61,60 @@ find_library(PETSC_LAPACK_LIBRARY
 
 # print message if there was still no blas found!
 if(NOT LAPACK_FOUND AND NOT PETSC_LAPACK_LIBRARY)
-  message(STATUS "LAPACK not found but required for PETSC")
+  message(STATUS "LAPACK not found but required for PETSc")
   return()
 endif()
-list(APPEND CMAKE_REQUIRED_LIBRARIES "${PETSC_LAPACK_LIBRARY}")
 
 find_package(X11 QUIET)
 if (X11_FOUND)
     list(APPEND PETSC_X11_LIBRARY "${X11_LIBRARIES}")
 endif()
-list(APPEND CMAKE_REQUIRED_LIBRARIES "${PETSC_X11_LIBRARY}")
 
-# only probe if we haven't a path in our cache
-if (Petsc_ROOT)
- set (PETSC_ROOT "${Petsc_ROOT}")
-endif (Petsc_ROOT)
+# these variables must exist. Since not finding MPI, both the header and the
+# object file , may not be an error, we want the option of concatenating the
+# empty variable onto the PETSC_LIBRARIES/INCLUDE_DIRS lists
+set(PETSC_MPI_LIBRARY "")
+set(PETSC_MPI_INCLUDE_DIRS "")
 
-find_path (PETSC_NORMAL_INCLUDE_DIR
-    NAMES "petsc.h"
-    PATHS ${PETSC_ROOT}
-    PATH_SUFFIXES "petsc-3.4.4" "include" "petsc"
-    ${_no_default_path}
-    )
+find_package(MPI)
+if(MPI_FOUND)
+    list(APPEND PETSC_MPI_LIBRARY "${MPI_LIBRARIES}")
+    set(PETSC_MPI_INCLUDE_DIRS ${MPI_INCLUDE_PATH})
 
-# if parallel computing is explicitly enabled - reuse the paths and links from
-# OpmMainLib + OpmFind
-# this needs to be called explicitly as FindPetsc runs before OpmMainLib starts
-# looking for MPI (for some reason). Ideally this isn't necessary
-if(USE_MPI)
-    find_package(MPI)
-endif()
-
-set(PETSC_MPI_FOUND ${MPI_FOUND})
-set(PETSC_MPI_INCLUDE_DIRS ${MPI_INCLUDE_PATH})
-set(PETSC_MPI_LIBRARIES ${MPI_LIBRARIES})
-
-# fallback - use the petsc provided implementation of serial MPI.
-if (NOT PETSC_MPI_INCLUDE_DIRS)
-    message(STATUS "Building without MPI support - looking for PETSc provided serial implementation")
-    find_path (PETSC_MPI_INCLUDE_DIRS
+else(MPI_FOUND)
+# if a system MPI wasn't found, look for PETSc's serial implementation. This
+# won't be available if PETSc was compiled with --with-mpi=0, so not finding
+# this won't be an error. This only needs to find the header, as the MPI
+# implementation should be already be compiled into PETSc.
+    message(STATUS "Could not find a system provided MPI. Searching for PETSc provided mpiuni fallback implementation.")
+    find_path(PETSC_MPI_INCLUDE_DIRS
         NAMES "mpi.h"
         PATHS ${PETSC_ROOT}/include
         PATH_SUFFIXES "mpiuni"
         ${_no_default_path}
         )
+endif(MPI_FOUND)
 
-    if(PETSC_MPI_INCLUDE_DIRS)
-        set(PETSC_MPI_FOUND 1)
-    endif(PETSC_MPI_INCLUDE_DIRS)
-
+if(NOT PETSC_MPI_INCLUDE_DIRS)
+    message(WARNING "Could not find any MPI implementation. If PETSc is compiled with --with-mpi=0 this is ok. Otherwise you will get linker errors or (possibly subtle) runtime errors. Continuing.")
+    if(NOT USE_MPI)
+        message("To build with MPI support, pass -DUSE_MPI=ON to CMake.")
+    endif(NOT USE_MPI)
 endif(NOT PETSC_MPI_INCLUDE_DIRS)
 
-# couldn't find any usable mpi implementation - abort
-if(NOT PETSC_MPI_FOUND)
-    message(STATUS "Could not find any suitable MPI implementation.")
-    return()
-endif()
+# only probe if we haven't a path in our cache
+if (Petsc_ROOT)
+    set (PETSC_ROOT "${Petsc_ROOT}")
+endif (Petsc_ROOT)
+
+find_path (PETSC_NORMAL_INCLUDE_DIR
+    NAMES "petsc.h"
+    PATHS ${PETSC_ROOT}
+    PATH_SUFFIXES "include" "petsc"
+    ${_no_default_path}
+    )
+
+list(APPEND PETSC_INCLUDE_DIR ${PETSC_NORMAL_INCLUDE_DIR})
 
 # look for actual Petsc library
 find_library(PETSC_LIBRARY
@@ -132,11 +129,6 @@ if(NOT PETSC_LIBRARY)
   return()
 endif()
 
-list(APPEND CMAKE_REQUIRED_LIBRARIES "${PETSC_LIBRARY}" "${PETSC_MPI_LIBRARIES}")
-
-if (PETSC_MPI_INCLUDE_DIRS AND PETSC_NORMAL_INCLUDE_DIR)
-    list (APPEND PETSC_INCLUDE_DIR ${PETSC_MPI_INCLUDE_DIRS} ${PETSC_NORMAL_INCLUDE_DIR})
-endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Petsc DEFAULT_MSG PETSC_INCLUDE_DIR PETSC_LIBRARY)
@@ -145,9 +137,12 @@ mark_as_advanced(PETSC_INCLUDE_DIR PETSC_LIBRARY)
 # if both headers and library are found, store results
 if(PETSC_FOUND)
     set(PETSC_INCLUDE_DIRS ${PETSC_INCLUDE_DIR})
+    list(APPEND PETSC_INCLUDE_DIRS ${PETSC_MPI_INCLUDE_DIRS})
+
     set(PETSC_LIBRARIES ${PETSC_LIBRARY})
 
     list(APPEND PETSC_LIBRARIES ${PETSC_BLAS_LIBRARY})
     list(APPEND PETSC_LIBRARIES ${PETSC_LAPACK_LIBRARY})
     list(APPEND PETSC_LIBRARIES ${PETSC_X11_LIBRARY})
+    list(APPEND PETSC_LIBRARIES ${PETSC_MPI_LIBRARY})
 endif()

--- a/cmake/Modules/opm-core-prereqs.cmake
+++ b/cmake/Modules/opm-core-prereqs.cmake
@@ -26,13 +26,14 @@ set (opm-core_DEPS
 	"SuiteSparse COMPONENTS umfpack"
 	# solver
 	"SuperLU"
-	"Petsc"
 	# xml processing (for config parsing)
 	"TinyXML"
 	# Ensembles-based Reservoir Tools (ERT)
 	"ERT REQUIRED"
 	# Look for MPI support
 	"MPI"
+	# PETSc numerical backend
+	"PETSc"
 	# DUNE dependency
 	"dune-common"
 	"dune-istl"


### PR DESCRIPTION
Now building will no longer fail if PETSc isn't available, and it correctly
degrades if it cannot find an available MPI. It should now behave similarly as
other optionals, such as SuperLU.

A continuation of https://github.com/OPM/opm-core/pull/727, but with slightly reformulated goals. Now, instead of being an explicit USE_PETSC flag it rather just looks for it like other CMake Modules.