### PR TITLE
Makes setupCompressedToCartesian a free function.

### DIFF
--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -391,8 +391,8 @@ namespace Opm
         well_collection_.applyExplicitReinjectionControls(well_reservoirrates_phase, well_surfacerates_phase);
     }
 
-    void WellsManager::setupCompressedToCartesian(const int* global_cell, int number_of_cells,
-                                                  std::map<int,int>& cartesian_to_compressed ) {
+    void setupCompressedToCartesian(const int* global_cell, int number_of_cells,
+                                    std::map<int,int>& cartesian_to_compressed ) {
         // global_cell is a map from compressed cells to Cartesian grid cells.
         // We must make the inverse lookup.
 

--- a/opm/core/wells/WellsManager.hpp
+++ b/opm/core/wells/WellsManager.hpp
@@ -153,7 +153,6 @@ namespace Opm
         // Disable copying and assignment.
         WellsManager(const WellsManager& other);
         WellsManager& operator=(const WellsManager& other);
-        static void setupCompressedToCartesian(const int* global_cell, int number_of_cells, std::map<int,int>& cartesian_to_compressed );
         void setupWellControls(std::vector<WellConstPtr>& wells, size_t timeStep,
                                std::vector<std::string>& well_names, const PhaseUsage& phaseUsage,
                                const std::vector<int>& wells_on_proc);
@@ -184,6 +183,8 @@ namespace Opm
         bool is_parallel_run_;
     };
 
+    /// \brief Creates a table to lookup the compressed global index from the ijk triple.
+    void setupCompressedToCartesian(const int* global_cell, int number_of_cells, std::map<int,int>& cartesian_to_compressed );
 } // namespace Opm
 
 #include "WellsManager_impl.hpp"


### PR DESCRIPTION
This lets us reuse this code at various places. E.g.
I need this functionality in dune-cornerpoint to create
a graph representing the well completions connect the cells.

LWe should probably move this function out of the
WellsManager as it has nothing to do with it. Feel free to propse a header and source file.