### PR TITLE
Use estimated time-step instead of average in next report step

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping.hpp
@@ -86,7 +86,7 @@ namespace Opm {
         const int solver_restart_max_;        //!< how many restart of solver are allowed
         const bool solver_verbose_;           //!< solver verbosity
         const bool timestep_verbose_;         //!< timestep verbosity
-        double last_timestep_;                //!< size of last timestep
+        double suggested_next_timestep_;      //!< suggested size of next timestep
         bool full_timestep_initially_;        //!< beginning with the size of the time step from data file
     };
 }

--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -225,8 +225,8 @@ namespace Opm {
         }
 
 
-        // store max of the small time step for next reportStep
-        last_timestep_ = substepTimer.averageStepLength();
+        // store estimated time step for next reportStep
+        last_timestep_ = substepTimer.currentStepLength();
         if( timestep_verbose_ )
         {
             substepTimer.report( std::cout );


### PR DESCRIPTION
The last estimated time-step is used for the initial sub-step in the report step instead of the average of the time-steps used in the previous report step.
 . 
Testes: 
Norne: 3.7% speedup
SPE1: (run using: flow SPE1DECK.DATA): 37% speedup
SPE9: (run using: flow SPE9.DATA) 15% speedup. 

 