### PR TITLE
Define the UF_long type if necessary.

### DIFF
--- a/opm/core/linalg/call_umfpack.c
+++ b/opm/core/linalg/call_umfpack.c
@@ -42,6 +42,11 @@
 #include <opm/core/linalg/sparse_sys.h>
 #include <opm/core/linalg/call_umfpack.h>
 
+/* To handle new versions of SuiteSparse. */
+#ifndef UF_long
+#define UF_long SuiteSparse_long
+#endif
+
 struct CSCMatrix {
     UF_long  n;
     UF_long  nnz;


### PR DESCRIPTION
The UF_long type is deprecated in UMFPack, and actually seems to be removed from the latest versions.

In the long term, we should switch to using SuiteSparse_long instead of UF_long, but that would increase the minimum version required to 4.0.0 (I think). The proposed solution defines a macro only in the .c file where it is used.