### PR TITLE
Fix mask to min (completes PR PR #805)

### DIFF
--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -481,7 +481,7 @@ private:
             // for integral types.
             if( std::is_integral<Result>::value )
             {
-                return -std::numeric_limits<Result>::min();
+                return std::numeric_limits<Result>::min();
             }
             else
             {


### PR DESCRIPTION
Bård spotet a bug after PR #805 was merged. Indead returning ```-numeric_limits<type>::min()``` does not make sense for integral values. This commit resorts to returning numeric_limits<type>::min() and adds some more tests.