### PR TITLE
Fix abs bug and warnings

### DIFF
--- a/opm/core/flowdiagnostics/AnisotropicEikonal.hpp
+++ b/opm/core/flowdiagnostics/AnisotropicEikonal.hpp
@@ -25,6 +25,8 @@
 #include <set>
 #include <map>
 
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
+
 #include <boost/version.hpp>
 
 #define BOOST_HEAP_AVAILABLE ((BOOST_VERSION / 100 % 1000) >= 49)
@@ -32,6 +34,9 @@
 #if BOOST_HEAP_AVAILABLE
 #include <boost/heap/fibonacci_heap.hpp>
 #endif
+
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+
 
 struct UnstructuredGrid;
 

--- a/opm/core/grid/GridUtilities.cpp
+++ b/opm/core/grid/GridUtilities.cpp
@@ -19,7 +19,11 @@
 
 #include <opm/core/grid/GridUtilities.hpp>
 #include <opm/core/grid/GridHelpers.hpp>
+
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
 #include <boost/math/constants/constants.hpp>
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+
 #include <set>
 #include <vector>
 #include <cmath>

--- a/opm/core/grid/grid.c
+++ b/opm/core/grid/grid.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
 
 
 void
@@ -550,14 +551,15 @@ static int memcmp_double(const double * p1 , const double *p2 , size_t num_eleme
     if (memcmp(p1 , p2 , num_elements * sizeof * p1) == 0)
         return 0;
     else {
-        const double epsilon = 1e-5;
+        const double abs_epsilon = 1e-8;
+        const double rel_epsilon = 1e-5;
 
         for (size_t index = 0; index < num_elements; index++) {
-            double diff = abs(p1[index] - p2[index]);
-            if (diff != 0) {
-                double sum = abs(p1[index]) + abs(p2[index]);
+            double diff = fabs(p1[index] - p2[index]);
+            if (diff > abs_epsilon) {
+                double sum = fabs(p1[index]) + fabs(p2[index]);
                 
-                if (diff > sum * epsilon)
+                if (diff > sum * rel_epsilon)
                     return 1;
             }
         }

--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -28,9 +28,9 @@
 #include <exception>
 
 #if HAVE_MPI && HAVE_DUNE_ISTL
-#include <mpi.h>
 
 #include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <mpi.h>
 #include <dune/istl/owneroverlapcopy.hh>
 #include <dune/common/parallel/interface.hh>
 #include <dune/common/parallel/communicator.hh>

--- a/tests/DuneIstlTestHelpers.hpp
+++ b/tests/DuneIstlTestHelpers.hpp
@@ -19,14 +19,15 @@
 */
 #ifndef OPM_DUNEISTLTESTHELPERS_HEADER
 #define OPM_DUNEISTLTESTHELPERS_HEADER
+
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
+
 // MPI header
 #if HAVE_MPI
 #include <mpi.h>
 #else
 #error "This file needs to compiled with MPI support!"
 #endif
-
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)

--- a/tests/test_anisotropiceikonal.cpp
+++ b/tests/test_anisotropiceikonal.cpp
@@ -25,7 +25,10 @@
 #define NVERBOSE // to suppress our messages when throwing
 
 #define BOOST_TEST_MODULE AnisotropicEikonalTest
+
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/core/flowdiagnostics/AnisotropicEikonal.hpp>
 #include <opm/core/grid/GridManager.hpp>

--- a/tests/test_parallel_linearsolver.cpp
+++ b/tests/test_parallel_linearsolver.cpp
@@ -29,9 +29,7 @@
 
 // MPI header
 #if HAVE_MPI
-#include <mpi.h>
 #include <dune/common/version.hh>
-
 #include <opm/core/linalg/ParallelIstlInformation.hpp>
 #else
 #error "This file needs to compiled with MPI support!"

--- a/tests/test_parallelistlinformation.cpp
+++ b/tests/test_parallelistlinformation.cpp
@@ -28,11 +28,6 @@
 
 #define BOOST_TEST_MODULE OPM-ParallelIstlInformation
 #include <boost/test/unit_test.hpp>
-#if HAVE_MPI
-#include <mpi.h>
-#else
-#error "This file needs to compiled with MPI support!"
-#endif
 #include "DuneIstlTestHelpers.hpp"
 #include <opm/core/linalg/ParallelIstlInformation.hpp>
 #include <functional>

--- a/tests/test_regionmapping.cpp
+++ b/tests/test_regionmapping.cpp
@@ -27,8 +27,11 @@
 #define NVERBOSE  // Suppress own messages when throw()ing
 
 #define BOOST_TEST_MODULE UnitsTest
+
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/floating_point_comparison.hpp>
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
 
 /* --- our own headers --- */
 

--- a/tests/test_shadow.cpp
+++ b/tests/test_shadow.cpp
@@ -8,7 +8,9 @@
 #define NVERBOSE // to suppress our messages when throwing
 
 #define BOOST_TEST_MODULE ShadowTest
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/core/props/IncompPropertiesBasic.hpp>

--- a/tests/test_sparsetable.cpp
+++ b/tests/test_sparsetable.cpp
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(construction_and_queries)
     BOOST_CHECK_EQUAL(st2.rowSize(1), 0);
     BOOST_CHECK_EQUAL(st2[3][1], 4);
     BOOST_CHECK_EQUAL(st2[4][2], 9);
-    BOOST_CHECK(st2[4].size() == rowsizes[4]);
+    BOOST_CHECK(int(st2[4].size()) == rowsizes[4]);
     const SparseTable<int> st2_again(elem, elem + num_elem, rowsizes, rowsizes + num_rows);
     BOOST_CHECK(st2 == st2_again);
     SparseTable<int> st2_byassign;


### PR DESCRIPTION
This fixes a bug in an internal utility that affected the grid_equal() function (it would give false positives).

Also, many warnings have been silenced. (The bug was discovered during the warning-squashing process as a compiler warning was given for the buggy behaviour.)