### PR TITLE
Finddune-istl.cmake: Add UMFPACK as an optional dependency

### DIFF
--- a/cmake/Modules/Finddune-istl.cmake
+++ b/cmake/Modules/Finddune-istl.cmake
@@ -17,7 +17,8 @@ find_opm_package (
 
   # required dependencies
   "dune-common REQUIRED;
-  SuperLU
+  SuperLU;
+  SuiteSparse COMPONENTS umfpack
   "
   # header to search for
   "dune/istl/bcrsmatrix.hh"


### PR DESCRIPTION
this makes the cmake module usable by downstream modules which do not
explicitly specify an UMFPACK dependency.