### PR TITLE
Change default values

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -37,8 +37,8 @@ namespace Opm {
     AdaptiveTimeStepping::AdaptiveTimeStepping( const parameter::ParameterGroup& param,
                                             const boost::any& parallel_information )
         : timeStepControl_()
-        , restart_factor_( param.getDefault("solver.restartfactor", double(0.1) ) )
-        , growth_factor_( param.getDefault("solver.growthfactor", double(1.25) ) )
+        , restart_factor_( param.getDefault("solver.restartfactor", double(0.33) ) )
+        , growth_factor_( param.getDefault("solver.growthfactor", double(2) ) )
         , max_growth_( param.getDefault("timestep.control.maxgrowth", double(3.0) ) )
           // default is 1 year, convert to seconds
         , max_time_step_( unit::convert::from(param.getDefault("timestep.max_timestep_in_days", 365.0 ), unit::day) )
@@ -49,11 +49,11 @@ namespace Opm {
         , full_timestep_initially_( param.getDefault("full_timestep_initially", bool(false) ) )
     {
         // valid are "pid" and "pid+iteration"
-        std::string control = param.getDefault("timestep.control", std::string("pid+iteration") );
+        std::string control = param.getDefault("timestep.control", std::string("pid") );
         // iterations is the accumulation of all linear iterations over all newton steops per time step
         const int defaultTargetIterations = 30;
 
-        const double tol = param.getDefault("timestep.control.tol", double(1e-3) );
+        const double tol = param.getDefault("timestep.control.tol", double(1e-1) );
         if( control == "pid" ) {
             timeStepControl_ = TimeStepControlType( new PIDTimeStepControl( tol, parallel_information ) );
         }


### PR DESCRIPTION
- use time stepping algorithm pid instead of pid + iter
Adjusting the time-steps on the number of linear iterations does
currently not give any improvents on the time-stepping.
- Change the pid tolerance. The time-stepper will take longer time-steps
and thus reduce the simulation time significantly. The Norne and the SPE
results does not degrade
- Less aggressive reduction of time-steps after convergence problems