### PR TITLE
adding command line option full_timestep_initially_

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping.hpp
@@ -87,6 +87,7 @@ namespace Opm {
         const bool solver_verbose_;           //!< solver verbosity
         const bool timestep_verbose_;         //!< timestep verbosity
         double last_timestep_;                //!< size of last timestep
+        bool full_timestep_initially_;        //!< beginning with the size of the time step from data file
     };
 }
 

--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -44,6 +44,7 @@ namespace Opm {
         , solver_restart_max_( param.getDefault("solver.restart", int(10) ) )
         , solver_verbose_( param.getDefault("solver.verbose", bool(true) ) )
         , timestep_verbose_( param.getDefault("timestep.verbose", bool(true) ) )
+        , full_timestep_initially_( param.getDefault("full_timestep_initially", bool(false) ) )
         , last_timestep_( -1.0 )
     {
         // valid are "pid" and "pid+iteration"
@@ -103,6 +104,10 @@ namespace Opm {
         // init last time step as a fraction of the given time step
         if( last_timestep_ < 0 ) {
             last_timestep_ = restart_factor_ * timestep;
+        }
+
+        if (full_timestep_initially_) {
+            last_timestep_ = timestep;
         }
 
         // TODO


### PR DESCRIPTION
To set its value to be `true`, the grammar is `full_timestep_initially=true`. 

When the option is true, for each report step, the size of the adaptive time step always beginning with the size of the report step.

The implementation of the current master branch is to use the average time step from the running of the previous report step. Under some conditions, it can result in relative small time step for the subsequent report steps. 

A preliminary test with all the other options defaulted, `full_timestep_initially_=true` reduce the number of Newton iterations from 2585 (current master branch with dune2.3) to 2143. And total running time from 5504 seconds to 4867 seconds. 

Before we decide to make this option to be `true` by default, it is `false` by default at the moment. 
