### PR TITLE
RegionMapping<>: Support arbitrary active regions

### DIFF
--- a/opm/core/simulator/EquilibrationHelpers.hpp
+++ b/opm/core/simulator/EquilibrationHelpers.hpp
@@ -887,9 +887,9 @@ namespace Opm
         }
 
         /// Return true if capillary pressure function is constant
-        bool isConstPc(const BlackoilPropertiesInterface& props,
-                       const int phase,
-                       const int cell)
+        inline bool isConstPc(const BlackoilPropertiesInterface& props,
+                              const int                          phase,
+                              const int                          cell)
         {
             // Find minimum and maximum saturations.
             double sminarr[BlackoilPhases::MaxNumPhases];

--- a/opm/core/simulator/initStateEquil.hpp
+++ b/opm/core/simulator/initStateEquil.hpp
@@ -399,13 +399,10 @@ namespace Opm
                                  const Grid&                       G    ,
                                  const double grav)
                 {
-                    for (typename RMap::RegionId
-                             r = 0, nr = reg.numRegions();
-                         r < nr; ++r)
-                    {
-                        const typename RMap::CellRange cells = reg.cells(r);
-
+                    for (const auto& r : reg.activeRegions()) {
+                        const auto& cells = reg.cells(r);
                         const int repcell = *cells.begin();
+
                         const RhoCalc calc(props, repcell);
                         const EqReg eqreg(rec[r], calc,
                                           rs_func_[r], rv_func_[r],

--- a/opm/core/simulator/initStateEquil_impl.hpp
+++ b/opm/core/simulator/initStateEquil_impl.hpp
@@ -780,14 +780,22 @@ namespace Opm
         inline std::vector<double>
         convertSats(const std::vector< std::vector<double> >& sat)
         {
-            const int np = sat.size();
-            const int nc = sat[0].size();
+            const auto np = sat.size();
+            const auto nc = sat[0].size();
+
             std::vector<double> s(np * nc);
-            for (int c = 0; c < nc; ++c) {
-                for (int p = 0; p < np; ++p) {
-                    s[np*c + p] = sat[p][c];
+
+            for (decltype(sat.size()) p = 0; p < np; ++p) {
+                const auto& sat_p = sat[p];
+                double*     sp    = & s[0*nc + p];
+
+                for (decltype(sat[0].size()) c = 0;
+                     c < nc; ++c, sp += np)
+                {
+                    *sp = sat_p[c];
                 }
             }
+
             return s;
         }
     } // namespace Details

--- a/opm/core/simulator/initStateEquil_impl.hpp
+++ b/opm/core/simulator/initStateEquil_impl.hpp
@@ -777,7 +777,8 @@ namespace Opm
         /// Convert saturations from a vector of individual phase saturation vectors
         /// to an interleaved format where all values for a given cell come before all
         /// values for the next cell, all in a single vector.
-        std::vector<double> convertSats(const std::vector< std::vector<double> >& sat)
+        inline std::vector<double>
+        convertSats(const std::vector< std::vector<double> >& sat)
         {
             const int np = sat.size();
             const int nc = sat[0].size();

--- a/tests/test_equil.cpp
+++ b/tests/test_equil.cpp
@@ -307,10 +307,8 @@ BOOST_AUTO_TEST_CASE (RegMapping)
     Opm::RegionMapping<> eqlmap(eqlnum);
 
     PPress ppress(2, PVal(G->number_of_cells, 0));
-    for (int r = 0, e = eqlmap.numRegions(); r != e; ++r)
-    {
-        const Opm::RegionMapping<>::CellRange&
-            rng = eqlmap.cells(r);
+    for (const auto& r : eqlmap.activeRegions()) {
+        const auto& rng = eqlmap.cells(r);
 
         const int    rno  = r;
         const double grav = 10;
@@ -318,14 +316,13 @@ BOOST_AUTO_TEST_CASE (RegMapping)
             Opm::Equil::phasePressures(*G, region[rno], rng, grav);
 
         PVal::size_type i = 0;
-        for (Opm::RegionMapping<>::CellRange::const_iterator
-                 c = rng.begin(), ce = rng.end();
-             c != ce; ++c, ++i)
-        {
+        for (const auto& c : rng) {
             assert (i < p[0].size());
 
-            ppress[0][*c] = p[0][i];
-            ppress[1][*c] = p[1][i];
+            ppress[0][c] = p[0][i];
+            ppress[1][c] = p[1][i];
+
+            ++i;
         }
     }
 

--- a/tests/test_regionmapping.cpp
+++ b/tests/test_regionmapping.cpp
@@ -26,42 +26,130 @@
 
 #define NVERBOSE  // Suppress own messages when throw()ing
 
-#define BOOST_TEST_MODULE UnitsTest
+#define BOOST_TEST_MODULE RegionMapping
 
 #include <opm/core/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <boost/test/floating_point_comparison.hpp>
 #include <opm/core/utility/platform_dependent/reenable_warnings.h>
 
 /* --- our own headers --- */
 
 #include <opm/core/utility/RegionMapping.hpp>
 
+#include <algorithm>
+#include <map>
 
 BOOST_AUTO_TEST_SUITE ()
 
 
-BOOST_AUTO_TEST_CASE (RegionMapping)
+BOOST_AUTO_TEST_CASE (Forward)
 {
-    //                           0  1  2  3  4  5  6  7  8
     std::vector<int> regions = { 2, 5, 2, 4, 2, 7, 6, 3, 6 };
+
     Opm::RegionMapping<> rm(regions);
-    for (size_t i = 0; i < regions.size(); ++i) {
+
+    for (decltype(regions.size()) i = 0, n = regions.size(); i < n; ++i) {
         BOOST_CHECK_EQUAL(rm.region(i), regions[i]);
-    }
-    std::vector<int> region_ids = { 2, 3, 4, 5, 6, 7 };
-    std::vector< std::vector<int> > region_cells = {  { 0, 2, 4 },  { 7 },  { 3 },  { 1 },  { 6, 8 },  { 5 }  };
-    BOOST_REQUIRE_EQUAL(rm.numRegions(), region_ids.size());
-    for (size_t i = 0; i < region_ids.size(); ++i) {
-        auto cells = rm.cells(region_ids[i]);
-        BOOST_REQUIRE_EQUAL(std::distance(cells.begin(), cells.end()), region_cells[i].size());
-        size_t count = 0;
-        for (auto iter = cells.begin(); iter != cells.end(); ++iter, ++count) {
-            BOOST_CHECK_EQUAL(*iter, region_cells[i][count]);
-        }
     }
 }
 
+
+BOOST_AUTO_TEST_CASE (ActiveRegions)
+{
+    //                           0  1  2  3  4  5  6  7  8
+    std::vector<int> regions = { 2, 5, 2, 4, 2, 7, 6, 3, 6 };
+
+    Opm::RegionMapping<> rm(regions);
+
+    std::vector<int> region_ids = { 2, 3, 4, 5, 6, 7 };
+
+    auto active = [&region_ids](const int reg)
+        {
+            auto b = region_ids.begin();
+            auto e = region_ids.end();
+
+            return std::find(b, e, reg) != e;
+        };
+
+    BOOST_CHECK_EQUAL(rm.activeRegions().size(), region_ids.size());
+
+    for (const auto& reg : rm.activeRegions()) {
+        BOOST_CHECK(active(reg));
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE (Consecutive)
+{
+    using RegionCells = std::map<int, std::vector<int>>;
+
+    //                           0  1  2  3  4  5  6  7  8
+    std::vector<int> regions = { 2, 5, 2, 4, 2, 7, 6, 3, 6 };
+
+    Opm::RegionMapping<> rm(regions);
+
+    std::vector<int> region_ids = { 2, 3, 4, 5, 6, 7 };
+    RegionCells      region_cells;
+    {
+        using VT = RegionCells::value_type;
+
+        region_cells.insert(VT(2, { 0, 2, 4 }));
+        region_cells.insert(VT(3, { 7 }));
+        region_cells.insert(VT(4, { 3 }));
+        region_cells.insert(VT(5, { 1 }));
+        region_cells.insert(VT(6, { 6, 8 }));
+        region_cells.insert(VT(7, { 5 }));
+    }
+
+    for (const auto& reg : region_ids) {
+        const auto& cells  = rm.cells(reg);
+        const auto& expect = region_cells[reg];
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(cells .begin(), cells .end(),
+                                      expect.begin(), expect.end());
+    }
+
+    // Verify that there are no cells in unused regions 0 and 1.
+    for (const auto& r : { 0, 1 }) {
+        BOOST_CHECK(rm.cells(r).empty());
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE (NonConsecutive)
+{
+    using RegionCells = std::map<int, std::vector<int>>;
+
+    //                           0  1  2  3  4  5  6  7  8
+    std::vector<int> regions = { 2, 4, 2, 4, 2, 7, 6, 3, 6 };
+
+    Opm::RegionMapping<> rm(regions);
+
+    std::vector<int> region_ids = { 2, 3, 4, 6, 7 };
+    RegionCells      region_cells;
+    {
+        using VT = RegionCells::value_type;
+
+        region_cells.insert(VT(2, { 0, 2, 4 }));
+        region_cells.insert(VT(3, { 7 }));
+        region_cells.insert(VT(4, { 1, 3 }));
+        region_cells.insert(VT(6, { 6, 8 }));
+        region_cells.insert(VT(7, { 5 }));
+    }
+
+    for (const auto& reg : region_ids) {
+        const auto& cells  = rm.cells(reg);
+        const auto& expect = region_cells[reg];
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(cells .begin(), cells .end(),
+                                      expect.begin(), expect.end());
+    }
+
+    // Verify that there are no cells in unused regions 0, 1, and 5.
+    for (const auto& r : { 0, 1, 5 }) {
+        BOOST_CHECK(rm.cells(r).empty());
+    }
+}
 
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This change-set addresses the issue that was brought up in PR #858.  We introduce support for arbitrary region lookup provided the region ID supports `std::hash<>` and simplify the interface by replacing the custom `CellRange` class with a `boost::iterator_range<>`.

Method `cells()` returns an empty range if the region ID corresponds to an inactive region.

Note: The changes to `EquilibrationHelpers.hpp` and `initStateEquil_impl.hpp` are, strictly speaking, ancillary, but the issues were highlighted by this work and the changes included for convenience.

Note: This supersedes and closes #864.