### PR TITLE
Catch more istl exceptions

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -157,7 +157,7 @@ namespace Opm {
             }
             catch (const Dune::MatrixBlockError& e) {
                 std::cerr << e.what() << std::endl;
-                // also catch errors in ISTL AMG that occur when time step is too large
+                // this can be thrown by ISTL's ILU0 in block mode, yet is not an ISTLError
             }
 
             // (linearIterations < 0 means no convergence in solver)

--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -27,6 +27,7 @@
 #include <opm/core/simulator/AdaptiveSimulatorTimer.hpp>
 #include <opm/core/simulator/TimeStepControl.hpp>
 #include <dune/istl/istlexception.hh>
+#include <dune/istl/ilu.hh> // For MatrixBlockException
 
 namespace Opm {
 
@@ -151,6 +152,10 @@ namespace Opm {
                 // also catch linear solver not converged
             }
             catch (const Dune::ISTLError& e) {
+                std::cerr << e.what() << std::endl;
+                // also catch errors in ISTL AMG that occur when time step is too large
+            }
+            catch (const Dune::MatrixBlockError& e) {
                 std::cerr << e.what() << std::endl;
                 // also catch errors in ISTL AMG that occur when time step is too large
             }


### PR DESCRIPTION
This can be thrown by the ILU0 preconditioner when using the interleaved solver approach. Catching it allows us to shorten timesteps etc. as we do with other kinds of linear solver trouble.

This makes it possible to run through Norne with the interleaved solver.