### PR TITLE
properly initialize the attributes of the SatHyst class

### DIFF
--- a/opm/core/props/satfunc/SatFuncBase.hpp
+++ b/opm/core/props/satfunc/SatFuncBase.hpp
@@ -65,6 +65,14 @@ namespace Opm
     
     // Hysteresis
     struct SatHyst {
+        SatHyst() {
+            sg_hyst = -1.0;
+            sow_hyst = -1.0;
+
+            sg_shift = 0.0;
+            sow_shift = 0.0;
+        }
+
         double sg_hyst;
         double sg_shift;
         double sow_hyst;


### PR DESCRIPTION
this caused the hysteresis saturation shifts to be initially wrong and
was probably the source of a lot of my confusion w.r.t. the saturation
scaling and hysteresis shift code. I guess this also fixes a valgrind
complaint, but I haven't checked...

I propose this PR as a precursor to #834 because it makes the comparison stuff easier because it fixes a bug in the current code.