### PR TITLE
Correct documentation of why we use operator[] to initialize map. (Completes #784)

### DIFF
--- a/opm/core/linalg/LinearSolverPetsc.cpp
+++ b/opm/core/linalg/LinearSolverPetsc.cpp
@@ -38,8 +38,10 @@ namespace{
             : default_type_(default_type)
         {
             // g++-4.4 has problems converting const char* to char*
-            // which it thinks is needed for constructing std::string.
-            // Using operator[] circumvents this problem.
+            // The problem is caused by the mapped type being PCType
+            // which (at least in PETSc 3.2) is char* because of C
+            // (in the header there is "#define PCType character*(80)").
+            // and the KSP...  defines being const char* (because of C++).
             type_map_["richardson"] = KSPRICHARDSON;
             // Not available in PETSC 3.2 on Debian
             //type_map_["chebyshev"] = KSPCHEBYSHEV;


### PR DESCRIPTION
This commit updates the source code comment about using operator[] to
initialize the unordered map. Thanks to Bard's persistence we found
out that the cause is not the construction of the key value of type
std::string from const char* but the mapped type being a (mutable)
char* (due to C?).

This completes the PR #784.