### PR TITLE
Store unhandled command-line arguments

### DIFF
--- a/examples/compute_eikonal_from_files.cpp
+++ b/examples/compute_eikonal_from_files.cpp
@@ -60,7 +60,7 @@ try
 {
     using namespace Opm;
 
-    parameter::ParameterGroup param(argc, argv, false);
+    parameter::ParameterGroup param(argc, argv);
 
     // Read grid.
     GridManager grid_manager(param.get<std::string>("grid_filename"));

--- a/examples/compute_initial_state.cpp
+++ b/examples/compute_initial_state.cpp
@@ -81,7 +81,7 @@ try
     using namespace Opm;
 
     // Setup.
-    parameter::ParameterGroup param(argc, argv, false);
+    parameter::ParameterGroup param(argc, argv);
     std::cout << "---------------    Reading parameters     ---------------" << std::endl;
     const std::string deck_filename = param.get<std::string>("deck_filename");
     Opm::ParserPtr parser(new Opm::Parser() );

--- a/examples/compute_tof.cpp
+++ b/examples/compute_tof.cpp
@@ -160,7 +160,7 @@ try
     using namespace Opm;
 
     std::cout << "\n================    Test program for incompressible tof computations     ===============\n\n";
-    parameter::ParameterGroup param(argc, argv, false);
+    parameter::ParameterGroup param(argc, argv);
     std::cout << "---------------    Reading parameters     ---------------" << std::endl;
 
     // Read the deck.

--- a/examples/compute_tof_from_files.cpp
+++ b/examples/compute_tof_from_files.cpp
@@ -77,7 +77,7 @@ try
 {
     using namespace Opm;
 
-    parameter::ParameterGroup param(argc, argv, false);
+    parameter::ParameterGroup param(argc, argv);
 
     // Read grid.
     GridManager grid_manager(param.get<std::string>("grid_filename"));

--- a/opm/core/utility/parameters/ParameterGroup.cpp
+++ b/opm/core/utility/parameters/ParameterGroup.cpp
@@ -329,7 +329,7 @@ namespace Opm {
 	    }
 	}
 
-        const std::vector<std::string> ParameterGroup::unhandledArguments() const
+        const std::vector<std::string>& ParameterGroup::unhandledArguments() const
         {
             return unhandled_arguments_;
         }

--- a/opm/core/utility/parameters/ParameterGroup.cpp
+++ b/opm/core/utility/parameters/ParameterGroup.cpp
@@ -329,5 +329,10 @@ namespace Opm {
 	    }
 	}
 
+        const std::vector<std::string> ParameterGroup::unhandledArguments() const
+        {
+            return unhandled_arguments_;
+        }
+
     } // namespace parameter
 } // namespace Opm

