### PR TITLE
Zero-porosity cells and MINPV.

### DIFF
--- a/opm/core/grid/MinpvProcessor.hpp
+++ b/opm/core/grid/MinpvProcessor.hpp
@@ -109,7 +109,7 @@ namespace Opm
                         }
                         setCellZcorn(ii, jj, kk, cz, zcorn);
                         // Check if there is a cell below.
-                        if (kk < dims_[2] - 1) {
+                        if (pv[c] > 0.0 && kk < dims_[2] - 1) {
                             // Set lower k coordinates of cell below to upper cells's coordinates.
                             std::array<double, 8> cz_below = getCellZcorn(ii, jj, kk + 1, zcorn);
                             for (int count = 0; count < 4; ++count) {


### PR DESCRIPTION
Model 2 partly uses PORO=0.0 to signal inactive cells. This PR
prevents such cells from causing unwanted zcorn modifications in
the current min-pv algoritm. (The problem is however more general as
zero PORO or NTG should kill a cell whether MINPV is active or not,
refer kw ACTNUM.)