### PR TITLE
Cell center depth also from zcorn average.

### DIFF
--- a/opm/core/grid/GridHelpers.cpp
+++ b/opm/core/grid/GridHelpers.cpp
@@ -70,6 +70,7 @@ double cellCenterDepth(const UnstructuredGrid& grid, int cell_index)
     // Traverse the bottom and top cell-face
     for (int i=grid.cell_facepos[cell_index+1]-2; i<grid.cell_facepos[cell_index+1]; ++i) {
         // Traverse the vertices associated with each face
+        assert(grid.face_nodepos[grid.cell_faces[i]+1] - grid.face_nodepos[grid.cell_faces[i]] == nv/2);
         for (int j=grid.face_nodepos[grid.cell_faces[i]]; j<grid.face_nodepos[grid.cell_faces[i]+1]; ++j) {
             zz += (grid.node_coordinates+nd*(grid.face_nodes[j]))[nd-1];
         }

--- a/opm/core/grid/GridHelpers.cpp
+++ b/opm/core/grid/GridHelpers.cpp
@@ -57,6 +57,17 @@ const double* beginCellCentroids(const UnstructuredGrid& grid)
     return grid.cell_centroids;
 }
 
+double cellCenterDepth(const UnstructuredGrid& grid, int cell_index) 
+{
+    double zz = 0.0;
+    for (int i=grid.cell_facepos[cell_index+1]-2; i<grid.cell_facepos[cell_index+1]; ++i) {
+        for (int j=grid.face_nodepos[grid.cell_faces[i]]; j<grid.face_nodepos[grid.cell_faces[i]+1]; ++j) {
+            zz += (grid.node_coordinates+dimensions(grid)*(grid.face_nodes[j]))[2];
+        }
+    }
+    return zz/8.0;
+}
+
 double cellCentroidCoordinate(const UnstructuredGrid& grid, int cell_index,
                                  int coordinate)
 {

--- a/opm/core/grid/GridHelpers.cpp
+++ b/opm/core/grid/GridHelpers.cpp
@@ -59,13 +59,22 @@ const double* beginCellCentroids(const UnstructuredGrid& grid)
 
 double cellCenterDepth(const UnstructuredGrid& grid, int cell_index) 
 {
+    // This method is an alternative to the method cellCentroidCoordinate(...) below.
+    // The cell center depth is computed as a raw average of cell corner depths.
+    // For cornerpoint grids, this is likely to give slightly different depths that seem
+    // to agree with eclipse.
+    assert(grid.dimensions == 3);
+    const int nd = 3; // Assuming 3-dimensional grid ...
+    const int nv = 8; // Assuming 2*4 vertices ...
     double zz = 0.0;
+    // Traverse the bottom and top cell-face
     for (int i=grid.cell_facepos[cell_index+1]-2; i<grid.cell_facepos[cell_index+1]; ++i) {
+        // Traverse the vertices associated with each face
         for (int j=grid.face_nodepos[grid.cell_faces[i]]; j<grid.face_nodepos[grid.cell_faces[i]+1]; ++j) {
-            zz += (grid.node_coordinates+dimensions(grid)*(grid.face_nodes[j]))[2];
+            zz += (grid.node_coordinates+nd*(grid.face_nodes[j]))[nd-1];
         }
     }
-    return zz/8.0;
+    return zz/nv;
 }
 
 double cellCentroidCoordinate(const UnstructuredGrid& grid, int cell_index,

--- a/opm/core/grid/GridHelpers.hpp
+++ b/opm/core/grid/GridHelpers.hpp
@@ -137,6 +137,13 @@ struct CellCentroidTraits<UnstructuredGrid>
 CellCentroidTraits<UnstructuredGrid>::IteratorType
 beginCellCentroids(const UnstructuredGrid& grid);
 
+
+/// \brief Get vertical position of cell center ("zcorn" average.)
+/// \brief grid The grid.
+/// \brief cell_index The index of the specific cell.
+double cellCenterDepth(const UnstructuredGrid& grid, int cell_index);
+
+
 /// \brief Get a coordinate of a specific cell centroid.
 /// \brief grid The grid.
 /// \brief cell_index The index of the specific cell.


### PR DESCRIPTION
There is a sligth difference between the cell depth taken from the
centroid (opm) and a straightforward average of corner coordinates
(ecl). For the initialisation of Norne this causes some differences
when deciding cell center positions relative contact depths.