### PR TITLE
Revise SimulatorState and BlackoilState.

### DIFF
--- a/opm/core/simulator/BlackoilState.cpp
+++ b/opm/core/simulator/BlackoilState.cpp
@@ -4,11 +4,16 @@
 using namespace Opm;
 
 void
-BlackoilState::init(int number_of_cells, int number_of_phases, int num_phases) {
-    SimulatorState::init(number_of_cells, number_of_phases, num_phases);
-   gor_.resize(number_of_cells, 0.) ;
-   rv_.resize(number_of_cells,0.);
+BlackoilState::init(int number_of_cells, int number_of_phases, int num_phases)
+{
+   SimulatorState::init(number_of_cells, number_of_phases, num_phases);
+
+   // register cell data in base class
+   gorId_ = SimulatorState::registerCellData( "GASOILRATIO", 1 );
+   rvId_  = SimulatorState::registerCellData( "RV", 1 );
+
    // surfvol_ intentionally empty, left to initBlackoilSurfvol
+   surfaceVolId_ = SimulatorState::registerCellData( "SURFACEVOL", 0 );
 }
 
 void

--- a/opm/core/simulator/BlackoilState.cpp
+++ b/opm/core/simulator/BlackoilState.cpp
@@ -12,7 +12,7 @@ BlackoilState::init(int number_of_cells, int number_of_phases, int num_phases)
    gorId_ = SimulatorState::registerCellData( "GASOILRATIO", 1 );
    rvId_  = SimulatorState::registerCellData( "RV", 1 );
 
-   // surfvol_ intentionally empty, left to initBlackoilSurfvol
+   // surfvolumes intentionally empty, left to initBlackoilSurfvol
    surfaceVolId_ = SimulatorState::registerCellData( "SURFACEVOL", 0 );
 }
 

--- a/opm/core/simulator/BlackoilState.hpp
+++ b/opm/core/simulator/BlackoilState.hpp
@@ -32,8 +32,10 @@ namespace Opm
     class BlackoilState : public SimulatorState
     {
     public:
+        using SimulatorState :: cellData ;
+
         virtual void init(const UnstructuredGrid& grid, int num_phases);
-        
+
         virtual void init(int number_of_cells, int number_of_faces, int num_phases);
 
         /// Set the first saturation to either its min or max value in
@@ -47,18 +49,22 @@ namespace Opm
         virtual bool equals(const SimulatorState& other,
                             double epsilon = 1e-8) const;
 
-        std::vector<double>& surfacevol  () { return surfvol_; }
-        std::vector<double>& gasoilratio () { return gor_   ; }
-        std::vector<double>& rv () {return rv_ ; }
+        std::vector<double>& surfacevol  () { return cellData()[ surfaceVolId_ ]; }
+        std::vector<double>& gasoilratio () { return cellData()[ gorId_ ] ; }
+        std::vector<double>& rv () {return cellData()[ rvId_ ] ; }
 
-        const std::vector<double>& surfacevol  () const { return surfvol_; }
-        const std::vector<double>& gasoilratio () const { return gor_   ; }
-        const std::vector<double>& rv () const {return rv_ ; }
+        const std::vector<double>& surfacevol  () const { return cellData()[ surfaceVolId_ ]; }
+        const std::vector<double>& gasoilratio () const { return cellData()[ gorId_ ] ; }
+        const std::vector<double>& rv () const { return cellData()[ rvId_ ] ; }
 
     private:
-        std::vector<double> surfvol_; // no entries = no cells * no phases
-        std::vector<double> gor_   ;  // no entries = no cells
-        std::vector<double> rv_ ;     // no entries = no cells
+        int gorId_ ;   // no entries = no cells (gas oil ratio id)
+        int rvId_ ;    // no entries = no cells ( rv id )
+        int surfaceVolId_ ; // no entries = no cells * no phases (surfaceVol id )
+
+        //std::vector<double> surfvol_; // no entries = no cells * no phases
+        //std::vector<double> gor_   ;  // no entries = no cells
+        //std::vector<double> rv_ ;     // no entries = no cells
     };
 } // namespace Opm
 

