### PR TITLE
SimulatorState: export num_cells_ and num_faces_.

### DIFF
--- a/opm/core/props/BlackoilPropertiesFromDeck_impl.hpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck_impl.hpp
@@ -13,7 +13,7 @@ namespace Opm
                                                            bool init_rock)
     {
         std::vector<int> compressedToCartesianIdx(number_of_cells);
-        for (unsigned cellIdx = 0; cellIdx < number_of_cells; ++cellIdx) {
+        for (int cellIdx = 0; cellIdx < number_of_cells; ++cellIdx) {
             if (global_cell) {
                 compressedToCartesianIdx[cellIdx] = global_cell[cellIdx];
             }
@@ -40,7 +40,7 @@ namespace Opm
                                                            bool init_rock)
     {
         std::vector<int> compressedToCartesianIdx(number_of_cells);
-        for (unsigned cellIdx = 0; cellIdx < number_of_cells; ++cellIdx) {
+        for (int cellIdx = 0; cellIdx < number_of_cells; ++cellIdx) {
             if (global_cell) {
                 compressedToCartesianIdx[cellIdx] = global_cell[cellIdx];
             }

--- a/opm/core/props/IncompPropertiesFromDeck.cpp
+++ b/opm/core/props/IncompPropertiesFromDeck.cpp
@@ -35,7 +35,7 @@ namespace Opm
         auto materialLawManager = std::make_shared<typename SaturationPropsFromDeck::MaterialLawManager>();
 
         std::vector<int> compressedToCartesianIdx(grid.number_of_cells);
-        for (unsigned cellIdx = 0; cellIdx < grid.number_of_cells; ++cellIdx) {
+        for (int cellIdx = 0; cellIdx < grid.number_of_cells; ++cellIdx) {
             if (grid.global_cell) {
                 compressedToCartesianIdx[cellIdx] = grid.global_cell[cellIdx];
             }

--- a/opm/core/simulator/SimulatorState.hpp
+++ b/opm/core/simulator/SimulatorState.hpp
@@ -50,6 +50,8 @@ namespace Opm
                          ExtremalSat es);
     public:
         int numPhases() const { return num_phases_; }
+        int numCells () const { return num_cells_; }
+        int numFaces () const { return num_faces_; }
 
         std::vector<double>& pressure    () { return cellData_[ pressureId_ ]; }
         std::vector<double>& temperature () { return cellData_[ temperatureId_ ]; }
@@ -76,6 +78,11 @@ namespace Opm
         std::vector< std::vector<double> >& faceData() { return faceData_; }
         const std::vector< std::vector<double> >& faceData() const { return faceData_; }
 
+        const std::vector< std::string >& cellDataNames() const { return cellDataNames_; }
+        const std::vector< std::string >& faceDataNames() const { return faceDataNames_; }
+
+        size_t registerCellData( const std::string& name, const int components, const double initialValue = 0.0 );
+        size_t registerFaceData( const std::string& name, const int components, const double initialValue = 0.0 );
     private:
         int num_cells_;
         int num_faces_;
@@ -92,9 +99,6 @@ namespace Opm
         std::vector< std::string > faceDataNames_;
 
     protected:
-        size_t registerCellData( const std::string& name, const int components, const double initialValue = 0.0 );
-        size_t registerFaceData( const std::string& name, const int components, const double initialValue = 0.0 );
-
         /**
          * Check if two vectors are equal within a margin.
          *

--- a/opm/core/simulator/initState_impl.hpp
+++ b/opm/core/simulator/initState_impl.hpp
@@ -470,7 +470,7 @@ namespace Opm
                         State& state)
     {
         initStateBasic(grid.number_of_cells, grid.global_cell, grid.cartdims,
-                       grid.number_of_faces, UgGridHelpers::faceCells(grid), 
+                       grid.number_of_faces, UgGridHelpers::faceCells(grid),
                        grid.face_centroids, grid.cell_centroids, grid.dimensions,
                        props, param, gravity, state);
     }
@@ -716,7 +716,7 @@ namespace Opm
                 }
             }
         }
-    }   
+    }
     /// Initialize surface volume from pressure and saturation by z = As.
     /// Here the solution gas/oil ratio or vapor oil/gas ratio is used to
     /// compute an intial z for the computation of A.
@@ -733,7 +733,7 @@ namespace Opm
                                         const Props& props,
                                         State& state)
     {
-        
+
         if (props.numPhases() != 3) {
             OPM_THROW(std::runtime_error, "initBlackoilSurfvol() is only supported in three-phase simulations.");
         }


### PR DESCRIPTION
This PR adds methods numCells and numFaces to SimulatorState and also allows to register data from outside. This is needed for the ParallelOutput. 

Also, some warnings in BlackoilPropsFromDeck have been fixed.