### PR TITLE
fix SatFuncMultiplexer on old compilers

### DIFF
--- a/opm/core/props/satfunc/SatFuncMultiplexer.hpp
+++ b/opm/core/props/satfunc/SatFuncMultiplexer.hpp
@@ -82,11 +82,18 @@ public:
     SatFuncMultiplexer()
     {}
 
+    ~SatFuncMultiplexer()
+    {}
+
+    // this constructor not really a copy constructor, but it is
+    // required to make std::unique_ptr happy
     SatFuncMultiplexer(const SatFuncMultiplexer&)
     {}
 
-    ~SatFuncMultiplexer()
-    {}
+    // this operator does not do anything and is thus not a copy operator, but it is
+    // required to make std::unique_ptr happy on old compilers
+    SatFuncMultiplexer& operator=(const SatFuncMultiplexer& other)
+    { return *this; }
 
     /*!
      * \brief Pick the correct saturation function type and initialize the object using


### PR DESCRIPTION
"old" == "gcc 4.4". the standard c++ library of this compiler seems to
invoke the copy operator when creating objects in a vector, whereas
newer versions of the library don't. The problem is that std::unique
pointer cannot be copied because it is -- err -- unique and thus the
implicit copy operator for the SatFuncMultiplexer class gets deleted
by the compiler.

the fix is to introduce a "fake" copy operator which does not do
anything but is present to make std::vector of stdlibc++-4.4
happy. this is obviously not very elegant, but I could not come up
with a better solution. (another fix would be to use raw pointers
instead of std::unique_ptr, but IMO this does not qualify as
"better".)