--- a/opm/core/utility/parameters/ParameterGroup.hpp
+++ b/opm/core/utility/parameters/ParameterGroup.hpp
@@ -268,7 +268,7 @@ namespace Opm {
 	    void insertParameter(const std::string& name, const std::string& value);
 
             /// Unhandled arguments from command line parsing.
-            const std::vector<std::string> unhandledArguments() const;
+            const std::vector<std::string>& unhandledArguments() const;
 
 	private:
 	    typedef std::shared_ptr<ParameterMapItem> data_type;
@@ -279,7 +279,7 @@ namespace Opm {
 	    map_type map_;
 	    const ParameterGroup* parent_;
 	    bool output_is_enabled_;
-            std::vector<std::string> unhandled_arguments_;
+	    std::vector<std::string> unhandled_arguments_;
 
 	    template<typename T, class Requirement>
 	    T translate(const pair_type& data, const Requirement& chk) const;

--- a/opm/core/utility/parameters/ParameterGroup.hpp
+++ b/opm/core/utility/parameters/ParameterGroup.hpp
@@ -127,12 +127,16 @@ namespace Opm {
 	    ///
 	    /// It is required that argv[0] is the program name, while if
 	    /// 0 < i < argc, then argv[i] is either
-	    /// the name of an xml file or parametername=value.
+	    /// the name of an xml file, parameter file or parametername=value.
 	    ///
 	    /// \param argc is the number of command-line arguments,
 	    ///        including the name of the executable.
 	    /// \param argv is an array of char*, each of which is a
-	    /// command line argument.
+	    ///        command line argument.
+	    /// \param verify_syntax  If true (default), then it is an error to
+	    ///        pass arguments that cannot be handled by the ParameterGroup,
+	    ///        or an empty argument list. If false, such arguments are stored
+	    ///        and can be retrieved later with unhandledArguments().
             template <typename StringArray>
 	    ParameterGroup(int argc, StringArray argv, const bool verify_syntax = true);
 
@@ -284,7 +288,7 @@ namespace Opm {
 	    template<typename T, class Requirement>
 	    T translate(const pair_type& data, const Requirement& chk) const;
             template <typename StringArray>
-	    void parseCommandLineArguments(int argc, StringArray argv);
+	    void parseCommandLineArguments(int argc, StringArray argv, bool verify_syntax);
 	    void recursiveSetIsOutputEnabled(bool output_is_enabled);
 
 	    // helper routines to do textual I/O

--- a/opm/core/utility/parameters/ParameterGroup.hpp
+++ b/opm/core/utility/parameters/ParameterGroup.hpp
@@ -267,6 +267,9 @@ namespace Opm {
             /// Insert a new parameter item into the group.
 	    void insertParameter(const std::string& name, const std::string& value);
 
+            /// Unhandled arguments from command line parsing.
+            const std::vector<std::string> unhandledArguments() const;
+
 	private:
 	    typedef std::shared_ptr<ParameterMapItem> data_type;
 	    typedef std::pair<std::string, data_type> pair_type;
@@ -276,6 +279,7 @@ namespace Opm {
 	    map_type map_;
 	    const ParameterGroup* parent_;
 	    bool output_is_enabled_;
+            std::vector<std::string> unhandled_arguments_;
 
 	    template<typename T, class Requirement>
 	    T translate(const pair_type& data, const Requirement& chk) const;

--- a/opm/core/utility/parameters/ParameterGroup_impl.hpp
+++ b/opm/core/utility/parameters/ParameterGroup_impl.hpp
@@ -150,9 +150,7 @@ namespace Opm {
 		} else if (file_type.second == "param") {
 		    this->readParam(files[i]);
 		} else {
-		    std::cout << "WARNING: Ignoring file '"
-                              << files[i] << "' with unknown extension.\n"
-			      << "Valid filename extensions are 'xml' and 'param'.\n";
+                    unhandled_arguments_.push_back(files[i]);
 		}
 	    }
 	    for (int i = 0; i < int(assignments.size()); ++i) {

--- a/opm/core/utility/parameters/ParameterGroup_impl.hpp
+++ b/opm/core/utility/parameters/ParameterGroup_impl.hpp
@@ -38,11 +38,13 @@
 
 #include <iostream>
 #include <string>
+#include <stdexcept>
 
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/core/utility/parameters/ParameterStrings.hpp>
 #include <opm/core/utility/parameters/ParameterTools.hpp>
 #include <opm/core/utility/parameters/Parameter.hpp>
+#include <opm/core/utility/ErrorMacros.hpp>
 
 namespace Opm {
     namespace parameter {
@@ -115,11 +117,11 @@ namespace Opm {
 			  << "[...]" << std::endl;
 		exit(EXIT_FAILURE);
 	    }
-	    this->parseCommandLineArguments(argc, argv);
+	    this->parseCommandLineArguments(argc, argv, verify_syntax);
 	}
 
         template <typename StringArray>
-	void ParameterGroup::parseCommandLineArguments(int argc, StringArray argv)
+	void ParameterGroup::parseCommandLineArguments(int argc, StringArray argv, bool verify_syntax)
         {
 	    std::vector<std::string> files;
 	    std::vector<std::pair<std::string, std::string> > assignments;
@@ -150,7 +152,13 @@ namespace Opm {
 		} else if (file_type.second == "param") {
 		    this->readParam(files[i]);
 		} else {
-                    unhandled_arguments_.push_back(files[i]);
+                    if (verify_syntax) {
+                        std::cerr << "ERROR: Input '" << files[i] << "' is not a valid name for a parameter file.\n";
+                        std::cerr << "       Valid filename extensions are 'xml' and 'param'.\n";
+                        OPM_THROW(std::runtime_error, "ParameterGroup cannot handle argument: " << files[i]);
+                    } else {
+                        unhandled_arguments_.push_back(files[i]);
+                    }
 		}
 	    }
 	    for (int i = 0; i < int(assignments.size()); ++i) {

--- a/tests/test_param.cpp
+++ b/tests/test_param.cpp
@@ -73,6 +73,7 @@ BOOST_AUTO_TEST_CASE(commandline_syntax_init)
         "/slashtopitem=anotherstring\n"
         "/topitem=somestring\n";
     BOOST_CHECK(os.str() == correct_answer);
+    BOOST_CHECK(p.unhandledArguments().empty());
 
     // Tests that only run in debug mode.
 #ifndef NDEBUG
@@ -88,7 +89,7 @@ BOOST_AUTO_TEST_CASE(xml_syntax_init)
                   "/group/item=overridingstring",
                   "unhandledargument" };
     const std::size_t argc = sizeof(argv)/sizeof(argv[0]);
-    parameter::ParameterGroup p(argc, argv);
+    parameter::ParameterGroup p(argc, argv, false);
     BOOST_CHECK(p.get<std::string>("topitem") == "somestring");
     std::ostringstream os;
     p.writeParamToStream(os);
@@ -104,4 +105,16 @@ BOOST_AUTO_TEST_CASE(xml_syntax_init)
     // Tests that only run in debug mode.
 #ifndef NDEBUG
 #endif
+}
+
+
+BOOST_AUTO_TEST_CASE(failing_strict_xml_syntax_init)
+{
+    typedef const char* cp;
+    cp argv[] = { "program_command",
+                  "testdata.xml",
+                  "/group/item=overridingstring",
+                  "unhandledargument" };
+    const std::size_t argc = sizeof(argv)/sizeof(argv[0]);
+    BOOST_CHECK_THROW(parameter::ParameterGroup p(argc, argv), std::runtime_error);
 }

--- a/tests/test_param.cpp
+++ b/tests/test_param.cpp
@@ -47,22 +47,24 @@
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <cstddef>
 #include <sstream>
+#include <vector>
 
 using namespace Opm;
 
 BOOST_AUTO_TEST_CASE(commandline_syntax_init)
 {
     typedef const char* cp;
-    cp argv[] = { "program_command",
-                  "topitem=somestring",
-                  "/slashtopitem=anotherstring",
-                  "/group/item=1",
-                  "/group/anotheritem=2",
-                  "/group/subgroup/item=3",
-                  "/group/subgroup/anotheritem=4",
-                  "/group/item=overridingstring" };
-    const std::size_t argc = sizeof(argv)/sizeof(argv[0]);
-    parameter::ParameterGroup p(argc, argv);
+    std::vector<cp> argv = { "program_command",
+                             "topitem=somestring",
+                             "/slashtopitem=anotherstring",
+                             "/group/item=1",
+                             "/group/anotheritem=2",
+                             "/group/subgroup/item=3",
+                             "/group/subgroup/anotheritem=4",
+                             "/group/item=overridingstring",
+                             0 };
+    const std::size_t argc = argv.size() - 1;
+    parameter::ParameterGroup p(argc, argv.data());
     BOOST_CHECK(p.get<std::string>("topitem") == "somestring");
     std::ostringstream os;
     p.writeParamToStream(os);
@@ -84,12 +86,13 @@ BOOST_AUTO_TEST_CASE(commandline_syntax_init)
 BOOST_AUTO_TEST_CASE(xml_syntax_init)
 {
     typedef const char* cp;
-    cp argv[] = { "program_command",
-                  "testdata.xml",
-                  "/group/item=overridingstring",
-                  "unhandledargument" };
-    const std::size_t argc = sizeof(argv)/sizeof(argv[0]);
-    parameter::ParameterGroup p(argc, argv, false);
+    std::vector<cp> argv = { "program_command",
+                             "testdata.xml",
+                             "/group/item=overridingstring",
+                             "unhandledargument",
+                             0};
+    const std::size_t argc = argv.size() - 1;
+    parameter::ParameterGroup p(argc, argv.data(), false);
     BOOST_CHECK(p.get<std::string>("topitem") == "somestring");
     std::ostringstream os;
     p.writeParamToStream(os);
@@ -111,10 +114,11 @@ BOOST_AUTO_TEST_CASE(xml_syntax_init)
 BOOST_AUTO_TEST_CASE(failing_strict_xml_syntax_init)
 {
     typedef const char* cp;
-    cp argv[] = { "program_command",
-                  "testdata.xml",
-                  "/group/item=overridingstring",
-                  "unhandledargument" };
-    const std::size_t argc = sizeof(argv)/sizeof(argv[0]);
-    BOOST_CHECK_THROW(parameter::ParameterGroup p(argc, argv), std::runtime_error);
+    std::vector<cp> argv = { "program_command",
+                             "testdata.xml",
+                             "/group/item=overridingstring",
+                             "unhandledargument",
+                             0 };
+    const std::size_t argc = argv.size() - 1;
+    BOOST_CHECK_THROW(parameter::ParameterGroup p(argc, argv.data()), std::runtime_error);
 }

--- a/tests/test_param.cpp
+++ b/tests/test_param.cpp
@@ -85,7 +85,8 @@ BOOST_AUTO_TEST_CASE(xml_syntax_init)
     typedef const char* cp;
     cp argv[] = { "program_command",
                   "testdata.xml",
-                  "/group/item=overridingstring" };
+                  "/group/item=overridingstring",
+                  "unhandledargument" };
     const std::size_t argc = sizeof(argv)/sizeof(argv[0]);
     parameter::ParameterGroup p(argc, argv);
     BOOST_CHECK(p.get<std::string>("topitem") == "somestring");
@@ -98,7 +99,8 @@ BOOST_AUTO_TEST_CASE(xml_syntax_init)
         "/slashtopitem=anotherstring\n"
         "/topitem=somestring\n";
     BOOST_CHECK(os.str() == correct_answer);
-
+    BOOST_REQUIRE(p.unhandledArguments().size() == 1);
+    BOOST_CHECK_EQUAL(p.unhandledArguments()[0], "unhandledargument");
     // Tests that only run in debug mode.
 #ifndef NDEBUG
 #endif


### PR DESCRIPTION
The ParameterGroup class will after this no longer ignore command-line arguments it does not handle itself, but store and make the unhandled arguments available through the unhandledArguments() method.

This should not affect existing usage. The reason for the change is a need for more command-line flexibility for applications such as flow.