### PR TITLE
Limit the time step growth for all time-stepping algorithm

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping.hpp
@@ -82,6 +82,7 @@ namespace Opm {
         TimeStepControlType timeStepControl_; //!< time step control object
         const double restart_factor_;         //!< factor to multiply time step with when solver fails to converge
         const double growth_factor_;          //!< factor to multiply time step when solver recovered from failed convergence
+        const double max_growth_;             //!< factor that limits the maximum growth of a time step
         const double max_time_step_;          //!< maximal allowed time step size
         const int solver_restart_max_;        //!< how many restart of solver are allowed
         const bool solver_verbose_;           //!< solver verbosity

--- a/opm/core/simulator/TimeStepControl.cpp
+++ b/opm/core/simulator/TimeStepControl.cpp
@@ -169,12 +169,10 @@ namespace Opm
     PIDAndIterationCountTimeStepControl::
     PIDAndIterationCountTimeStepControl( const int target_iterations,
                                          const double tol,
-                                         const double maxgrowth,
                                          const boost::any& pinfo,
                                          const bool verbose)
         : BaseType( tol, pinfo, verbose )
         , target_iterations_( target_iterations )
-        , maxgrowth_( maxgrowth )
     {}
 
     double PIDAndIterationCountTimeStepControl::
@@ -188,9 +186,6 @@ namespace Opm
             // if iterations was the same or dts were the same, do some magic
             dtEstimate *= double( target_iterations_ ) / double(iterations);
         }
-
-        // limit the growth of the timestep size by the growth factor
-        dtEstimate = std::min( dtEstimate, double(maxgrowth_ * dt) );
 
         return dtEstimate;
     }

--- a/opm/core/simulator/TimeStepControl.hpp
+++ b/opm/core/simulator/TimeStepControl.hpp
@@ -158,7 +158,6 @@ namespace Opm
         /// \param verbose    if true get some output (default = false)
         PIDAndIterationCountTimeStepControl( const int target_iterations = 20,
                                              const double tol = 1e-3,
-                                             const double maxgrowth = 3.0,
                                              const boost::any& = boost::any(),
                                              const bool verbose = false);
 
@@ -167,7 +166,6 @@ namespace Opm
 
     protected:
         const int     target_iterations_;
-        const double  maxgrowth_;
     };
 
 


### PR DESCRIPTION
The time step restriction is moved to AdaptiveTimeStepping_impl.hpp to
make it apply to all time-stepping algorithms.