### PR TITLE
Opm 206 Use IOConfig from EclipseState to decide which Eclipse output files to write (and when)

### DIFF
--- a/opm/core/io/eclipse/EclipseWriter.hpp
+++ b/opm/core/io/eclipse/EclipseWriter.hpp
@@ -115,7 +115,6 @@ private:
     double deckToSiTemperatureFactor_;
     double deckToSiTemperatureOffset_;
     bool enableOutput_;
-    int outputInterval_;
     int writeStepIdx_;
     int reportStepIdx_;
     std::string outputDir_;

--- a/tests/test_EclipseWriter.cpp
+++ b/tests/test_EclipseWriter.cpp
@@ -365,6 +365,8 @@ BOOST_AUTO_TEST_CASE(EclipseWriterIntegration)
 {
     const char *deckString =
         "RUNSPEC\n"
+        "INIT\n"
+        "UNIFOUT\n"
         "OIL\n"
         "GAS\n"
         "WATER\n"
@@ -386,6 +388,9 @@ BOOST_AUTO_TEST_CASE(EclipseWriterIntegration)
         "PERMX\n"
         "27*1 /\n"
         "SCHEDULE\n"
+        "RPTRST\n"
+        "BASIC=1\n"
+        "/\n"
         "TSTEP\n"
         "1.0 2.0 3.0 4.0 /\n"
         "WELSPECS\n"

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -162,7 +162,8 @@ Opm::EclipseWriterPtr createEclipseWriter(Opm::DeckConstPtr deck,
 BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo)
 {
     std::string eclipse_data_filename    = "testBlackoilState3.DATA";
-    std::string eclipse_restart_filename = "TESTBLACKOILSTATE3.UNRST";
+    std::string eclipse_restart_filename = "TESTBLACKOILSTATE3.X0004";
+
 
     test_work_area_type * test_area = test_work_area_alloc("TEST_EclipseWriteNumWells");
     test_work_area_copy_file(test_area, eclipse_data_filename.c_str());


### PR DESCRIPTION
Use the IOConfig object from EclipseState to decide:
* Whether restart file should be written for a specified report step
* whether restart files are to be unified or not (UNIFOUT keyword, default if keyword not present is multiple)
* whether an EGRID file should be written (GRIDFILE, NOGGF keywords)
* whether an INIT file should be written (INIT keyword)
* whether the above files should be formatted or not (FMTOUT keyword, default if keyword not present is unformatted)


* Removed former setting for interval writes to disk (from params) 


* Changed a test due to changes in behaviour when using IOConfig (ie if UNIFOUT keyword not set, default is multiple restart files, not unified)
