### PR TITLE
Fix bugs related to ExplicitArraysFluidState

### DIFF
--- a/opm/core/props/satfunc/SaturationPropsFromDeck_impl.hpp
+++ b/opm/core/props/satfunc/SaturationPropsFromDeck_impl.hpp
@@ -280,10 +280,10 @@ namespace Opm
     {
         assert(cells != 0);
 
-        ExplicitArraysFluidState fluidState;
+        const int np = phase_usage_.num_phases;
+        ExplicitArraysFluidState fluidState(np);
         fluidState.setSaturationArray(s);
 
-        const int np = phase_usage_.num_phases;
         if (dkrds) {
 // #pragma omp parallel for
             for (int i = 0; i < n; ++i) {
@@ -333,10 +333,10 @@ namespace Opm
     {
         assert(cells != 0);
 
-        ExplicitArraysFluidState fluidState;
+        const int np = phase_usage_.num_phases;
+        ExplicitArraysFluidState fluidState(np);
         fluidState.setSaturationArray(s);
 
-        const int np = phase_usage_.num_phases;
         if (dpcds) {
 // #pragma omp parallel for
             for (int i = 0; i < n; ++i) {
@@ -474,7 +474,7 @@ namespace Opm
                 const int max_np = BlackoilPhases::MaxNumPhases;
                 double s[max_np] = { 0.0 };
                 s[wpos] = swat;
-                ExplicitArraysFluidState fluidState;
+                ExplicitArraysFluidState fluidState(phase_usage_.num_phases);
                 fluidState.setSaturationArray(s);
                 fluidState.setIndex(0);
                 double pc[max_np] = { 0.0 };

--- a/opm/core/props/satfunc/SaturationPropsFromDeck_impl.hpp
+++ b/opm/core/props/satfunc/SaturationPropsFromDeck_impl.hpp
@@ -299,6 +299,7 @@ namespace Opm
         } else {
 // #pragma omp parallel for
             for (int i = 0; i < n; ++i) {
+                fluidState.setIndex(i);
                 if (do_hyst_) {
                    satfunc_[cell_to_func_[cells[i]]].evalKr(fluidState, kr + np*i, &(eps_transf_[cells[i]]), &(eps_transf_hyst_[cells[i]]), &(sat_hyst_[cells[i]]));
                 } else if (do_eps_) {

--- a/opm/core/simulator/ExplicitArraysFluidState.hpp
+++ b/opm/core/simulator/ExplicitArraysFluidState.hpp
@@ -36,10 +36,8 @@ class ExplicitArraysFluidState
 public:
     typedef double Scalar;
 
-    enum { numPhases = 3 };
-    enum { numComponents = 3 };
-
-    ExplicitArraysFluidState()
+    explicit ExplicitArraysFluidState(const unsigned int num_phases)
+	: numPhases_(num_phases)
     {}
 
     /*!
@@ -75,7 +73,7 @@ public:
      * \brief Returns the saturation of a phase for the current cell index.
      */
     Scalar saturation(int phaseIdx) const
-    { return saturations_[numPhases*arrayIdx_ + phaseIdx]; }
+    { return saturations_[numPhases_*arrayIdx_ + phaseIdx]; }
 
     /*!
      * \brief Returns the temperature [K] of a phase for the current cell index.
@@ -90,6 +88,7 @@ private:
     const double* temperature_;
 
     unsigned arrayIdx_;
+    unsigned numPhases_;
 };
 
 } // namespace Opm


### PR DESCRIPTION
This makes the two-phase simulators work again. It could have a negative effect on #834, if that requires the number of phases to be known at compile time. If so, we need to discuss how to work that out.