### PR TITLE
Reverse changes that should not have been merged into master

### DIFF
--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -1293,7 +1293,7 @@ void EclipseWriter::writeTimeStep(const SimulatorTimerInterface& timer,
 
         {
             ecl_rsthead_type rsthead_data = {};
-            rsthead_data.sim_time   = timer.startOfCurrentStepPosixTime();
+            rsthead_data.sim_time   = timer.currentPosixTime();
             rsthead_data.nactive    = numCells_;
             rsthead_data.nx         = cartesianSize_[0];
             rsthead_data.ny         = cartesianSize_[1];
@@ -1304,7 +1304,7 @@ void EclipseWriter::writeTimeStep(const SimulatorTimerInterface& timer,
             rsthead_data.niconz     = EclipseWriterDetails::Restart::NICONZ;
             rsthead_data.ncwmax     = ncwmax;
             rsthead_data.phase_sum  = Opm::EclipseWriterDetails::ertPhaseMask(phaseUsage_);
-            rsthead_data.sim_days   = Opm::unit::convert::to(timer.simulationStartTimeForCurrentReportStep(), Opm::unit::day); //data for doubhead
+            rsthead_data.sim_days   = Opm::unit::convert::to(timer.simulationTimeElapsed(), Opm::unit::day); //data for doubhead
 
             restartHandle.writeHeader(timer,
                                       timer.reportStepNum(),

--- a/opm/core/simulator/AdaptiveSimulatorTimer.cpp
+++ b/opm/core/simulator/AdaptiveSimulatorTimer.cpp
@@ -112,8 +112,6 @@ namespace Opm
 
     double AdaptiveSimulatorTimer::simulationTimeElapsed() const { return current_time_; }
 
-    double AdaptiveSimulatorTimer::simulationStartTimeForCurrentReportStep() const { return start_time_; }
-
     bool AdaptiveSimulatorTimer::done () const { return (current_time_ >= total_time_) ; }
 
     double AdaptiveSimulatorTimer::averageStepLength() const

--- a/opm/core/simulator/AdaptiveSimulatorTimer.hpp
+++ b/opm/core/simulator/AdaptiveSimulatorTimer.hpp
@@ -71,10 +71,6 @@ namespace Opm
         /// \brief \copydoc SimulationTimer::simulationTimeElapsed
         double simulationTimeElapsed() const;
 
-        /// \brief \copydoc SimulationTimer::simulationStartTimeForCurrentReportStep
-        double simulationStartTimeForCurrentReportStep() const;
-
-
         /// \brief \copydoc SimulationTimer::done
         bool done () const;
 

--- a/opm/core/simulator/SimulatorTimerInterface.hpp
+++ b/opm/core/simulator/SimulatorTimerInterface.hpp
@@ -75,11 +75,6 @@ namespace Opm
         /// beginning of the current time step [s].
         virtual double simulationTimeElapsed() const = 0;
 
-
-        /// Time elapsed since the start of the simulation until the
-        /// beginning of the current time step [s].
-        virtual double simulationStartTimeForCurrentReportStep() const { return simulationTimeElapsed(); }
-
         /// advance time by currentStepLength
         virtual void advance() = 0 ;
 
@@ -96,12 +91,6 @@ namespace Opm
                //boost::posix_time::ptime(startDate()) +  boost::posix_time::seconds( (int) simulationTimeElapsed());
         }
 
-        /// Return start time for current report step as a posix time object.
-        virtual boost::posix_time::ptime currentStepStartTime() const
-        {
-            return startDateTime() + boost::posix_time::seconds( (int) simulationStartTimeForCurrentReportStep());
-        }
-
         /// Time elapsed since the start of the POSIX epoch (Jan 1st,
         /// 1970) until the current time step begins [s].
         virtual time_t currentPosixTime() const
@@ -109,20 +98,6 @@ namespace Opm
             tm t = boost::posix_time::to_tm(currentDateTime());
             return std::mktime(&t);
         }
-
-        /// Time elapsed since the start of the POSIX epoch (Jan 1st,
-        /// 1970) until the current time step begins [s].
-        /// This method might give different results from currentPosixTime()
-        /// if timer contains supstepping.
-        /// Override method simulationStartTimeForCurrentReportStep() if timer
-        /// contains substeps and currentPosixTime() and startOfCurrentStepPosixTime()
-        /// can differ due to substepping
-        virtual time_t startOfCurrentStepPosixTime() const
-        {
-            tm t = boost::posix_time::to_tm(currentStepStartTime());
-            return std::mktime(&t);
-        }
-
     };
 
 


### PR DESCRIPTION
No need for to use new methods startOfCurrentStepPosixTime() / currentStepStartTime() / simmulationStartTimeForCurrentReportStep() when substep data are not written to restart file. Removing the method and use of it. 