### PR TITLE
Vertical flow performance tables

### DIFF
--- a/examples/compute_tof.cpp
+++ b/examples/compute_tof.cpp
@@ -59,7 +59,7 @@
 namespace
 {
     const static double alq_invalid = -std::numeric_limits<double>::max();
-    const static double vfp_invalid = -std::numeric_limits<int>::max();
+    const static int vfp_invalid = -std::numeric_limits<int>::max();
 
     void warnIfUnusedParams(const Opm::parameter::ParameterGroup& param)
     {

--- a/examples/compute_tof.cpp
+++ b/examples/compute_tof.cpp
@@ -90,7 +90,9 @@ namespace
             WellControls* ctrl = wells.ctrls[w];
             const double target = (wells.type[w] == INJECTOR) ? 200*Opm::unit::barsa : 100*Opm::unit::barsa;
             const double distr[3] = { 1.0, 0.0, 0.0 }; // Large enough irrespective of #phases.
-            well_controls_add_new(BHP, target, -1e100, -1e100, distr, ctrl);
+            well_controls_add_new(BHP, target,
+                    -std::numeric_limits<int>::max(), -std::numeric_limits<int>::max(),
+                    distr, ctrl);
             well_controls_set_current(ctrl, well_controls_get_num(ctrl) - 1);
         }
     }

--- a/examples/compute_tof.cpp
+++ b/examples/compute_tof.cpp
@@ -58,6 +58,9 @@
 
 namespace
 {
+    const static double alq_invalid = -std::numeric_limits<double>::max();
+    const static double vfp_invalid = -std::numeric_limits<int>::max();
+
     void warnIfUnusedParams(const Opm::parameter::ParameterGroup& param)
     {
         if (param.anyUnused()) {
@@ -91,7 +94,7 @@ namespace
             const double target = (wells.type[w] == INJECTOR) ? 200*Opm::unit::barsa : 100*Opm::unit::barsa;
             const double distr[3] = { 1.0, 0.0, 0.0 }; // Large enough irrespective of #phases.
             well_controls_add_new(BHP, target,
-                    -std::numeric_limits<int>::max(), -std::numeric_limits<int>::max(),
+                    alq_invalid, vfp_invalid,
                     distr, ctrl);
             well_controls_set_current(ctrl, well_controls_get_num(ctrl) - 1);
         }

--- a/examples/compute_tof.cpp
+++ b/examples/compute_tof.cpp
@@ -90,7 +90,7 @@ namespace
             WellControls* ctrl = wells.ctrls[w];
             const double target = (wells.type[w] == INJECTOR) ? 200*Opm::unit::barsa : 100*Opm::unit::barsa;
             const double distr[3] = { 1.0, 0.0, 0.0 }; // Large enough irrespective of #phases.
-            well_controls_add_new(BHP, target, distr, ctrl);
+            well_controls_add_new(BHP, target, -1e100, -1e100, distr, ctrl);
             well_controls_set_current(ctrl, well_controls_get_num(ctrl) - 1);
         }
     }

