### PR TITLE
[bugfix] Allow querying the current time step even if we are done.

### DIFF
--- a/opm/core/simulator/AdaptiveSimulatorTimer.cpp
+++ b/opm/core/simulator/AdaptiveSimulatorTimer.cpp
@@ -96,7 +96,6 @@ namespace Opm
 
     double AdaptiveSimulatorTimer::currentStepLength () const
     {
-        assert( ! done () );
         return dt_;
     }
 


### PR DESCRIPTION
Previously there was an assertion whether the time stepping is still
running when querying the time step. After commit 5af794cfd588b this
triggered an assertion for Norne. As there is no reason to limit querying
the current time step in this way. This commit simply removes the assertion
in AdaptiveSimulatorTimer::currentStepLength.

This closes OPM/opm-autodiff#446