### PR TITLE
WellState: move mapping from well name to well index to here.

### DIFF
--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -63,6 +63,7 @@ namespace Opm
 
                     // setup wellname -> well index mapping
                     {
+                        assert( wells->name[ w ] );
                         std::string name( wells->name[ w ] );
                         assert( name.size() > 0 );
                         mapentry_t& wellMapEntry = wellMap_[name];

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -23,6 +23,8 @@
 #include <opm/core/wells.h>
 #include <opm/core/well_controls.h>
 #include <vector>
+#include <array>
+#include <map>
 #include <cassert>
 #include <cstddef>
 
@@ -32,6 +34,10 @@ namespace Opm
     /// The state of a set of wells.
     class WellState
     {
+    protected:
+        typedef std::array< int, 3 >  mapentry_t;
+        typedef std::map< std::string, mapentry_t > WellMapType;
+
     public:
         /// Allocate and initialize if wells is non-null.
         /// Also tries to give useful initial values to the bhp() and
@@ -41,6 +47,9 @@ namespace Opm
         template <class State>
         void init(const Wells* wells, const State& state)
         {
+            // clear old name mapping
+            wellMap_.clear();
+
             if (wells) {
                 const int nw = wells->number_of_wells;
                 const int np = wells->number_of_phases;
@@ -51,6 +60,19 @@ namespace Opm
                 for (int w = 0; w < nw; ++w) {
                     assert((wells->type[w] == INJECTOR) || (wells->type[w] == PRODUCER));
                     const WellControls* ctrl = wells->ctrls[w];
+
+                    // setup wellname -> well index mapping
+                    {
+                        std::string name( wells->name[ w ] );
+                        assert( name.size() > 0 );
+                        mapentry_t& wellMapEntry = wellMap_[name];
+                        wellMapEntry[ 0 ] = w;
+                        wellMapEntry[ 1 ] = wells->well_connpos[w];
+                        // also store the number of perforations in this well
+                        const int num_perf_this_well = wells->well_connpos[w + 1] - wells->well_connpos[w];
+                        wellMapEntry[ 2 ] = num_perf_this_well;
+                    }
+
                     if (well_controls_well_is_stopped(ctrl)) {
                         // Stopped well:
                         // 1. Rates: assign zero well rates.
@@ -170,6 +192,21 @@ namespace Opm
             return getRestartTemperatureOffset() + temperature_.size();
         }
 
+        const WellMapType& wellMap() const { return wellMap_; }
+        WellMapType& wellMap() { return wellMap_; }
+
+        /// The number of wells present.
+        int numWells() const
+        {
+            return bhp().size();
+        }
+
+        /// The number of phases present.
+        int numPhases() const
+        {
+            return wellRates().size() / numWells();
+        }
+
     private:
         std::vector<double> bhp_;
         std::vector<double> thp_;
@@ -177,6 +214,8 @@ namespace Opm
         std::vector<double> wellrates_;
         std::vector<double> perfrates_;
         std::vector<double> perfpress_;
+
+        WellMapType wellMap_;
     };
 
 } // namespace Opm

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -22,9 +22,10 @@
 
 #include <opm/core/wells.h>
 #include <opm/core/well_controls.h>
-#include <vector>
 #include <array>
 #include <map>
+#include <string>
+#include <vector>
 #include <cassert>
 #include <cstddef>
 
@@ -34,11 +35,10 @@ namespace Opm
     /// The state of a set of wells.
     class WellState
     {
-    protected:
+    public:
         typedef std::array< int, 3 >  mapentry_t;
         typedef std::map< std::string, mapentry_t > WellMapType;
 
-    public:
         /// Allocate and initialize if wells is non-null.
         /// Also tries to give useful initial values to the bhp() and
         /// wellRates() fields, depending on controls.  The


### PR DESCRIPTION
This PR moves the wellname -> wellIndex mapping from WellStateFullyImplicitBlackoil to the base class. 
This is needed for the ParallelDebugOutput where we only have WellSate objects and need this mapping (which is already available in the Blackoil stuff).