### PR TITLE
Fix complaint about initial declaration in foor loops.

### DIFF
--- a/opm/core/utility/memcmp_double.c
+++ b/opm/core/utility/memcmp_double.c
@@ -14,8 +14,8 @@ int memcmp_double(const double * p1 , const double *p2 , size_t num_elements) {
     else {
         const double abs_epsilon = 1e-8;
         const double rel_epsilon = 1e-5;
-
-        for (size_t index = 0; index < num_elements; index++) {
+        size_t index;
+        for (index = 0; index < num_elements; index++) {
             double diff = fabs(p1[index] - p2[index]);
             if (diff > abs_epsilon) {
                 double sum = fabs(p1[index]) + fabs(p2[index]);

--- a/opm/core/wells/well_controls.c
+++ b/opm/core/wells/well_controls.c
@@ -364,7 +364,8 @@ well_controls_get_current_distr(const struct WellControls * ctrl) {
 void 
 well_controls_iset_distr(const struct WellControls * ctrl, int control_index, const double * distr) {
     int offset = control_index * ctrl->number_of_phases;
-    for (int p=0; p < ctrl->number_of_phases; p++)
+    int p;
+    for (p=0; p < ctrl->number_of_phases; p++)
         ctrl->distr[offset + p] = distr[p];
 }
 

--- a/opm/core/wells/wells.c
+++ b/opm/core/wells/wells.c
@@ -544,7 +544,8 @@ wells_equal(const struct Wells *W1, const struct Wells *W2 , bool verbose)
         return are_equal;
     }
 
-    for (int i=0; i<W1->number_of_wells; i++) {
+    int i;
+    for (i=0; i<W1->number_of_wells; i++) {
         if (are_equal) {
             /*
               The name attribute can be NULL. The comparison is as


### PR DESCRIPTION
gcc-4.7.2 (Debian 4.7.2-5) complained about:
```
'for’ loop initial declarations are only allowed in C99 mode
note: use option -std=c99 or -std=gnu99 to compile your code"
```
when seeing somethink like this:
```c
for(int i=0; i<end; i++)
```
This is fixed by moving the declaration before the for loop with
this commit. Altenatively, we could use the above option.