### PR TITLE
Make adaptive time stepping parallel

### DIFF
--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -404,6 +404,12 @@ private:
     template<typename BinaryOperator>
     struct MaskToMinOperator
     {
+        // This is a real nice one: numeric limits has to a type without const
+        // or reference. Otherwise we get complete nonesense.
+        typedef typename std::remove_reference<
+            typename std::remove_const<typename BinaryOperator::result_type>::type
+            >::type Result;
+
         MaskToMinOperator(BinaryOperator b)
         : b_(b)
         {}
@@ -432,11 +438,11 @@ private:
                 // for integral types.
                 if( std::is_integral<T>::value )
                 {
-                    return -std::numeric_limits<float>::min();
+                    return -std::numeric_limits<Result>::min();
                 }
                 else
                 {
-                    return -std::numeric_limits<float>::max();
+                    return -std::numeric_limits<Result>::max();
                 }
             }
         }
@@ -458,6 +464,12 @@ private:
     template<typename BinaryOperator>
     struct MaskToMaxOperator
     {
+        // This is a real nice one: numeric limits has to a type without const
+        // or reference. Otherwise we get complete nonesense.
+        typedef typename std::remove_cv<
+            typename std::remove_reference<typename BinaryOperator::result_type>::type
+            >::type Result;
+
         MaskToMaxOperator(BinaryOperator b)
         : b_(b)
         {}

--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -403,6 +403,37 @@ private:
         BinaryOperator b_;
     };
 
+    /// \brief An operator for computing a parallel inner product.
+    template<class T>
+    struct InnerProductFunctor
+    {
+        /// \brief Apply the underlying binary operator according to the mask.
+        ///
+        /// The BinaryOperator will be called with t1, and mask*t2.
+        /// \param t1 first value
+        /// \param t2 second value (might be modified).
+        /// \param mask The mask (0 or 1).
+        template<class T1>
+        T operator()(const T& t1, const T& t2, const T1& mask)
+        {
+            T masked =  maskValue(t2, mask);
+            return t1 + masked * masked;
+        }
+        template<class T1>
+        T maskValue(const T& t, const T1& mask)
+        {
+            return t*mask;
+        }
+        std::plus<T> localOperator()
+        {
+            return std::plus<T>();
+        }
+        T getInitialValue()
+        {
+            return T();
+        }
+    };
+
     /// \brief An operator that converts the values where mask is 0 to the minimum value
     ///
     /// Could be used to compute a global maximum.
@@ -548,6 +579,12 @@ private:
         return MaskToMaxOperator<std::pointer_to_binary_function<const T&,const T&,const T&> >
             (std::pointer_to_binary_function<const T&,const T&,const T&>
              ((const T&(*)(const T&, const T&))std::min<T>));
+    }
+    template<class T>
+    InnerProductFunctor<T>
+    makeInnerProductFunctor()
+    {
+        return InnerProductFunctor<T>();
     }
     } // end namespace Reduction
 } // end namespace Opm

