### PR TITLE
Allow a few well completions in the overlap.

### DIFF
--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -152,10 +152,6 @@ void WellsManager::createWellsFromSpecs(std::vector<WellConstPtr>& wells, size_t
                     if (cgit == cartesian_to_compressed.end()) {
                         if ( is_parallel_run_ )
                         {
-                            // \todo remove hack for parallel runs! HACK!
-                            std::cerr<<" Warning: Cell with i,j,k indices " << i << ' ' << j << ' '
-                                     << k << " not found in grid (well = " << well->name()
-                                     << ") Assuming a parallel run and ignoring it"<<std::endl;
                             completion_on_proc[c]=0;
                             continue;
                         }
@@ -222,10 +218,12 @@ void WellsManager::createWellsFromSpecs(std::vector<WellConstPtr>& wells, size_t
                     // Check that the complete well is on this process
                     if ( sum_completions_on_proc < completionSet->size() )
                     {
-                        std::size_t missing = completionSet->size()-sum_completions_on_proc;
-                        OPM_THROW(std::runtime_error, "Each well must be completely stored "
-                                  << "on one process! Not the case for " << well->name() << ": "
-                                  << missing << " completions missing.");
+                        std::cout<< "Well "<< well->name() << " semms not be in "
+                                 << "completely in the disjoint partition of "
+                                 << "process deactivating here." << std::endl;
+                        // Mark well as not existent on this process
+                        wells_on_proc[wellIter-wells.begin()] = 0;
+                        continue;
                     }
                 }
             }


### PR DESCRIPTION
If on one process a well completion is next to border then
it might also be stored in the neighbor process. Still not
all the completions of the well are known to the neighbor.
This breaks the previous assumption that for each well all
completions must belong to the partition of the process.

Therefore with this commit we allow wells that only have a
part of their completions assigned to the partition of the process.
This wells are deactivated under the assumption that they must
exist completely on another process due to the partitioning.