### PR TITLE
Use the correct (new) method from the Group class for group RESV.

### DIFF
--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -1064,7 +1064,7 @@ namespace Opm
             production_specification.gas_max_rate_ = group->getGasTargetRate(timeStep);
             production_specification.liquid_max_rate_ = group->getLiquidTargetRate(timeStep);
             production_specification.procedure_ = toProductionProcedure(GroupProductionExceedLimit::ActionEnum2String(group->getProductionExceedLimitAction(timeStep)));
-            production_specification.reservoir_flow_max_rate_ = group->getReservoirMaxRate(timeStep);
+            production_specification.reservoir_flow_max_rate_ = group->getReservoirVolumeTargetRate(timeStep);
         }
 
         std::shared_ptr<WellsGroupInterface> wells_group(new WellsGroup(group->name(), production_specification, injection_specification, phase_usage));

--- a/tests/test_wellsgroup.cpp
+++ b/tests/test_wellsgroup.cpp
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(ConstructGroupFromGroup) {
             BOOST_CHECK_EQUAL(group->getTargetVoidReplacementFraction(2), wellsGroup->injSpec().voidage_replacment_fraction_);
         }
         if (group->isProductionGroup(2)) {
-            BOOST_CHECK_EQUAL(group->getReservoirMaxRate(2), wellsGroup->prodSpec().reservoir_flow_max_rate_);
+            BOOST_CHECK_EQUAL(group->getReservoirVolumeTargetRate(2), wellsGroup->prodSpec().reservoir_flow_max_rate_);
             BOOST_CHECK_EQUAL(group->getGasTargetRate(2), wellsGroup->prodSpec().gas_max_rate_);
             BOOST_CHECK_EQUAL(group->getOilTargetRate(2), wellsGroup->prodSpec().oil_max_rate_);
             BOOST_CHECK_EQUAL(group->getWaterTargetRate(2), wellsGroup->prodSpec().water_max_rate_);


### PR DESCRIPTION
Production controls now are no longer initialised from injection control data.

This requires OPM/opm-parser#554.