--- a/opm/core/simulator/AdaptiveTimeStepping.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping.hpp
@@ -1,5 +1,7 @@
 /*
   Copyright 2014 IRIS AS
+  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2015 Statoil AS
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/core/simulator/AdaptiveTimeStepping.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping.hpp
@@ -37,7 +37,11 @@ namespace Opm {
     {
     public:
         //! \brief contructor taking parameter object
-        AdaptiveTimeStepping( const parameter::ParameterGroup& param );
+        //! \param param The parameter object
+        //! \param pinfo The information about the data distribution
+        //!              and communication for a parallel run.
+        AdaptiveTimeStepping( const parameter::ParameterGroup& param,
+                              const boost::any& pinfo=boost::any() );
 
         /** \brief  step method that acts like the solver::step method
                     in a sub cycle of time steps

--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -33,7 +33,8 @@ namespace Opm {
     // AdaptiveTimeStepping
     //---------------------
 
-    AdaptiveTimeStepping::AdaptiveTimeStepping( const parameter::ParameterGroup& param )
+    AdaptiveTimeStepping::AdaptiveTimeStepping( const parameter::ParameterGroup& param,
+                                            const boost::any& parallel_information )
         : timeStepControl_()
         , restart_factor_( param.getDefault("solver.restartfactor", double(0.1) ) )
         , growth_factor_( param.getDefault("solver.growthfactor", double(1.25) ) )
@@ -51,13 +52,13 @@ namespace Opm {
 
         const double tol = param.getDefault("timestep.control.tol", double(1e-3) );
         if( control == "pid" ) {
-            timeStepControl_ = TimeStepControlType( new PIDTimeStepControl( tol ) );
+            timeStepControl_ = TimeStepControlType( new PIDTimeStepControl( tol, parallel_information ) );
         }
         else if ( control == "pid+iteration" )
         {
             const int iterations   = param.getDefault("timestep.control.targetiteration", defaultTargetIterations );
             const double maxgrowth = param.getDefault("timestep.control.maxgrowth", double(3.0) );
-            timeStepControl_ = TimeStepControlType( new PIDAndIterationCountTimeStepControl( iterations, tol, maxgrowth ) );
+            timeStepControl_ = TimeStepControlType( new PIDAndIterationCountTimeStepControl( iterations, tol, maxgrowth, parallel_information ) );
         }
         else if ( control == "iterationcount" )
         {

--- a/opm/core/simulator/TimeStepControl.cpp
+++ b/opm/core/simulator/TimeStepControl.cpp
@@ -1,5 +1,7 @@
 /*
   Copyright 2014 IRIS AS
+  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2015 Statoil AS
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/core/simulator/TimeStepControl.hpp
+++ b/opm/core/simulator/TimeStepControl.hpp
@@ -1,5 +1,7 @@
 /*
   Copyright 2014 IRIS AS
+  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2015 Statoil AS
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/core/simulator/TimeStepControl.hpp
+++ b/opm/core/simulator/TimeStepControl.hpp
@@ -21,7 +21,10 @@
 
 #include <vector>
 
+#include <boost/any.hpp>
+#include <boost/range/iterator_range.hpp>
 #include <opm/core/simulator/TimeStepControlInterface.hpp>
+#include <opm/core/linalg/ParallelIstlInformation.hpp>
 
 namespace Opm
 {
@@ -73,8 +76,12 @@ namespace Opm
         /// \brief constructor
         /// \param tol      tolerance for the relative changes of the numerical solution to be accepted
         ///                 in one time step (default is 1e-3)
+        /// \paramm pinfo   The information about the parallel information. Needed to
+        ///                 compute parallel scalarproducts.
         /// \param verbose  if true get some output (default = false)
-        PIDTimeStepControl( const double tol = 1e-3, const bool verbose = false );
+        PIDTimeStepControl( const double tol = 1e-3,
+                            const boost::any& pinfo = boost::any(),
+                            const bool verbose = false );
 
         /// \brief \copydoc TimeStepControlInterface::initialize
         void initialize( const SimulatorState& state );
@@ -83,15 +90,38 @@ namespace Opm
         double computeTimeStepSize( const double dt, const int /* iterations */, const SimulatorState& state ) const;
 
     protected:
-        // return inner product for given container, here std::vector
         template <class Iterator>
