### PR TITLE
reduce the default optimization level from -O3 to -O2

### DIFF
--- a/cmake/Modules/UseOptimization.cmake
+++ b/cmake/Modules/UseOptimization.cmake
@@ -38,7 +38,7 @@ if (CXX_COMPAT_GCC)
 
   # default optimization flags, if not set by user
   set_default_option (CXX _opt_dbg "-O0" "(^|\ )-O")
-  set_default_option (CXX _opt_rel "-O3" "(^|\ )-O")
+  set_default_option (CXX _opt_rel "-O2" "(^|\ )-O")
 
   # use these options for debug builds - no optimizations
   add_options (ALL_LANGUAGES "${_prof_DEBUG}" ${_opt_dbg} "-DDEBUG")


### PR DESCRIPTION
-O3 is sometimes declared "unsafe"
(cf. https://wiki.gentoo.org/wiki/GCC_optimization ) and it seems like
it bit us in https://github.com/OPM/opm-material/issues/23 if GCC 4.8
was used. so let's play safe and use -O2 for now...