--- a/opm/core/pressure/tpfa/cfs_tpfa_residual.c
+++ b/opm/core/pressure/tpfa/cfs_tpfa_residual.c
@@ -876,6 +876,7 @@ assemble_completion_to_well(int i, int w, int c, int nc, int np,
     else {
         switch (well_controls_get_current_type(ctrl)) {
         case BHP :
+        case THP : // THP is implemented as a BHP target
             welleq_coeff_bhp(np, pw - well_controls_get_current_target( ctrl ),
                              h, &res, &w2c, &w2w);
             break;

--- a/opm/core/pressure/tpfa/ifs_tpfa.c
+++ b/opm/core/pressure/tpfa/ifs_tpfa.c
@@ -374,6 +374,7 @@ assemble_well_contrib(int                   nc ,
 
             switch (well_controls_get_current_type(ctrls)) {
             case BHP:
+            case THP : // THP is implemented as a BHP target
                 *all_rate = 0;
                 assemble_bhp_well (nc, w, W, mt, wdp, h);
                 break;

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -124,9 +124,9 @@ namespace Opm
                         //    pressure in first perforation cell.
                         switch (well_controls_get_current_type(ctrl)) {
                             case BHP:
+                                //Already taken care of above in 2.
                                 break;
                             case THP:
-                                //bhp_[w] = thp_[w]; //< TODO: ARB Adding this produces identical results as without THP control for artificial test case
                                 //Already taken care of above in 2.
                                 break;
 

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -67,14 +67,12 @@ namespace Opm
                                 bhp_[w] = well_controls_get_current_target( ctrl );
                                 break;
                             case THP:
-                                assert(false && "Not properly implemented");
                                 thp_[w] = well_controls_get_current_target( ctrl );
                                 break;
                             default:
                             {
                                 const int first_cell = wells->well_cells[wells->well_connpos[w]];
                                 bhp_[w] = state.pressure()[first_cell];
-                                thp_[w] = -1e100;
                             }
                         }
                     } else {

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -113,6 +113,8 @@ namespace Opm
                                 case THP:
                                     thp_[w] = well_controls_iget_target( ctrl , i );
                                     break;
+                                default:
+                                    break;
                             }
                         }
 

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -45,6 +45,7 @@ namespace Opm
                 const int nw = wells->number_of_wells;
                 const int np = wells->number_of_phases;
                 bhp_.resize(nw);
+                thp_.resize(nw);
                 temperature_.resize(nw, 273.15 + 20); // standard temperature for now
                 wellrates_.resize(nw * np, 0.0);
                 for (int w = 0; w < nw; ++w) {
@@ -59,11 +60,19 @@ namespace Opm
                         // 2. Assign bhp equal to bhp control, if
                         //    applicable, otherwise assign equal to
                         //    first perforation cell pressure.
-                        if (well_controls_get_current_type(ctrl) == BHP) {
-                            bhp_[w] = well_controls_get_current_target( ctrl );
-                        } else {
-                            const int first_cell = wells->well_cells[wells->well_connpos[w]];
-                            bhp_[w] = state.pressure()[first_cell];
+                        //    thp set to thp control
+                        switch (well_controls_get_current_type(ctrl)) {
+                            case BHP:
+                                bhp_[w] = well_controls_get_current_target( ctrl );
+                                break;
+                            case THP:
+                                thp_[w] = well_controls_get_current_target( ctrl );
+                                break;
+                            default:
+                            {
+                                const int first_cell = wells->well_cells[wells->well_connpos[w]];
+                                bhp_[w] = state.pressure()[first_cell];
+                            }
                         }
                     } else {
                         // Open well:
@@ -112,6 +121,10 @@ namespace Opm
         std::vector<double>& bhp() { return bhp_; }
         const std::vector<double>& bhp() const { return bhp_; }
 
+        /// One thp pressure per well.
+        std::vector<double>& thp() { return thp_; }
+        const std::vector<double>& thp() const { return thp_; }
+
         /// One temperature per well.
         std::vector<double>& temperature() { return temperature_; }
         const std::vector<double>& temperature() const { return temperature_; }
@@ -150,6 +163,7 @@ namespace Opm
 
     private:
         std::vector<double> bhp_;
+        std::vector<double> thp_;
         std::vector<double> temperature_;
         std::vector<double> wellrates_;
         std::vector<double> perfrates_;

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -67,7 +67,6 @@ namespace Opm
                                 bhp_[w] = well_controls_get_current_target( ctrl );
                                 break;
                             case THP:
-                                assert(false && "Not properly implemented");
                                 thp_[w] = well_controls_get_current_target( ctrl );
                                 break;
                             default:

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -67,6 +67,7 @@ namespace Opm
                                 bhp_[w] = well_controls_get_current_target( ctrl );
                                 break;
                             case THP:
+                                assert(false && "Not properly implemented");
                                 thp_[w] = well_controls_get_current_target( ctrl );
                                 break;
                             default:
@@ -123,13 +124,10 @@ namespace Opm
                         //    pressure in first perforation cell.
                         switch (well_controls_get_current_type(ctrl)) {
                             case BHP:
-                                bhp_[w] = well_controls_get_current_target( ctrl );
-                                thp_[w] = -1e100;
                                 break;
-
                             case THP:
-                                bhp_[w] = -1e100;
-                                thp_[w] = well_controls_get_current_target( ctrl );
+                                //bhp_[w] = thp_[w]; //< TODO: ARB Adding this produces identical results as without THP control for artificial test case
+                                //Already taken care of above in 2.
                                 break;
 
                             default:
@@ -137,7 +135,7 @@ namespace Opm
                                 const int first_cell = wells->well_cells[wells->well_connpos[w]];
                                 const double safety_factor = (wells->type[w] == INJECTOR) ? 1.01 : 0.99;
                                 bhp_[w] = safety_factor*state.pressure()[first_cell];
-                                thp_[w] = -1e100;
+                                // thp_[w] = -1e100;
                             }
                         }
                     }

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -57,22 +57,22 @@ namespace Opm
                         for (int p = 0; p < np; ++p) {
                             wellrates_[np*w + p] = 0.0;
                         }
-			// 2. Bhp: assign bhp equal to bhp control, if
-			//    applicable, otherwise assign equal to
-			//    first perforation cell pressure.
+                        // 2. Bhp: assign bhp equal to bhp control, if
+                        //    applicable, otherwise assign equal to
+                        //    first perforation cell pressure.
                         if (well_controls_get_current_type(ctrl) == BHP) {
                             bhp_[w] = well_controls_get_current_target( ctrl );
                         } else {
                             const int first_cell = wells->well_cells[wells->well_connpos[w]];
                             bhp_[w] = state.pressure()[first_cell];
-			}
-			// 3. Thp: assign thp equal to thp control, if applicable,
-			//    otherwise assign equal to bhp value.
+                        }
+                        // 3. Thp: assign thp equal to thp control, if applicable,
+                        //    otherwise assign equal to bhp value.
                         if (well_controls_get_current_type(ctrl) == THP) {
                             thp_[w] = well_controls_get_current_target( ctrl );
                         } else {
                             thp_[w] = bhp_[w];
-			}
+                        }
                     } else {
                         // Open well:
                         // 1. Rates: initialize well rates to match controls
@@ -97,26 +97,26 @@ namespace Opm
 
                         // 2. Bhp: initialize bhp to be target pressure if
                         //    bhp-controlled well, otherwise set to a
-			//    little above or below (depending on if
-			//    the well is an injector or producer)
-			//    pressure in first perforation cell.
-                        if (well_controls_get_current_type(ctrl) == BHP) {
-                            bhp_[w] = well_controls_get_current_target( ctrl );
-                        } else {
-                            const int first_cell = wells->well_cells[wells->well_connpos[w]];
-                            const double safety_factor = (wells->type[w] == INJECTOR) ? 1.01 : 0.99;
-                            bhp_[w] = safety_factor*state.pressure()[first_cell];
-			}
+                        //    little above or below (depending on if
+                        //    the well is an injector or producer)
+                        //    pressure in first perforation cell.
+                                    if (well_controls_get_current_type(ctrl) == BHP) {
+                                        bhp_[w] = well_controls_get_current_target( ctrl );
+                                    } else {
+                                        const int first_cell = wells->well_cells[wells->well_connpos[w]];
+                                        const double safety_factor = (wells->type[w] == INJECTOR) ? 1.01 : 0.99;
+                                        bhp_[w] = safety_factor*state.pressure()[first_cell];
+                        }
 
-			// 3. Thp: assign thp equal to thp control, if applicable,
-			//    otherwise assign equal to bhp value.
-                        if (well_controls_get_current_type(ctrl) == THP) {
-                            thp_[w] = well_controls_get_current_target( ctrl );
-                        } else {
-                            thp_[w] = bhp_[w];
-			}
-		    }
-		}
+                        // 3. Thp: assign thp equal to thp control, if applicable,
+                        //    otherwise assign equal to bhp value.
+                                    if (well_controls_get_current_type(ctrl) == THP) {
+                                        thp_[w] = well_controls_get_current_target( ctrl );
+                                    } else {
+                                        thp_[w] = bhp_[w];
+                        }
+                        }
+                }
 
                 // The perforation rates and perforation pressures are
                 // not expected to be consistent with bhp_ and wellrates_

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -73,6 +73,7 @@ namespace Opm
                             {
                                 const int first_cell = wells->well_cells[wells->well_connpos[w]];
                                 bhp_[w] = state.pressure()[first_cell];
+                                thp_[w] = -1e100;
                             }
                         }
                     } else {
@@ -122,10 +123,13 @@ namespace Opm
                         //    pressure in first perforation cell.
                         switch (well_controls_get_current_type(ctrl)) {
                             case BHP:
+                                bhp_[w] = well_controls_get_current_target( ctrl );
+                                thp_[w] = -1e100;
                                 break;
+
                             case THP:
-                                //bhp_[w] = thp_[w]; //< TODO: ARB Adding this produces identical results as without THP control for artificial test case
-                                //Already taken care of above in 2.
+                                bhp_[w] = -1e100;
+                                thp_[w] = well_controls_get_current_target( ctrl );
                                 break;
 
                             default:
@@ -133,7 +137,7 @@ namespace Opm
                                 const int first_cell = wells->well_cells[wells->well_connpos[w]];
                                 const double safety_factor = (wells->type[w] == INJECTOR) ? 1.01 : 0.99;
                                 bhp_[w] = safety_factor*state.pressure()[first_cell];
-                                // thp_[w] = -1e100;
+                                thp_[w] = -1e100;
                             }
                         }
                     }