-        double euclidianNormSquared( Iterator it, const Iterator end ) const
+        double euclidianNormSquared( Iterator it, const Iterator end,
+                                           int num_components=1 ) const
         {
-            double product = 0.0 ;
-            for( ; it != end; ++it ) {
-                product += ( *it * *it );
+#if HAVE_MPI
+            if ( parallel_information_.type() == typeid(ParallelISTLInformation) )
+            {
+                const ParallelISTLInformation& info =
+                    boost::any_cast<const ParallelISTLInformation&>(parallel_information_);
+                std::size_t size_per_component = (end - it) / num_components;
+                assert((end - it) == num_components * size_per_component);
+                double component_product = 0.0;
+                for( std::size_t i = 0; i < num_components; ++i )
+                {
+                    auto component_container =
+                        boost::make_iterator_range(it + i * size_per_component,
+                                                   it + (i + 1) * size_per_component);
+                    info.computeReduction(component_container,
+                                           Opm::Reduction::makeInnerProductFunctor<double>(),
+                                           component_product);
+                }
+                return component_product;
             }
-            return product;
+            else
+#endif
+            {
+                double product = 0.0 ;
+                for( ; it != end; ++it ) {
+                    product += ( *it * *it );
+                }
+                return product;
+            }
         }
 
     protected:
@@ -102,6 +132,8 @@ namespace Opm
         mutable std::vector< double > errors_;
 
         const bool verbose_;
+    private:
+        const boost::any parallel_information_;
     };
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -119,10 +151,13 @@ namespace Opm
         /// \param tol        tolerance for the relative changes of the numerical solution to be accepted
         ///                   in one time step (default is 1e-3)
         //  \param maxgrowth  max growth factor for new time step in relation of old time step (default = 3.0)
+        /// \paramm pinfo     The information about the parallel information. Needed to
+        ///                   compute parallel scalarproducts.
         /// \param verbose    if true get some output (default = false)
         PIDAndIterationCountTimeStepControl( const int target_iterations = 20,
                                              const double tol = 1e-3,
                                              const double maxgrowth = 3.0,
+                                             const boost::any& = boost::any(),
                                              const bool verbose = false);
 
         /// \brief \copydoc TimeStepControlInterface::computeTimeStepSize

--- a/tests/test_parallelistlinformation.cpp
+++ b/tests/test_parallelistlinformation.cpp
@@ -1,6 +1,7 @@
 /*
   Copyright 2015 Dr. Markus Blatt - HPC-Simulation-Software & Services
   Copyright 2015 NTNU
+  Copyright 2015 Statoil AS
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/tests/test_parallelistlinformation.cpp
+++ b/tests/test_parallelistlinformation.cpp
@@ -48,16 +48,20 @@ void runSumMaxMinTest(const int offset)
     assert(comm.indexSet()->size()==x.size());
     for(auto i=comm.indexSet()->begin(), iend=comm.indexSet()->end(); i!=iend; ++i)
         x[i->local()]=i->global()+offset;
-    auto containers = std::make_tuple(x, x, x);
+    auto containers = std::make_tuple(x, x, x, x);
     auto operators  = std::make_tuple(Opm::Reduction::makeGlobalSumFunctor<int>(),
                                       Opm::Reduction::makeGlobalMaxFunctor<int>(),
-                                      Opm::Reduction::makeGlobalMinFunctor<int>());
-    auto values     = std::make_tuple(0,0,100000);
+                                      Opm::Reduction::makeGlobalMinFunctor<int>(),
+                                      Opm::Reduction::makeInnerProductFunctor<int>());
+    auto values     = std::make_tuple(0,0,100000, 0);
     auto oldvalues  = values;
+    start = offset;
+    end   = start+N;
     comm.computeReduction(containers,operators,values);
     BOOST_CHECK(std::get<0>(values)==std::get<0>(oldvalues)+((N-1+2*offset)*N)/2);
     BOOST_CHECK(std::get<1>(values)==std::max(N+offset-1, std::get<1>(oldvalues)));
     BOOST_CHECK(std::get<2>(values)==std::min(offset, std::get<2>(oldvalues)));
+    BOOST_CHECK(std::get<3>(values)==((end-1)*end*(2*end-1)-(start-1)*start*(2*start-1))/6+std::get<3>(oldvalues));
 }
 
 BOOST_AUTO_TEST_CASE(tupleReductionTest)


### PR DESCRIPTION
The only stage where parallelism changes the adaptive time stepping is when some inner products on the saturation andpressure are computed.

This PR makes this part parallel by adding an additonal boost::any parameter to the constuctor of the adaptive time stepping and the controller classes. Per default this is empty. In a parallel run it contains a ParallelIstlInformation object encapsulating the information about the parallelisation. This then used
to compute the parallel inner product.

There will be a small upcoming PR in opm-autodiff that uses this one.