--- a/opm/core/simulator/BlackoilState.hpp
+++ b/opm/core/simulator/BlackoilState.hpp
@@ -1,5 +1,6 @@
 /*
   Copyright 2012 SINTEF ICT, Applied Mathematics.
+  Copyright 2015 IRIS AS
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/core/simulator/SimulatorState.cpp
+++ b/opm/core/simulator/SimulatorState.cpp
@@ -50,8 +50,9 @@ SimulatorState::init(int number_of_cells, int number_of_faces, int num_phases)
 {
     num_phases_ = num_phases;
 
-    cellData_.resize( 3 );
-    faceData_.resize( 2 );
+    // clear memory
+    cellData_ = std::vector< std::vector<double> > ( 3 );
+    faceData_ = std::vector< std::vector<double> > ( 2 );
 
     pressure().resize(number_of_cells, 0.0);
     temperature().resize(number_of_cells, 273.15 + 20);

--- a/opm/core/simulator/SimulatorState.cpp
+++ b/opm/core/simulator/SimulatorState.cpp
@@ -2,6 +2,7 @@
 #include <opm/core/grid.h>
 
 #include <cmath>
+#include <cassert>
 
 using namespace Opm;
 
@@ -48,19 +49,61 @@ void
 SimulatorState::init(int number_of_cells, int number_of_faces, int num_phases)
 {
     num_phases_ = num_phases;
-    press_.resize(number_of_cells, 0.0);
-    temp_.resize(number_of_cells, 273.15 + 20);
-    fpress_.resize(number_of_faces, 0.0);
-    flux_.resize(number_of_faces, 0.0);
-    sat_.resize(num_phases_ * number_of_cells, 0.0);
+
+    cellData_.resize( 3 );
+    faceData_.resize( 2 );
+
+    pressure().resize(number_of_cells, 0.0);
+    temperature().resize(number_of_cells, 273.15 + 20);
+    saturation().resize(num_phases_ * number_of_cells, 0.0);
+
+    cellDataNames_.resize( 3 );
+    cellDataNames_[ pressureId_ ] = "PRESSURE" ;
+    cellDataNames_[ temperatureId_ ] = "TEMPERATURE";
+    cellDataNames_[ saturationId_ ] = "SATURATION" ;
+
     for (int cell = 0; cell < number_of_cells; ++cell) {
         // Defaulting the second saturation to 1.0.
         // This will usually be oil in a water-oil case,
         // gas in an oil-gas case.
         // For proper initialization, one should not rely on this,
         // but use available phase information instead.
-        sat_[num_phases_*cell + 1] = 1.0;
+        saturation()[num_phases_*cell + 1] = 1.0;
     }
+
+    facepressure().resize(number_of_faces, 0.0);
+    faceflux().resize(number_of_faces, 0.0);
+
+    faceDataNames_.resize( 2 );
+    faceDataNames_[ facePressureId_ ] = "FACEPRESSURE" ;
+    faceDataNames_[ faceFluxId_ ] =  "FACEFLUX" ;
+
+}
+
+size_t
+SimulatorState::registerCellData( const std::string& name, const int components, const double initialValue )
+{
+    // check if init has been called
+    assert( cellData_.size() > 0 );
+    const size_t pos = cellData_.size();
+    cellDataNames_.push_back( name );
+    const size_t nCells = pressure().size();
+    assert( nCells > 0 );
+    cellData_.push_back( std::vector<double>( nCells * components, initialValue ) );
+    return pos;
+}
+
+size_t
+SimulatorState::registerFaceData( const std::string& name, const int components, const double initialValue )
+{
+    // check if init has been called
+    assert( faceData_.size() > 0 );
+    const size_t pos = faceData_.size();
+    faceDataNames_.push_back( name );
+    const size_t nFaces = facepressure().size();
+    assert( nFaces > 0 );
+    faceData_.push_back( std::vector<double>( nFaces * components, initialValue ) );
+    return pos ;
 }
 
 template <typename Props> void
@@ -75,11 +118,12 @@ SimulatorState::setFirstSat(const std::vector<int>& cells,
     std::vector<double> smin(num_phases_*n);
     std::vector<double> smax(num_phases_*n);
     props.satRange(n, &cells[0], &smin[0], &smax[0]);
+    std::vector< double >& sat = saturation();
     const double* svals = (es == MinSat) ? &smin[0] : &smax[0];
     for (int ci = 0; ci < n; ++ci) {
         const int cell = cells[ci];
-        sat_[num_phases_*cell] = svals[num_phases_*ci];
-        sat_[num_phases_*cell + 1] = 1.0 - sat_[num_phases_*cell];
+        sat[num_phases_*cell] = svals[num_phases_*ci];
+        sat[num_phases_*cell + 1] = 1.0 - sat[num_phases_*cell];
     }
 }
 

--- a/opm/core/simulator/SimulatorState.hpp
+++ b/opm/core/simulator/SimulatorState.hpp
@@ -5,6 +5,7 @@
 #define OPM_SIMULATORSTATE_HEADER_INCLUDED
 
 #include <vector>
+#include <string>
 
 // forward declaration
 struct UnstructuredGrid;
@@ -18,8 +19,20 @@ namespace Opm
         virtual void init(const UnstructuredGrid& g, int num_phases);
 
         virtual void init(int number_of_cells, int number_of_faces, int num_phases);
-        
+
         enum ExtremalSat { MinSat, MaxSat };
+
+        /// \brief pressure per cell.
+        static const int pressureId_ = 0;
+        /// \brief temperature per cell.
+        static const int temperatureId_ = 1;
+        /// \brief The saturation of each phase per cell.
+        static const int saturationId_ = 2;
+
+        /// \brief pressure per face.
+        static const int facePressureId_ = 0;
+        /// \brief The fluxes at the faces.
+        static const int faceFluxId_ = 1;
 
     protected:
         /**
@@ -37,17 +50,17 @@ namespace Opm
     public:
         int numPhases() const { return num_phases_; }
 
-        std::vector<double>& pressure    () { return press_ ; }
-        std::vector<double>& temperature () { return temp_  ; }
-        std::vector<double>& facepressure() { return fpress_; }
-        std::vector<double>& faceflux    () { return flux_  ; }
-        std::vector<double>& saturation  () { return sat_   ; }
+        std::vector<double>& pressure    () { return cellData_[ pressureId_ ]; }
+        std::vector<double>& temperature () { return cellData_[ temperatureId_ ]; }
+        std::vector<double>& facepressure() { return faceData_[ facePressureId_]; }
+        std::vector<double>& faceflux    () { return faceData_[ faceFluxId_ ];        }
+        std::vector<double>& saturation  () { return cellData_[ saturationId_ ];  }
 
-        const std::vector<double>& pressure    () const { return press_ ; }
-        const std::vector<double>& temperature () const { return temp_  ; }
-        const std::vector<double>& facepressure() const { return fpress_; }
-        const std::vector<double>& faceflux    () const { return flux_  ; }
-        const std::vector<double>& saturation  () const { return sat_   ; }
+        const std::vector<double>& pressure    () const { return cellData_[ pressureId_ ];    }
+        const std::vector<double>& temperature () const { return cellData_[ temperatureId_ ]; }
+        const std::vector<double>& facepressure() const { return faceData_[ facePressureId_]; }
+        const std::vector<double>& faceflux    () const { return faceData_[ faceFluxId_ ];        }
+        const std::vector<double>& saturation  () const { return cellData_[ saturationId_ ];  }
 
         /**
          * Compare this state with another, to see if they are different
@@ -55,20 +68,30 @@ namespace Opm
          */
         virtual bool equals(const SimulatorState& other,
                             double epsilon = 1e-8) const;