--- a/opm/core/well_controls.h
+++ b/opm/core/well_controls.h
@@ -33,6 +33,7 @@ extern "C" {
 
 enum WellControlType  {
     BHP,              /**< Well constrained by BHP target */
+    THP,              /**< Well constrained by THP target */
     RESERVOIR_RATE,   /**< Well constrained by reservoir volume flow rate */
     SURFACE_RATE      /**< Well constrained by surface volume flow rate */
 };
@@ -82,7 +83,7 @@ void
 well_controls_stop_well( struct WellControls * ctrl);
 
 int
-well_controls_add_new(enum WellControlType type , double target , const double * distr , struct WellControls * ctrl);
+well_controls_add_new(enum WellControlType type , double target , double alq , int vfp , const double * distr , struct WellControls * ctrl);
 
 enum WellControlType 
 well_controls_iget_type(const struct WellControls * ctrl, int control_index);
@@ -98,6 +99,18 @@ well_controls_iset_target(struct WellControls * ctrl, int control_index , double
 
 double
 well_controls_iget_target(const struct WellControls * ctrl, int control_index);
+
+void
+well_controls_iset_alq(struct WellControls * ctrl, int control_index , double alq);
+
+double
+well_controls_iget_alq(const struct WellControls * ctrl, int control_index );
+
+void
+well_controls_iset_vfp(struct WellControls * ctrl, int control_index , int vfp);
+
+int
+well_controls_iget_vfp(const struct WellControls * ctrl, int control_index );
 
 double
 well_controls_get_current_target(const struct WellControls * ctrl);

--- a/opm/core/wells.h
+++ b/opm/core/wells.h
@@ -212,6 +212,8 @@ add_well(enum WellType  type     ,
  *
  * \param[in] type       Control type.
  * \param[in] target     Target value for the control.
+ * \param[in] alq        Artificial lift quantity for control (for THP type only)
+ * \param[in] vfp        VFP table number for control (for THP type only)
  * \param[in] distr      Array of size W->number_of_phases or NULL.
  * \param[in] well_index Index of well to receive additional control.
  * \param[in,out] W  Existing set of well controls.
@@ -222,6 +224,8 @@ add_well(enum WellType  type     ,
 int
 append_well_controls(enum WellControlType type  ,
                      double               target,
+                     double               alq,
+                     int                  vfp,
                      const double        *distr,
                      int                  well_index,
                      struct Wells        *W);

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -26,6 +26,12 @@
 #include <memory>
 #include <iostream>
 
+namespace
+{
+    static double invalid_alq = -1e100;
+    static double invalid_vfp = -2147483647;
+} //Namespace
+
 namespace Opm
 {
 
@@ -762,7 +768,7 @@ namespace Opm
             if (group_control_index_ < 0) {
                 // The well only had its own controls, no group controls.
                 append_well_controls(SURFACE_RATE, target,
-                        -std::numeric_limits<int>::max(), -std::numeric_limits<int>::max(),
+                        invalid_alq, invalid_vfp,
                         distr, self_index_, wells_);
                 group_control_index_ = well_controls_get_num(wells_->ctrls[self_index_]) - 1;
             } else {
@@ -819,7 +825,7 @@ namespace Opm
 
         if (group_control_index_ < 0) {
             // The well only had its own controls, no group controls.
-            append_well_controls(wct, target, -1e100, -1e100, distr, self_index_, wells_);
+            append_well_controls(wct, target, invalid_alq, invalid_vfp, distr, self_index_, wells_);
             group_control_index_ = well_controls_get_num(wells_->ctrls[self_index_]) - 1;
         } else {
             // We will now modify the last control, that
@@ -931,7 +937,7 @@ namespace Opm
 
         if (group_control_index_ < 0) {
             // The well only had its own controls, no group controls.
-            append_well_controls(wct, ntarget, -1e100, -1e100, distr, self_index_, wells_);
+            append_well_controls(wct, ntarget, invalid_alq, invalid_vfp, distr, self_index_, wells_);
             group_control_index_ = well_controls_get_num(wells_->ctrls[self_index_]) - 1;
         } else {
             // We will now modify the last control, that

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -761,7 +761,9 @@ namespace Opm
 
             if (group_control_index_ < 0) {
                 // The well only had its own controls, no group controls.
-                append_well_controls(SURFACE_RATE, target, -1e100, -1e100, distr, self_index_, wells_);
+                append_well_controls(SURFACE_RATE, target,
+                        -std::numeric_limits<int>::max(), -std::numeric_limits<int>::max(),
+                        distr, self_index_, wells_);
                 group_control_index_ = well_controls_get_num(wells_->ctrls[self_index_]) - 1;
             } else {
                 // We will now modify the last control, that

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -751,11 +751,12 @@ namespace Opm
         }
         else {
             const double target = 0.0;
+            const double alq = 0.0;
             const double distr[3] = {1.0, 1.0, 1.0};
 
             if (group_control_index_ < 0) {
                 // The well only had its own controls, no group controls.
-                append_well_controls(SURFACE_RATE, target, distr, self_index_, wells_);
+                append_well_controls(SURFACE_RATE, target, -1e100, -1e100, distr, self_index_, wells_);
                 group_control_index_ = well_controls_get_num(wells_->ctrls[self_index_]) - 1;
             } else {
                 // We will now modify the last control, that
@@ -763,6 +764,7 @@ namespace Opm
                 
                 well_controls_iset_type( wells_->ctrls[self_index_] , group_control_index_ , SURFACE_RATE);
                 well_controls_iset_target( wells_->ctrls[self_index_] , group_control_index_ , target);
+                well_controls_iset_alq( wells_->ctrls[self_index_] , group_control_index_ , alq);
                 well_controls_iset_distr(wells_->ctrls[self_index_] , group_control_index_ , distr);
             }
             well_controls_open_well( wells_->ctrls[self_index_]);
@@ -810,13 +812,14 @@ namespace Opm
 
         if (group_control_index_ < 0) {
             // The well only had its own controls, no group controls.
-            append_well_controls(wct, target, distr, self_index_, wells_);
+            append_well_controls(wct, target, -1e100, -1e100, distr, self_index_, wells_);
             group_control_index_ = well_controls_get_num(wells_->ctrls[self_index_]) - 1;
         } else {
             // We will now modify the last control, that
             // "belongs to" the group control.
             well_controls_iset_type(wells_->ctrls[self_index_] , group_control_index_ , wct);
             well_controls_iset_target(wells_->ctrls[self_index_] , group_control_index_ ,target);
+            well_controls_iset_alq(wells_->ctrls[self_index_] , group_control_index_ , -1e100);
             well_controls_iset_distr(wells_->ctrls[self_index_] , group_control_index_ , distr);
         }
         set_current_control(self_index_, group_control_index_, wells_);
@@ -921,13 +924,14 @@ namespace Opm
 
         if (group_control_index_ < 0) {
             // The well only had its own controls, no group controls.
-            append_well_controls(wct, ntarget, distr, self_index_, wells_);
+            append_well_controls(wct, ntarget, -1e100, -1e100, distr, self_index_, wells_);
             group_control_index_ = well_controls_get_num(wells_->ctrls[self_index_]) - 1;
         } else {
             // We will now modify the last control, that
             // "belongs to" the group control.
             well_controls_iset_type(wells_->ctrls[self_index_] , group_control_index_ , wct);
             well_controls_iset_target(wells_->ctrls[self_index_] , group_control_index_ , ntarget);
+            well_controls_iset_alq(wells_->ctrls[self_index_] , group_control_index_ , -1e100);
             well_controls_iset_distr(wells_->ctrls[self_index_] , group_control_index_ , distr);
         }
         set_current_control(self_index_, group_control_index_, wells_);

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -678,6 +678,11 @@ namespace Opm
                 break;
             }
 
+            case THP: {
+                //TODO: Implement support
+                OPM_THROW(std::invalid_argument, "THP not implemented in WellNode::conditionsMet.");
+            }
+
             case RESERVOIR_RATE: {
                 double my_rate = 0.0;
                 const double * ctrls_distr = well_controls_iget_distr( ctrls , ctrl_index );

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -483,7 +483,6 @@ namespace Opm
 
                 if (ok && injectionProperties.hasInjectionControl(WellInjector::BHP)) {
                     control_pos[WellsManagerDetail::InjectionControl::BHP] = well_controls_get_num(w_->ctrls[well_index]);
-                    control_pos[WellsManagerDetail::InjectionControl::BHP] = well_controls_get_num(w_->ctrls[well_index]); //Fixme: duplicate, a nop-bug?
                     ok = append_well_controls(BHP,
                                               injectionProperties.BHPLimit,
                                               -std::numeric_limits<int>::max(),

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -452,6 +452,8 @@ namespace Opm
 
                     ok = append_well_controls(SURFACE_RATE,
                                               injectionProperties.surfaceInjectionRate, 
+                                              -1e100,
+                                              -1e100,
                                               distr,
                                               well_index,
                                               w_);
@@ -472,6 +474,8 @@ namespace Opm
 
                     ok = append_well_controls(RESERVOIR_RATE,
                                               injectionProperties.reservoirInjectionRate, 
+                                              -1e100,
+                                              -1e100,
                                               distr,
                                               well_index,
                                               w_);
@@ -481,14 +485,16 @@ namespace Opm
                     control_pos[WellsManagerDetail::InjectionControl::BHP] = well_controls_get_num(w_->ctrls[well_index]);
                     control_pos[WellsManagerDetail::InjectionControl::BHP] = well_controls_get_num(w_->ctrls[well_index]);
                     ok = append_well_controls(BHP,
-                                              injectionProperties.BHPLimit, 
+                                              injectionProperties.BHPLimit,
+                                              -1e100,
+                                              -1e100,
                                               NULL,
                                               well_index,
                                               w_);
                 }
 
                 if (ok && injectionProperties.hasInjectionControl(WellInjector::THP)) {
-                    OPM_THROW(std::runtime_error, "We cannot handle THP limit for well " << well_names[well_index]);
+                    OPM_THROW(std::runtime_error, "We cannot handle THP limit for injecting well " << well_names[well_index]);
                 }
 
                 if (!ok) {
@@ -548,7 +554,9 @@ namespace Opm
                     double distr[3] = { 0.0, 0.0, 0.0 };
                     distr[phaseUsage.phase_pos[BlackoilPhases::Liquid]] = 1.0;
                     ok = append_well_controls(SURFACE_RATE,
-                                              -productionProperties.OilRate, 
+                                              -productionProperties.OilRate,
+                                              -1e100,
+                                              -1e100,
                                               distr,
                                                well_index,
                                               w_);
@@ -563,6 +571,8 @@ namespace Opm
                     distr[phaseUsage.phase_pos[BlackoilPhases::Aqua]] = 1.0;
                     ok = append_well_controls(SURFACE_RATE,
                                               -productionProperties.WaterRate, 
+                                              -1e100,
+                                              -1e100,
                                               distr,
                                               well_index,
                                               w_);
@@ -577,6 +587,8 @@ namespace Opm
                     distr[phaseUsage.phase_pos[BlackoilPhases::Vapour]] = 1.0;
                     ok = append_well_controls(SURFACE_RATE,
                                               -productionProperties.GasRate,
+                                              -1e100,
+                                              -1e100,
                                               distr,
                                               well_index,
                                               w_);
@@ -595,6 +607,8 @@ namespace Opm
                     distr[phaseUsage.phase_pos[BlackoilPhases::Liquid]] = 1.0;
                     ok = append_well_controls(SURFACE_RATE,
                                               -productionProperties.LiquidRate , 
+                                              -1e100,
+                                              -1e100,
                                               distr,
                                               well_index,
                                               w_);
@@ -605,7 +619,27 @@ namespace Opm
                     double distr[3] = { 1.0, 1.0, 1.0 };
                     ok = append_well_controls(RESERVOIR_RATE,
                                               -productionProperties.ResVRate , 
+                                              -1e100,
+                                              -1e100,
                                               distr,
+                                              well_index,
+                                              w_);
+                }
+
+                if (ok && productionProperties.hasProductionControl(WellProducer::THP)) {
+                    const bool has_explicit_limit = productionProperties.hasProductionControl(WellProducer::THP);
+                    if (!has_explicit_limit) {
+                        OPM_THROW(std::runtime_error, "THP specified, but no target THP supplied for well " << well_names[well_index]);
+                    }
+                    const double thp_limit  = productionProperties.THPLimit;
+                    const double alq_value  = productionProperties.ALQValue;
+                    const int    vfp_number = productionProperties.VFPTableNumber;
+                    control_pos[WellsManagerDetail::ProductionControl::THP] = well_controls_get_num(w_->ctrls[well_index]);
+                    ok = append_well_controls(THP,
+                                              thp_limit,
+                                              alq_value,
+                                              vfp_number,
+                                              NULL,
                                               well_index,
                                               w_);
                 }
@@ -618,13 +652,11 @@ namespace Opm
                     control_pos[WellsManagerDetail::ProductionControl::BHP] = well_controls_get_num(w_->ctrls[well_index]);
                     ok = append_well_controls(BHP,
                                               bhp_limit,
+                                              -1e100,
+                                              -1e100,
                                               NULL,
                                               well_index,
                                               w_);
-                }
-
-                if (ok && productionProperties.hasProductionControl(WellProducer::THP)) {
-                    OPM_THROW(std::runtime_error, "We cannot handle THP limit for well " << well_names[well_index]);
                 }
 
                 if (!ok) {

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -493,9 +493,9 @@ namespace Opm
                 }
 
                 if (ok && injectionProperties.hasInjectionControl(WellInjector::THP)) {
+                    control_pos[WellsManagerDetail::InjectionControl::THP] = well_controls_get_num(w_->ctrls[well_index]);
                     const double thp_limit  = injectionProperties.THPLimit;
                     const int    vfp_number = injectionProperties.VFPTableNumber;
-                    control_pos[WellsManagerDetail::ProductionControl::THP] = well_controls_get_num(w_->ctrls[well_index]);
                     ok = append_well_controls(THP,
                                               thp_limit,
                                               -std::numeric_limits<int>::max(),

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -39,6 +39,11 @@
 #include <utility>
 #include <iostream>
 
+namespace
+{
+    static double invalid_alq = -1e100;
+    static double invalid_vfp = -2147483647;
+} //Namespace
 
 // Helper structs and functions for the implementation.
 namespace WellsManagerDetail
@@ -452,8 +457,8 @@ namespace Opm
 
                     ok = append_well_controls(SURFACE_RATE,
                                               injectionProperties.surfaceInjectionRate, 
-                                              -std::numeric_limits<int>::max(),
-                                              -std::numeric_limits<int>::max(),
+                                              invalid_alq,
+                                              invalid_vfp,
                                               distr,
                                               well_index,
                                               w_);
@@ -474,8 +479,8 @@ namespace Opm
 
                     ok = append_well_controls(RESERVOIR_RATE,
                                               injectionProperties.reservoirInjectionRate, 
-                                              -std::numeric_limits<int>::max(),
-                                              -std::numeric_limits<int>::max(),
+                                              invalid_alq,
+                                              invalid_vfp,
                                               distr,
                                               well_index,
                                               w_);
@@ -485,8 +490,8 @@ namespace Opm
                     control_pos[WellsManagerDetail::InjectionControl::BHP] = well_controls_get_num(w_->ctrls[well_index]);
                     ok = append_well_controls(BHP,
                                               injectionProperties.BHPLimit,
-                                              -std::numeric_limits<int>::max(),
-                                              -std::numeric_limits<int>::max(),
+                                              invalid_alq,
+                                              invalid_vfp,
                                               NULL,
                                               well_index,
                                               w_);
@@ -498,7 +503,7 @@ namespace Opm
                     const int    vfp_number = injectionProperties.VFPTableNumber;
                     ok = append_well_controls(THP,
                                               thp_limit,
-                                              -std::numeric_limits<int>::max(),
+                                              invalid_alq,
                                               vfp_number,
                                               NULL,
                                               well_index,
@@ -563,10 +568,10 @@ namespace Opm
                     distr[phaseUsage.phase_pos[BlackoilPhases::Liquid]] = 1.0;
                     ok = append_well_controls(SURFACE_RATE,
                                               -productionProperties.OilRate,
-                                              -std::numeric_limits<int>::max(),
-                                              -std::numeric_limits<int>::max(),
+                                              invalid_alq,
+                                              invalid_vfp,
                                               distr,
-                                               well_index,
+                                              well_index,
                                               w_);
                 }
 
@@ -579,8 +584,8 @@ namespace Opm
                     distr[phaseUsage.phase_pos[BlackoilPhases::Aqua]] = 1.0;
                     ok = append_well_controls(SURFACE_RATE,
                                               -productionProperties.WaterRate, 
-                                              -std::numeric_limits<int>::max(),
-                                              -std::numeric_limits<int>::max(),
+                                              invalid_alq,
+                                              invalid_vfp,
                                               distr,
                                               well_index,
                                               w_);
@@ -595,8 +600,8 @@ namespace Opm
                     distr[phaseUsage.phase_pos[BlackoilPhases::Vapour]] = 1.0;
                     ok = append_well_controls(SURFACE_RATE,
                                               -productionProperties.GasRate,
-                                              -std::numeric_limits<int>::max(),
-                                              -std::numeric_limits<int>::max(),
+                                              invalid_alq,
+                                              invalid_vfp,
                                               distr,
                                               well_index,
                                               w_);
@@ -614,9 +619,9 @@ namespace Opm
                     distr[phaseUsage.phase_pos[BlackoilPhases::Aqua]] = 1.0;
                     distr[phaseUsage.phase_pos[BlackoilPhases::Liquid]] = 1.0;
                     ok = append_well_controls(SURFACE_RATE,
-                                              -productionProperties.LiquidRate , 
-                                              -std::numeric_limits<int>::max(),
-                                              -std::numeric_limits<int>::max(),
+                                              -productionProperties.LiquidRate,
+                                              invalid_alq,
+                                              invalid_vfp,
                                               distr,
                                               well_index,
                                               w_);
@@ -626,9 +631,9 @@ namespace Opm
                     control_pos[WellsManagerDetail::ProductionControl::RESV] = well_controls_get_num(w_->ctrls[well_index]);
                     double distr[3] = { 1.0, 1.0, 1.0 };
                     ok = append_well_controls(RESERVOIR_RATE,
-                                              -productionProperties.ResVRate , 
-                                              -std::numeric_limits<int>::max(),
-                                              -std::numeric_limits<int>::max(),
+                                              -productionProperties.ResVRate,
+                                              invalid_alq,
+                                              invalid_vfp,
                                               distr,
                                               well_index,
                                               w_);
@@ -656,8 +661,8 @@ namespace Opm
                     control_pos[WellsManagerDetail::ProductionControl::BHP] = well_controls_get_num(w_->ctrls[well_index]);
                     ok = append_well_controls(BHP,
                                               bhp_limit,
-                                              -std::numeric_limits<int>::max(),
-                                              -std::numeric_limits<int>::max(),
+                                              invalid_alq,
+                                              invalid_vfp,
                                               NULL,
                                               well_index,
                                               w_);

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -452,8 +452,8 @@ namespace Opm
 
                     ok = append_well_controls(SURFACE_RATE,
                                               injectionProperties.surfaceInjectionRate, 
-                                              -1e100,
-                                              -1e100,
+                                              -std::numeric_limits<int>::max(),
+                                              -std::numeric_limits<int>::max(),
                                               distr,
                                               well_index,
                                               w_);
@@ -474,8 +474,8 @@ namespace Opm
 
                     ok = append_well_controls(RESERVOIR_RATE,
                                               injectionProperties.reservoirInjectionRate, 
-                                              -1e100,
-                                              -1e100,
+                                              -std::numeric_limits<int>::max(),
+                                              -std::numeric_limits<int>::max(),
                                               distr,
                                               well_index,
                                               w_);
@@ -483,18 +483,27 @@ namespace Opm
 
                 if (ok && injectionProperties.hasInjectionControl(WellInjector::BHP)) {
                     control_pos[WellsManagerDetail::InjectionControl::BHP] = well_controls_get_num(w_->ctrls[well_index]);
-                    control_pos[WellsManagerDetail::InjectionControl::BHP] = well_controls_get_num(w_->ctrls[well_index]);
+                    control_pos[WellsManagerDetail::InjectionControl::BHP] = well_controls_get_num(w_->ctrls[well_index]); //Fixme: duplicate, a nop-bug?
                     ok = append_well_controls(BHP,
                                               injectionProperties.BHPLimit,
-                                              -1e100,
-                                              -1e100,
+                                              -std::numeric_limits<int>::max(),
+                                              -std::numeric_limits<int>::max(),
                                               NULL,
                                               well_index,
                                               w_);
                 }
 
                 if (ok && injectionProperties.hasInjectionControl(WellInjector::THP)) {
-                    OPM_THROW(std::runtime_error, "We cannot handle THP limit for injecting well " << well_names[well_index]);
+                    const double thp_limit  = injectionProperties.THPLimit;
+                    const int    vfp_number = injectionProperties.VFPTableNumber;
+                    control_pos[WellsManagerDetail::ProductionControl::THP] = well_controls_get_num(w_->ctrls[well_index]);
+                    ok = append_well_controls(THP,
+                                              thp_limit,
+                                              -std::numeric_limits<int>::max(),
+                                              vfp_number,
+                                              NULL,
+                                              well_index,
+                                              w_);
                 }
 
                 if (!ok) {
@@ -555,8 +564,8 @@ namespace Opm
                     distr[phaseUsage.phase_pos[BlackoilPhases::Liquid]] = 1.0;
                     ok = append_well_controls(SURFACE_RATE,
                                               -productionProperties.OilRate,
-                                              -1e100,
-                                              -1e100,
+                                              -std::numeric_limits<int>::max(),
+                                              -std::numeric_limits<int>::max(),
                                               distr,
                                                well_index,
                                               w_);
@@ -571,8 +580,8 @@ namespace Opm
                     distr[phaseUsage.phase_pos[BlackoilPhases::Aqua]] = 1.0;
                     ok = append_well_controls(SURFACE_RATE,
                                               -productionProperties.WaterRate, 
-                                              -1e100,
-                                              -1e100,
+                                              -std::numeric_limits<int>::max(),
+                                              -std::numeric_limits<int>::max(),
                                               distr,
                                               well_index,
                                               w_);
@@ -587,8 +596,8 @@ namespace Opm
                     distr[phaseUsage.phase_pos[BlackoilPhases::Vapour]] = 1.0;
                     ok = append_well_controls(SURFACE_RATE,
                                               -productionProperties.GasRate,
-                                              -1e100,
-                                              -1e100,
+                                              -std::numeric_limits<int>::max(),
+                                              -std::numeric_limits<int>::max(),
                                               distr,
                                               well_index,
                                               w_);
@@ -607,8 +616,8 @@ namespace Opm
                     distr[phaseUsage.phase_pos[BlackoilPhases::Liquid]] = 1.0;
                     ok = append_well_controls(SURFACE_RATE,
                                               -productionProperties.LiquidRate , 
-                                              -1e100,
-                                              -1e100,
+                                              -std::numeric_limits<int>::max(),
+                                              -std::numeric_limits<int>::max(),
                                               distr,
                                               well_index,
                                               w_);
@@ -619,18 +628,14 @@ namespace Opm
                     double distr[3] = { 1.0, 1.0, 1.0 };
                     ok = append_well_controls(RESERVOIR_RATE,
                                               -productionProperties.ResVRate , 
-                                              -1e100,
-                                              -1e100,
+                                              -std::numeric_limits<int>::max(),
+                                              -std::numeric_limits<int>::max(),
                                               distr,
                                               well_index,
                                               w_);
                 }
 
                 if (ok && productionProperties.hasProductionControl(WellProducer::THP)) {
-                    const bool has_explicit_limit = productionProperties.hasProductionControl(WellProducer::THP);
-                    if (!has_explicit_limit) {
-                        OPM_THROW(std::runtime_error, "THP specified, but no target THP supplied for well " << well_names[well_index]);
-                    }
                     const double thp_limit  = productionProperties.THPLimit;
                     const double alq_value  = productionProperties.ALQValue;
                     const int    vfp_number = productionProperties.VFPTableNumber;
@@ -652,8 +657,8 @@ namespace Opm
                     control_pos[WellsManagerDetail::ProductionControl::BHP] = well_controls_get_num(w_->ctrls[well_index]);
                     ok = append_well_controls(BHP,
                                               bhp_limit,
-                                              -1e100,
-                                              -1e100,
+                                              -std::numeric_limits<int>::max(),
+                                              -std::numeric_limits<int>::max(),
                                               NULL,
                                               well_index,
                                               w_);

--- a/opm/core/wells/wells.c
+++ b/opm/core/wells/wells.c
@@ -422,6 +422,8 @@ add_well(enum WellType  type     ,
 int
 append_well_controls(enum WellControlType type,
                      double               target,
+                     double               alq,
+                     int                  vfp,
                      const double        *distr,
                      int                  well_index,
                      struct Wells        *W)
@@ -436,7 +438,7 @@ append_well_controls(enum WellControlType type,
     assert (ctrl != NULL);
     
     well_controls_assert_number_of_phases( ctrl , W->number_of_phases);
-    return well_controls_add_new(type , target , distr , ctrl);
+    return well_controls_add_new(type , target , alq , vfp , distr , ctrl);
 }
 
 

--- a/tests/test_wellcontrols.cpp
+++ b/tests/test_wellcontrols.cpp
@@ -90,9 +90,9 @@ BOOST_AUTO_TEST_CASE(Construction)
     well_controls_iset_alq( ctrls , 1 , 234);
     BOOST_CHECK_EQUAL( 234 , well_controls_iget_alq( ctrls , 1 ));
 
-    well_controls_iset_alq( ctrls , 0 , 567);
+    well_controls_iset_vfp( ctrls , 0 , 567);
     BOOST_CHECK_EQUAL( 567 , well_controls_iget_vfp( ctrls , 0 ));
-    well_controls_iset_alq( ctrls , 1 , 890);
+    well_controls_iset_vfp( ctrls , 1 , 890);
     BOOST_CHECK_EQUAL( 890 , well_controls_iget_vfp( ctrls , 1 ));
 
     well_controls_iset_type( ctrls , 0 , SURFACE_RATE);

--- a/tests/test_wellcontrols.cpp
+++ b/tests/test_wellcontrols.cpp
@@ -52,15 +52,21 @@ BOOST_AUTO_TEST_CASE(Construction)
         double dist1[3] = {0 , 1  ,  2};
         double dist2[3] = {10, 11 , 12};
         double target = 77;
+        double alq = 88;
+        int vfp = 42;
 
         well_controls_assert_number_of_phases( ctrls , num_phases );
-        well_controls_add_new( type1 ,   target , dist1 , ctrls );
-        well_controls_add_new( type2 , 2*target , dist2 , ctrls );
+        well_controls_add_new( type1 ,   target ,   alq ,   vfp , dist1 , ctrls );
+        well_controls_add_new( type2 , 2*target , 2*alq , 2*vfp , dist2 , ctrls );
 
         BOOST_CHECK_EQUAL( target , well_controls_iget_target(ctrls , 0 ));
+        BOOST_CHECK_EQUAL( alq , well_controls_iget_alq(ctrls , 0 ));
+        BOOST_CHECK_EQUAL( vfp , well_controls_iget_vfp(ctrls , 0 ));
         BOOST_CHECK_EQUAL( type1 , well_controls_iget_type(ctrls , 0 ));
 
         BOOST_CHECK_EQUAL( 2*target , well_controls_iget_target(ctrls , 1 ));
+        BOOST_CHECK_EQUAL( 2*alq , well_controls_iget_alq(ctrls , 1 ));
+        BOOST_CHECK_EQUAL( 2*vfp , well_controls_iget_vfp(ctrls , 1 ));
         BOOST_CHECK_EQUAL( type2 , well_controls_iget_type(ctrls , 1 ));
         well_controls_set_current( ctrls , 1 );
         BOOST_CHECK_EQUAL( type2 , well_controls_get_current_type( ctrls ));
@@ -78,6 +84,16 @@ BOOST_AUTO_TEST_CASE(Construction)
     BOOST_CHECK_EQUAL( 123 , well_controls_iget_target( ctrls , 0 ));
     well_controls_iset_target( ctrls , 1 , 456);
     BOOST_CHECK_EQUAL( 456 , well_controls_iget_target( ctrls , 1 ));
+
+    well_controls_iset_alq( ctrls , 0 , 789);
+    BOOST_CHECK_EQUAL( 789 , well_controls_iget_alq( ctrls , 0 ));
+    well_controls_iset_alq( ctrls , 1 , 234);
+    BOOST_CHECK_EQUAL( 234 , well_controls_iget_alq( ctrls , 1 ));
+
+    well_controls_iset_alq( ctrls , 0 , 567);
+    BOOST_CHECK_EQUAL( 567 , well_controls_iget_vfp( ctrls , 0 ));
+    well_controls_iset_alq( ctrls , 1 , 890);
+    BOOST_CHECK_EQUAL( 890 , well_controls_iget_vfp( ctrls , 1 ));
 
     well_controls_iset_type( ctrls , 0 , SURFACE_RATE);
     BOOST_CHECK_EQUAL( SURFACE_RATE , well_controls_iget_type( ctrls , 0 ));
@@ -130,10 +146,12 @@ BOOST_AUTO_TEST_CASE(Clone)
     const double dist1[] = { 0,  1,  2};
     const double dist2[] = {10, 11, 12};
     const double target  = 77;
+    const double alq     = 88;
+    const int vfp        = 42;
 
     well_controls_assert_number_of_phases(ctrls.get(), num_phases);
-    well_controls_add_new(type1,   target, dist1, ctrls.get());
-    well_controls_add_new(type2, 2*target, dist2, ctrls.get());
+    well_controls_add_new(type1,   target,   alq,   vfp, dist1, ctrls.get());
+    well_controls_add_new(type2, 2*target, 2*alq, 2*vfp, dist2, ctrls.get());
 
     std::shared_ptr<WellControls>
         c(well_controls_clone(ctrls.get()),

--- a/tests/test_wells.cpp
+++ b/tests/test_wells.cpp
@@ -97,10 +97,14 @@ BOOST_AUTO_TEST_CASE(Controls)
 
         if (ok) {
             const double distr[] = { 1.0, 0.0 };
-            const bool   ok1     = append_well_controls(BHP, 1, &distr[0],
+            const bool   ok1     = append_well_controls(BHP, 1,
+                                                        -1e100, -1e100,
+                                                        &distr[0],
                                                         0, W.get());
             const bool   ok2     = append_well_controls(SURFACE_RATE, 1,
-                                                        &distr[0], 0, W.get());
+                                                        -1e100, -1e100,
+                                                        &distr[0],
+                                                        0, W.get());
 
             if (ok1 && ok2) {
                 WellControls* ctrls = W->ctrls[0];
@@ -150,9 +154,12 @@ BOOST_AUTO_TEST_CASE(Copy)
         bool ok = ok0 && ok1;
         for (int w = 0; ok && (w < W1->number_of_wells); ++w) {
             const double distr[] = { 1.0, 0.0 };
-            const bool   okc1     = append_well_controls(BHP, 1, &distr[0],
-                                                         w, W1.get());
+            const bool   okc1     = append_well_controls(BHP, 1,
+                                                         -1e100, -1e100,
+                                                         &distr[0], w,
+                                                         W1.get());
             const bool   okc2     = append_well_controls(SURFACE_RATE, 1,
+                                                         -1e100, -1e100,
                                                          &distr[0], w,
                                                          W1.get());
 

--- a/tests/test_wells.cpp
+++ b/tests/test_wells.cpp
@@ -35,6 +35,12 @@
 #include <vector>
 #include <memory>
 
+namespace
+{
+    static double invalid_alq = -1e100;
+    static double invalid_vfp = -2147483647;
+} //Namespace
+
 BOOST_AUTO_TEST_CASE(Construction)
 {
     const int nphases = 2;
@@ -98,11 +104,11 @@ BOOST_AUTO_TEST_CASE(Controls)
         if (ok) {
             const double distr[] = { 1.0, 0.0 };
             const bool   ok1     = append_well_controls(BHP, 1,
-                                                        -1e100, -1e100,
+                                                        invalid_alq, invalid_vfp,
                                                         &distr[0],
                                                         0, W.get());
             const bool   ok2     = append_well_controls(SURFACE_RATE, 1,
-                                                        -1e100, -1e100,
+                                                        invalid_alq, invalid_vfp,
                                                         &distr[0],
                                                         0, W.get());
 
@@ -155,11 +161,11 @@ BOOST_AUTO_TEST_CASE(Copy)
         for (int w = 0; ok && (w < W1->number_of_wells); ++w) {
             const double distr[] = { 1.0, 0.0 };
             const bool   okc1     = append_well_controls(BHP, 1,
-                                                         -1e100, -1e100,
+                                                         invalid_alq, invalid_vfp,
                                                          &distr[0], w,
                                                          W1.get());
             const bool   okc2     = append_well_controls(SURFACE_RATE, 1,
-                                                         -1e100, -1e100,
+                                                         invalid_alq, invalid_vfp,
                                                          &distr[0], w,
                                                          W1.get());
 


### PR DESCRIPTION
This sets up for using vertical flow performace tables for production and injection wells (i.e., tubing head pressure control). 

Most of the actual VFP code resides in opm-autodiff, but this should compile and run without merging that first.