### PR TITLE
[bugfix,parallel] Deactivate non-existing wells in manager.

### DIFF
--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -407,10 +407,19 @@ namespace Opm
 
 
     void WellsManager::setupWellControls(std::vector<WellConstPtr>& wells, size_t timeStep,
-                                         std::vector<std::string>& well_names, const PhaseUsage& phaseUsage) {
+                                         std::vector<std::string>& well_names, const PhaseUsage& phaseUsage,
+                                         const std::vector<int>& wells_on_proc) {
         int well_index = 0;
-        for (auto wellIter= wells.begin(); wellIter != wells.end(); ++wellIter) {
-            WellConstPtr well = (*wellIter);
+        auto well_on_proc = wells_on_proc.begin();
+
+        for (auto wellIter= wells.begin(); wellIter != wells.end(); ++wellIter, ++well_on_proc) {
+            if( ! *well_on_proc )
+            {
+                // Wells not stored on the process are not in the list
+                continue;
+            }
+
+           WellConstPtr well = (*wellIter);
 
             if (well->getStatus(timeStep) == WellCommon::STOP) {
                 // STOPed wells are kept in the well list but marked as stopped.

--- a/opm/core/wells/WellsManager.hpp
+++ b/opm/core/wells/WellsManager.hpp
@@ -155,7 +155,8 @@ namespace Opm
         WellsManager& operator=(const WellsManager& other);
         static void setupCompressedToCartesian(const int* global_cell, int number_of_cells, std::map<int,int>& cartesian_to_compressed );
         void setupWellControls(std::vector<WellConstPtr>& wells, size_t timeStep,
-                               std::vector<std::string>& well_names, const PhaseUsage& phaseUsage);
+                               std::vector<std::string>& well_names, const PhaseUsage& phaseUsage,
+                               const std::vector<int>& wells_on_proc);
 
         template<class C2F, class FC, class NTG>
         void createWellsFromSpecs( std::vector<WellConstPtr>& wells, size_t timeStep,
@@ -169,7 +170,8 @@ namespace Opm
                                    const PhaseUsage& phaseUsage,
                                    const std::map<int,int>& cartesian_to_compressed,
                                    const double* permeability,
-                                   const NTG& ntg);
+                                   const NTG& ntg,
+                                   std::vector<int>& wells_on_proc);
 
         void addChildGroups(GroupTreeNodeConstPtr parentNode, ScheduleConstPtr schedule, size_t timeStep, const PhaseUsage& phaseUsage);
         void setupGuideRates(std::vector<WellConstPtr>& wells, const size_t timeStep, std::vector<WellData>& well_data, std::map<std::string, int>& well_names_to_index);

--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -234,7 +234,6 @@ void WellsManager::createWellsFromSpecs(std::vector<WellConstPtr>& wells, size_t
 
         well_index++;
     }
-    std::cout<<"well_index="<<well_index<<" no wells="<<wells.size()<<std::endl;
     // Set up reference depths that were defaulted. Count perfs.
 
     const int num_wells = well_data.size();


### PR DESCRIPTION
Previously, we used the setStatus method to set wells that do not
exist on the local grid to SHUT. Or at least this is what I thought
that ```well.setStatus(timestep, SHUT)```. Unfortunately, my
assumption was wrong. This was revealed while testing a parallel run
with SPE9 that threw an expeption about "Elements must be added in
weakly increasing order" in Opm::DynamicState::add(int, T). Seems like
the method name is a bit misleading.

As it turns out the WellManager has its own complete list of active
wells (shut wells are simply left out). Therefore we can use this
behaviour to our advantage: With this commit we not only exclude shut
wells from the list, but also the ones that do not exist on the local
grid. We even get rid of an ugly const_cast.

With this PR I was able to run SPE9 in parallel.