### PR TITLE
Adds possibility of having a well not stored on a grid partitioning.

### DIFF
--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -308,13 +308,13 @@ namespace Opm
 
     /// Default constructor.
     WellsManager::WellsManager()
-        : w_(0), is_parallel_run_()
+        : w_(0), is_parallel_run_(false)
     {
     }
 
     /// Construct from existing wells object.
     WellsManager::WellsManager(struct Wells* W)
-        : w_(clone_wells(W)), is_parallel_run_()
+        : w_(clone_wells(W)), is_parallel_run_(false)
     {
     }
 
@@ -323,7 +323,7 @@ namespace Opm
                                const size_t timeStep,
                                const UnstructuredGrid& grid,
                                const double* permeability)
-        : w_(0), is_parallel_run_()
+        : w_(0), is_parallel_run_(false)
     {
         init(eclipseState, timeStep, UgGridHelpers::numCells(grid),
              UgGridHelpers::globalCell(grid), UgGridHelpers::cartDims(grid), 

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -308,13 +308,13 @@ namespace Opm
 
     /// Default constructor.
     WellsManager::WellsManager()
-        : w_(0)
+        : w_(0), is_parallel_run_()
     {
     }
 
     /// Construct from existing wells object.
     WellsManager::WellsManager(struct Wells* W)
-        : w_(clone_wells(W))
+        : w_(clone_wells(W)), is_parallel_run_()
     {
     }
 
@@ -323,7 +323,7 @@ namespace Opm
                                const size_t timeStep,
                                const UnstructuredGrid& grid,
                                const double* permeability)
-        : w_(0)
+        : w_(0), is_parallel_run_()
     {
         init(eclipseState, timeStep, UgGridHelpers::numCells(grid),
              UgGridHelpers::globalCell(grid), UgGridHelpers::cartDims(grid), 

--- a/opm/core/wells/WellsManager.hpp
+++ b/opm/core/wells/WellsManager.hpp
@@ -81,7 +81,8 @@ namespace Opm
                      int dimensions,
                      const F2C& f2c,
                      FC begin_face_centroids,
-                     const double* permeability);
+                     const double* permeability,
+                     bool is_parallel_run=false);
 
         WellsManager(const Opm::EclipseStateConstPtr eclipseState,
                      const size_t timeStep,
@@ -177,6 +178,8 @@ namespace Opm
         // Data
         Wells* w_;
         WellCollection well_collection_;
+        // Whether this is a parallel simulation
+        bool is_parallel_run_;
     };
 
 } // namespace Opm


### PR DESCRIPTION
In a parallel run each process only knows a part of the grid. Nevertheless
it does hold the complete well information. To resolve this the WellsManager
must be able to handle this case.

With this commit its constructor gets a flag indicating whether this is
a parallel run. If it is, then it does not throw if a well has cells that
are not present on the local part of the grid. Nevertheless it will check
that either all or none of the cells of a well are stored in the local part
of the grid.

Wells with no perforated cells on the local will still be present but set to SHUT.