### PR TITLE
 Allow to prevent printing to std::cout.

### DIFF
--- a/opm/core/simulator/SimulatorReport.cpp
+++ b/opm/core/simulator/SimulatorReport.cpp
@@ -23,12 +23,13 @@
 
 namespace Opm
 {
-    SimulatorReport::SimulatorReport()
+    SimulatorReport::SimulatorReport(bool verbose)
         : pressure_time(0.0),
           transport_time(0.0),
           total_time(0.0),
           total_newton_iterations( 0 ),
-          total_linear_iterations( 0 )
+          total_linear_iterations( 0 ),
+          verbose_(verbose)
     {
     }
 
@@ -43,31 +44,40 @@ namespace Opm
 
     void SimulatorReport::report(std::ostream& os)
     {
-        os << "Total time taken: " << total_time
-           << "\n  Pressure time:  " << pressure_time
-           << "\n  Transport time: " << transport_time
-           << "\n  Overall Newton Iterations:  " << total_newton_iterations
-           << "\n  Overall Linear Iterations:  " << total_linear_iterations
-           << std::endl;
+        if ( verbose_ )
+        {
+            os << "Total time taken: " << total_time
+               << "\n  Pressure time:  " << pressure_time
+               << "\n  Transport time: " << transport_time
+               << "\n  Overall Newton Iterations:  " << total_newton_iterations
+               << "\n  Overall Linear Iterations:  " << total_linear_iterations
+               << std::endl;
+        }
     }
 
     void SimulatorReport::reportFullyImplicit(std::ostream& os)
     {
-        os << "Total time taken (seconds):  " << total_time
-           << "\nSolver time (seconds):       " << pressure_time
-           << "\nOverall Newton Iterations:   " << total_newton_iterations
-           << "\nOverall Linear Iterations:   " << total_linear_iterations
-           << std::endl;
+        if ( verbose_ )
+        {
+            os << "Total time taken (seconds):  " << total_time
+               << "\nSolver time (seconds):       " << pressure_time
+               << "\nOverall Newton Iterations:   " << total_newton_iterations
+               << "\nOverall Linear Iterations:   " << total_linear_iterations
+               << std::endl;
+        }
     }
 
     void SimulatorReport::reportParam(std::ostream& os)
     {
-        os << "/timing/total_time=" << total_time
-           << "\n/timing/pressure/total_time=" << pressure_time
-           << "\n/timing/transport/total_time=" << transport_time
-           << "\n/timing/newton/iterations=" << total_newton_iterations
-           << "\n/timing/linear/iterations=" << total_linear_iterations
-           << std::endl;
+        if ( verbose_ )
+        {
+            os << "/timing/total_time=" << total_time
+               << "\n/timing/pressure/total_time=" << pressure_time
+               << "\n/timing/transport/total_time=" << transport_time
+               << "\n/timing/newton/iterations=" << total_newton_iterations
+               << "\n/timing/linear/iterations=" << total_linear_iterations
+               << std::endl;
+        }
     }
 
 

--- a/opm/core/simulator/SimulatorReport.hpp
+++ b/opm/core/simulator/SimulatorReport.hpp
@@ -36,7 +36,7 @@ namespace Opm
         unsigned int total_linear_iterations;
 
         /// Default constructor initializing all times to 0.0.
-        SimulatorReport();
+        SimulatorReport(bool verbose=true);
         /// Increment this report's times by those in sr.
         void operator+=(const SimulatorReport& sr);
         /// Print a report to the given stream.
@@ -44,6 +44,9 @@ namespace Opm
         /// Print a report, leaving out the transport time.
         void reportFullyImplicit(std::ostream& os);
         void reportParam(std::ostream& os);
+    private:
+        // Whether to print statistics to std::cout
+        bool verbose_;
     };
 
 } // namespace Opm

