### PR TITLE
Use cell thickness from EclipseGrid in the well transsmissibility

### DIFF
--- a/opm/core/wells/WellsManager.hpp
+++ b/opm/core/wells/WellsManager.hpp
@@ -164,6 +164,7 @@ namespace Opm
                                    const int* cart_dims,
                                    FC begin_face_centroids, 
                                    int dimensions,
+                                   std::vector<double>& dz,
                                    std::vector<std::string>& well_names,
                                    std::vector<WellData>& well_data,
                                    std::map<std::string, int> & well_names_to_index,


### PR DESCRIPTION
The `dz` calculated in `WellDetails::getCubeDim()` is not correct in cases where the face centroid of the horizontal faces is located above or below the face centroid or the vertical faces. The cell thickness in EclipseGrid, calculated using the Z-coordinates, is therefore used instead.

Tested on SPE9 with corner-point geometry. 

Questions to the reviewers.

 1. Should the call to `WellDetails::getCubeDim()` be moved outside `createWellsFromSpecs` and instead the cell dimensions passed directly.

 2. Do we need to calculate `dx` and `dy` from the z-coordinates as well?