### PR TITLE
OPM-218: Write restart files at same interval as eclipse

### DIFF
--- a/opm/core/io/OutputWriter.cpp
+++ b/opm/core/io/OutputWriter.cpp
@@ -34,9 +34,10 @@ struct MultiWriter : public OutputWriter {
 
     virtual void writeTimeStep(const SimulatorTimerInterface& timer,
                                const SimulatorState& reservoirState,
-                               const WellState& wellState) {
+                               const WellState& wellState,
+                               bool  substep) {
         for (it_t it = writers_->begin (); it != writers_->end(); ++it) {
-            (*it)->writeTimeStep (timer, reservoirState, wellState);
+            (*it)->writeTimeStep (timer, reservoirState, wellState, substep);
         }
     }
 

--- a/opm/core/io/OutputWriter.hpp
+++ b/opm/core/io/OutputWriter.hpp
@@ -88,7 +88,8 @@ public:
      */
     virtual void writeTimeStep(const SimulatorTimerInterface& timer,
                                const SimulatorState& reservoirState,
-                               const WellState& wellState) = 0;
+                               const WellState& wellState,
+                               bool  substep = false) = 0;
 
     /*!
      * Create a suitable set of output formats based on configuration.

--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -1219,8 +1219,10 @@ void EclipseWriter::writeInit(const SimulatorTimerInterface &timer)
 // implementation of the writeTimeStep method
 void EclipseWriter::writeTimeStep(const SimulatorTimerInterface& timer,
                                   const SimulatorState& reservoirState,
-                                  const WellState& wellState)
+                                  const WellState& wellState,
+                                  bool  substep)
 {
+
     // if we don't want to write anything, this method becomes a
     // no-op...
     if (!enableOutput_) {
@@ -1258,7 +1260,7 @@ void EclipseWriter::writeTimeStep(const SimulatorTimerInterface& timer,
 
 
     // Write restart file
-    if(ioConfig->getWriteRestartFile(timer.reportStepNum()))
+    if(!substep && ioConfig->getWriteRestartFile(timer.reportStepNum()))
     {
         const size_t ncwmax                 = eclipseState_->getSchedule()->getMaxNumCompletionsForWells(timer.reportStepNum());
         const size_t numWells               = eclipseState_->getSchedule()->numWells(timer.reportStepNum());

--- a/opm/core/io/eclipse/EclipseWriter.hpp
+++ b/opm/core/io/eclipse/EclipseWriter.hpp
@@ -98,7 +98,7 @@ public:
      */
     virtual void writeTimeStep(const SimulatorTimerInterface& timer,
                                const SimulatorState& reservoirState,
-                               const WellState& wellState);
+                               const WellState& wellState, bool substep = false);
 
 
     static int eclipseWellTypeMask(WellType wellType, WellInjector::TypeEnum injectorType);

--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -180,7 +180,8 @@ namespace Opm {
 
                 // write data if outputWriter was provided
                 if( outputWriter ) {
-                    outputWriter->writeTimeStep( substepTimer, state, well_state );
+                    bool substep = true;
+                    outputWriter->writeTimeStep( substepTimer, state, well_state, substep);
                 }
 
                 // set new time step length


### PR DESCRIPTION
Added substep as a parameter to writeTimeStep to avoid writing adaptive timesteps for restart files.
Write of restart files does not fully support the writing of substeps, and for now leave out the writing of these to write correct restart files with the same dates as eclipse. 
When this PR is merged, PR for opm-218 for autodiff must also be merged