+
+        std::vector< std::vector<double> >& cellData() { return cellData_; }
+        const std::vector< std::vector<double> >& cellData() const { return cellData_; }
+
+        std::vector< std::vector<double> >& faceData() { return faceData_; }
+        const std::vector< std::vector<double> >& faceData() const { return faceData_; }
+
     private:
         int num_phases_;
-        /// \brief pressure per cell.
-        std::vector<double> press_ ;
-        /// \brief temperature per cell.
-        std::vector<double> temp_  ;
-        /// \brief pressure per face.
-        std::vector<double> fpress_;
-        /// \brief The fluxes at the faces.
-        std::vector<double> flux_  ;
-        /// \brief The saturation of each phase per cell.
-        std::vector<double> sat_   ;
+
+        /// \brief vector containing all registered cell data
+        std::vector< std::vector< double > > cellData_;
+        /// \brief vector containing all registered face data
+        std::vector< std::vector< double > > faceData_;
+
+        /// \brief names for the cell data
+        std::vector< std::string > cellDataNames_;
+        /// \brief names for the face data
+        std::vector< std::string > faceDataNames_;
 
     protected:
+        size_t registerCellData( const std::string& name, const int components, const double initialValue = 0.0 );
+        size_t registerFaceData( const std::string& name, const int components, const double initialValue = 0.0 );
+
         /**
          * Check if two vectors are equal within a margin.
          *

--- a/opm/core/simulator/SimulatorState.hpp
+++ b/opm/core/simulator/SimulatorState.hpp
@@ -23,6 +23,7 @@ namespace Opm
 
         enum ExtremalSat { MinSat, MaxSat };
 
+    protected:
         /// \brief pressure per cell.
         static const int pressureId_ = 0;
         /// \brief temperature per cell.
@@ -35,7 +36,6 @@ namespace Opm
         /// \brief The fluxes at the faces.
         static const int faceFluxId_ = 1;
 
-    protected:
         /**
          * Initialize the first saturation to maximum value. This method
          * should be considered deprecated. Avoid to use it!

--- a/opm/core/simulator/SimulatorState.hpp
+++ b/opm/core/simulator/SimulatorState.hpp
@@ -77,6 +77,8 @@ namespace Opm
         const std::vector< std::vector<double> >& faceData() const { return faceData_; }
 
     private:
+        int num_cells_;
+        int num_faces_;
         int num_phases_;
 
         /// \brief vector containing all registered cell data

--- a/opm/core/simulator/SimulatorState.hpp
+++ b/opm/core/simulator/SimulatorState.hpp
@@ -1,4 +1,5 @@
 // Copyright (C) 2013 Uni Research AS
+// Copyright (C) 2015 IRIS AS
 // This file is licensed under the GNU General Public License v3.0
 
 #ifndef OPM_SIMULATORSTATE_HEADER_INCLUDED


### PR DESCRIPTION
This PR changes the implementation of the SimulatorState and BlackoilState such that all derived classes can add data via the registerCellData or registerFaceData. 

Application to simulator data such as I/O or communication can then be implemented on top of the SimulatorState class only. 

The current behavior of both classes should be as before.
