### PR TITLE
Modify region mapping to keep empty regions.

### DIFF
--- a/opm/core/simulator/initStateEquil.hpp
+++ b/opm/core/simulator/initStateEquil.hpp
@@ -404,6 +404,8 @@ namespace Opm
                          r < nr; ++r)
                     {
                         const typename RMap::CellRange cells = reg.cells(r);
+                        if (cells.size() == 0)
+                            continue;
 
                         const int repcell = *cells.begin();
                         const RhoCalc calc(props, repcell);

--- a/opm/core/utility/RegionMapping.hpp
+++ b/opm/core/utility/RegionMapping.hpp
@@ -171,7 +171,7 @@ namespace Opm
                 const std::pair<CI,CI>
                     m = std::minmax_element(reg.begin(), reg.end());
 
-                low  = *m.first;
+                low  = 0;
 
                 const typename Region::size_type
                     n = *m.second - low + 1;

--- a/tests/test_regionmapping.cpp
+++ b/tests/test_regionmapping.cpp
@@ -49,8 +49,8 @@ BOOST_AUTO_TEST_CASE (RegionMapping)
     for (size_t i = 0; i < regions.size(); ++i) {
         BOOST_CHECK_EQUAL(rm.region(i), regions[i]);
     }
-    std::vector<int> region_ids = { 2, 3, 4, 5, 6, 7 };
-    std::vector< std::vector<int> > region_cells = {  { 0, 2, 4 },  { 7 },  { 3 },  { 1 },  { 6, 8 },  { 5 }  };
+    std::vector<int> region_ids = { 0, 1, 2, 3, 4, 5, 6, 7 };
+    std::vector< std::vector<int> > region_cells = {  {},  {},  { 0, 2, 4 },  { 7 },  { 3 },  { 1 },  { 6, 8 },  { 5 }  };
     BOOST_REQUIRE_EQUAL(rm.numRegions(), region_ids.size());
     for (size_t i = 0; i < region_ids.size(); ++i) {
         auto cells = rm.cells(region_ids[i]);


### PR DESCRIPTION
This seems to be the most convenient way to maintain consistency between the EQUIL records and the region mapping give by EQLNUM. (In "Model 2" EQLNUM refers to several regions that are empty when
ACTNUM is accounted for.)