### PR TITLE
[bugfix] Account for shut completions when checking well in parallel

### DIFF
--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -217,13 +217,16 @@ void WellsManager::createWellsFromSpecs(std::vector<WellConstPtr>& wells, size_t
                     wells_on_proc[wellIter-wells.begin()] = 0;
                     continue;
                 }
-                // Check that the complete well is on this process
-                if( sum_completions_on_proc < completionSet->size() )
+                else
                 {
-                    std::size_t missing = completionSet->size()-shut_completions_number-sum_completions_on_proc;
-                    OPM_THROW(std::runtime_error, "Each well must be completely stored "
-                              <<"on one process! Not the case for "<< well->name()<<": "
-                              <<missing<<" completions missing.");
+                    // Check that the complete well is on this process
+                    if ( sum_completions_on_proc < completionSet->size() )
+                    {
+                        std::size_t missing = completionSet->size()-sum_completions_on_proc;
+                        OPM_THROW(std::runtime_error, "Each well must be completely stored "
+                                  << "on one process! Not the case for " << well->name() << ": "
+                                  << missing << " completions missing.");
+                    }
                 }
             }
         }

--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -217,10 +217,10 @@ void WellsManager::createWellsFromSpecs(std::vector<WellConstPtr>& wells, size_t
                 // Check that the complete well is on this process
                 if( sum_completions_on_proc < completionSet->size() )
                 {
-                    OPM_THROW(std::runtime_error, "Each well must be completely stored 
-                              <<"on processor! Not the case for "<< well->name()<<": "
-                              <<completionSet->size()-shut_completions-sum_completions_on_proc
-                              <<" completions missing.");
+                    std::size_t missing = completionSet->size()-shut_completions_number-sum_completions_on_proc;
+                    OPM_THROW(std::runtime_error, "Each well must be completely stored "
+                              <<"on one process! Not the case for "<< well->name()<<": "
+                              <<missing<<" completions missing.");
                 }
             }
         }

--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -205,9 +205,12 @@ void WellsManager::createWellsFromSpecs(std::vector<WellConstPtr>& wells, size_t
             }
             if ( is_parallel_run_ )
             {
-                // Set wells that are on other processor to SHUT.
+                // sum_completions_on_proc includes completions
+                // that are shut
                 std::size_t sum_completions_on_proc = std::accumulate(completion_on_proc.begin(),
                                                                       completion_on_proc.end(),0);
+                // Set wells that are not on this processor to SHUT.
+                // A well is not here if only shut completions are found.
                 if ( sum_completions_on_proc == shut_completions_number )
                 {
                     // Mark well as not existent on this process


### PR DESCRIPTION
Previously well with just some shut completions erroneously triggered an exception in parallel runs. This is fixed with this commit.

Due to the logic shut completions will always be marked as existing on a process. (Initially all  completions are marked as found. For each open completion we check whether the Cartesian index belongs to the local grid. If that is not the case we mark it as not found). Therefore we now check whether the found number of completions is either the number of shut completions or the number of all completions. In the former case the well is not stored on this process, and in the latter case it is. In other cases we throw an exception.