### PR TITLE
Allow to create the correct communication information for several unknowns.

### DIFF
--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -115,19 +115,20 @@ public:
     void copyValuesTo(ParallelIndexSet& indexSet, RemoteIndices& remoteIndices,
                       std::size_t local_component_size = 0, std::size_t num_components = 1) const
     {
-        ParallelIndexSet::GlobalIndex max_gi  = local_component_size;
+        ParallelIndexSet::GlobalIndex global_component_size  = local_component_size;
         if ( num_components > 1 )
         {
+            ParallelIndexSet::GlobalIndex max_gi = 0;
             // component the max global index
             for( auto i = indexSet_->begin(), end = indexSet_->end(); i != end; ++i )
             {
                 max_gi = std::max(max_gi, i->global());
             }
-            ++max_gi;
-            max_gi = communicator_.max(max_gi);
+            global_component_size = max_gi+1;
+            global_component_size = communicator_.max(global_component_size);
         }
         indexSet.beginResize();
-        IndexSetInserter<ParallelIndexSet> inserter(indexSet, max_gi,
+        IndexSetInserter<ParallelIndexSet> inserter(indexSet, global_component_size,
                                                     local_component_size, num_components);
         std::for_each(indexSet_->begin(), indexSet_->end(), inserter);
         indexSet.endResize();

--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -1,6 +1,6 @@
 /*
   Copyright 2014, 2015 Dr. Markus Blatt - HPC-Simulation-Software & Services
-  Copyright 2014 Statoil ASA
+  Copyright 2014, 2015 Statoil ASA
   Copyright 2015 NTNU
 
   This file is part of the Open Porous Media project (OPM).

--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -113,10 +113,10 @@ public:
     /// \param[out] indexSet The object to store the index set in.
     /// \param[out] remoteIndices The object to store the remote indices information in.
     void copyValuesTo(ParallelIndexSet& indexSet, RemoteIndices& remoteIndices,
-                      std::size_t local_component_size=0, std::size_t no_components=1) const
+                      std::size_t local_component_size=0, std::size_t num_components=1) const
     {
         ParallelIndexSet::GlobalIndex max_gi  = local_component_size;
-        if (no_components>1)
+        if ( num_components > 1 )
         {
             // component the max global index
             for( auto i = indexSet_->begin(), end = indexSet_->end(); i != end; ++i )
@@ -126,7 +126,7 @@ public:
         }
         indexSet.beginResize();
         IndexSetInserter<ParallelIndexSet> inserter(indexSet, max_gi,
-                                                    local_component_size, no_components);
+                                                    local_component_size, num_components);
         std::for_each(indexSet_->begin(), indexSet_->end(), inserter);
         indexSet.endResize();
         remoteIndices.rebuild<false>();
@@ -332,14 +332,14 @@ private:
         typedef typename ParallelIndexSet::GlobalIndex GlobalIndex;
 
         IndexSetInserter(ParallelIndexSet& indexSet, const GlobalIndex& component_size,
-                         std::size_t local_component_size, std::size_t no_components)
+                         std::size_t local_component_size, std::size_t num_components)
             : indexSet_(&indexSet), component_size_(component_size),
               local_component_size_(local_component_size),
-              no_components_(no_components)
+              num_components_(num_components)
         {}
         void operator()(const typename ParallelIndexSet::IndexPair& pair)
         {
-            for(std::size_t i = 0; i < no_components_; i++)
+            for(std::size_t i = 0; i < num_components_; i++)
                 indexSet_->add(i * component_size_ + pair.global(),
                                LocalIndex(i * local_component_size_  + pair.local(),
                                           pair.local().attribute()));
@@ -351,7 +351,7 @@ private:
         /// \brief The local number of unknowns per component/equation.
         std::size_t local_component_size_;
         /// \brief The number of components/equations.
-        std::size_t no_components_;
+        std::size_t num_components_;
     };
     std::shared_ptr<ParallelIndexSet> indexSet_;
     std::shared_ptr<RemoteIndices> remoteIndices_;

--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -113,14 +113,16 @@ public:
     /// \param[out] indexSet The object to store the index set in.
     /// \param[out] remoteIndices The object to store the remote indices information in.
     void copyValuesTo(ParallelIndexSet& indexSet, RemoteIndices& remoteIndices,
-                      std::size_t local_component_size=0, std::size_t num_components=1) const
+                      std::size_t local_component_size = 0, std::size_t num_components = 1) const
     {
         ParallelIndexSet::GlobalIndex max_gi  = local_component_size;
         if ( num_components > 1 )
         {
             // component the max global index
             for( auto i = indexSet_->begin(), end = indexSet_->end(); i != end; ++i )
+            {
                 max_gi = std::max(max_gi, i->global());
+            }
             ++max_gi;
             max_gi = communicator_.max(max_gi);
         }


### PR DESCRIPTION
In this case the parallel index set might represent N entries (this might be the number of
cells of grid). Nevertheless, there are several (n) equations/unknowns attached to each index.
In this case we construct a larger index set representing N*n unknows, where each unknown
is attached to an index.

This change only affects parallel runs.