--- a/opm/core/utility/parameters/Parameter.hpp
+++ b/opm/core/utility/parameters/Parameter.hpp
@@ -90,7 +90,8 @@ namespace Opm {
 	template<>
 	struct ParameterMapItemTrait<int> {
 	    static int convert(const ParameterMapItem& item,
-                               std::string& conversion_error)
+                               std::string& conversion_error,
+                               const bool)
             {
 		conversion_error = correct_parameter_tag(item);
 		if (conversion_error != "") {
@@ -125,7 +126,8 @@ namespace Opm {
 	template<>
 	struct ParameterMapItemTrait<double> {
 	    static double convert(const ParameterMapItem& item,
-                                  std::string& conversion_error)
+                                  std::string& conversion_error,
+                                  const bool)
             {
 		conversion_error = correct_parameter_tag(item);
 		if (conversion_error != "") {
@@ -160,7 +162,8 @@ namespace Opm {
 	template<>
 	struct ParameterMapItemTrait<bool> {
 	    static bool convert(const ParameterMapItem& item,
-                                std::string& conversion_error)
+                                std::string& conversion_error,
+                                const bool)
             {
 		conversion_error = correct_parameter_tag(item);
 		if (conversion_error != "") {
@@ -194,7 +197,8 @@ namespace Opm {
 	template<>
 	struct ParameterMapItemTrait<std::string> {
 	    static std::string convert(const ParameterMapItem& item,
-                                       std::string& conversion_error)
+                                       std::string& conversion_error,
+                                       const bool)
             {
 		conversion_error = correct_parameter_tag(item);
 		if (conversion_error != "") {

--- a/opm/core/utility/parameters/ParameterGroup.cpp
+++ b/opm/core/utility/parameters/ParameterGroup.cpp
@@ -87,8 +87,9 @@ namespace Opm {
 	}
 
 	ParameterGroup::ParameterGroup(const std::string& patharg,
-				       const ParameterGroup* parent)
-	: path_(patharg), parent_(parent), output_is_enabled_(true)
+	                               const ParameterGroup* parent,
+                                       const bool enable_output)
+	: path_(patharg), parent_(parent), output_is_enabled_(enable_output)
 	{
 	}
 
@@ -100,7 +101,7 @@ namespace Opm {
 
 	void ParameterGroup::readXML(const std::string& xml_filename)
         {
-	    fill_xml(*this, xml_filename);
+	    fill_xml(*this, xml_filename, output_is_enabled_);
 	}
 
 	namespace {
@@ -218,7 +219,8 @@ namespace Opm {
 		    map_[name_path.first] = data;
 		} else {
 		    std::shared_ptr<ParameterMapItem> data(new ParameterGroup(this->path() + ID_delimiter_path + name_path.first,
-										   this));
+                                                                              this,
+                                                                              output_is_enabled_));
 		    ParameterGroup& child = dynamic_cast<ParameterGroup&>(*data);
 		    child.insertParameter(name_path.second, value);
 		    map_[name_path.first] = data;

--- a/opm/core/utility/parameters/ParameterGroup.hpp
+++ b/opm/core/utility/parameters/ParameterGroup.hpp
@@ -116,7 +116,8 @@ namespace Opm {
 	    struct RequirementFailedException : public std::exception {};
 
 	    ParameterGroup();
-	    ParameterGroup(const std::string& path, const ParameterGroup* parent);
+	    ParameterGroup(const std::string& path, const ParameterGroup* parent,
+                           const bool enable_output);
 
 	    // From ParameterMapItem
 	    virtual ~ParameterGroup();
@@ -137,8 +138,10 @@ namespace Opm {
 	    ///        pass arguments that cannot be handled by the ParameterGroup,
 	    ///        or an empty argument list. If false, such arguments are stored
 	    ///        and can be retrieved later with unhandledArguments().
+            /// \param enable_output Whether to enable output or not.
             template <typename StringArray>
-	    ParameterGroup(int argc, StringArray argv, const bool verify_syntax = true);
+	    ParameterGroup(int argc, StringArray argv, const bool verify_syntax = true,
+                           const bool enabled_output=true);
 
 	    /// \brief This method checks if there is something with name
 	    ///        \p name in the parameter gropup.

--- a/opm/core/utility/parameters/ParameterGroup_impl.hpp
+++ b/opm/core/utility/parameters/ParameterGroup_impl.hpp
@@ -53,14 +53,15 @@ namespace Opm {
 	struct ParameterMapItemTrait<ParameterGroup> {
 	    static ParameterGroup
             convert(const ParameterMapItem& item,
-                    std::string& conversion_error)
+                    std::string& conversion_error,
+                    bool enable_output)
             {
 		std::string tag = item.getTag();
 		if (tag != ID_xmltag__param_grp) {
 		    conversion_error = "The XML tag was '" + tag +
                                        "' but should be '" +
                                        ID_xmltag__param_grp + "'.\n";
-		    return ParameterGroup("", 0);
+		    return ParameterGroup("", 0, enable_output);
 		}
 		conversion_error = "";
 		const ParameterGroup& pg = dynamic_cast<const ParameterGroup&>(item);
@@ -105,8 +106,9 @@ namespace Opm {
 	    }
 
         template <typename StringArray>
-	ParameterGroup::ParameterGroup(int argc, StringArray argv, bool verify_syntax)
-            : path_(ID_path_root), parent_(0), output_is_enabled_(true)
+	ParameterGroup::ParameterGroup(int argc, StringArray argv, bool verify_syntax,
+                                       const bool enable_output)
+            : path_(ID_path_root), parent_(0), output_is_enabled_(enable_output)
 	{
 	    if (verify_syntax && (argc < 2)) {
 		std::cerr << "Usage: " << argv[0] << " "
@@ -296,7 +298,8 @@ namespace Opm {
 	    const std::string& name = named_data.first;
 	    const data_type data = named_data.second;
 	    std::string conversion_error;
-	    T value = ParameterMapItemTrait<T>::convert(*data, conversion_error);
+	    T value = ParameterMapItemTrait<T>::convert(*data, conversion_error,
+                                                        output_is_enabled_);
 	    if (conversion_error != "") {
 		std::cerr << "ERROR: Failed to convert the element named '"
 			  << name

--- a/opm/core/utility/parameters/ParameterXML.hpp
+++ b/opm/core/utility/parameters/ParameterXML.hpp
@@ -47,7 +47,7 @@ namespace Opm {
 	///
 	/// \retval pg is the ParameterGroup to be filled.
 	/// \param filename is the name of an XML file.
-	void fill_xml(ParameterGroup& pg, const std::string filename);
+        void fill_xml(ParameterGroup& pg, const std::string filename, const bool enable_output);
     } // namespace parameter
 } // namespace Opm
 


### PR DESCRIPTION
This allows for deactivating output to std:cout. This is handy for parallel runs where we only
want to print statistics on one process.

