### PR TITLE
Account for possible null global_cell

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -415,6 +415,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/transport/reorder/tarjan.h
 	opm/core/utility/Average.hpp
 	opm/core/utility/CompressedPropertyAccess.hpp
+	opm/core/utility/compressedToCartesian.hpp
 	opm/core/utility/DataMap.hpp
 	opm/core/utility/ErrorMacros.hpp
 	opm/core/utility/Event.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -124,6 +124,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/core/transport/reorder/TransportSolverTwophaseReorder.cpp
 	opm/core/transport/reorder/reordersequence.cpp
 	opm/core/transport/reorder/tarjan.c
+	opm/core/utility/compressedToCartesian.cpp
 	opm/core/utility/Event.cpp
 	opm/core/utility/MonotCubicInterpolator.cpp
 	opm/core/utility/StopWatch.cpp

--- a/opm/core/props/BlackoilPropertiesFromDeck.cpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck.cpp
@@ -21,30 +21,12 @@
 #include <opm/core/props/BlackoilPropertiesFromDeck.hpp>
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
+#include <opm/core/utility/compressedToCartesian.hpp>
 #include <vector>
 #include <numeric>
 
 namespace Opm
 {
-
-    namespace
-    {
-        // Construct explicit mapping from active/compressed to logical cartesian
-        // indices, either as given in global_cell or as { 0, 1, 2, ....} if null.
-        std::vector<int> compressedToCartesian(const int num_cells,
-                                               const int* global_cell)
-        {
-            std::vector<int> retval;
-            if (global_cell) {
-                retval.assign(global_cell, global_cell + num_cells);
-            } else {
-                retval.resize(num_cells);
-                std::iota(retval.begin(), retval.end(), 0);
-            }
-            return retval;
-        }
-    } // anonymous namespace
-
 
     BlackoilPropertiesFromDeck::BlackoilPropertiesFromDeck(Opm::DeckConstPtr deck,
                                                            Opm::EclipseStateConstPtr eclState,

--- a/opm/core/utility/compressedToCartesian.cpp
+++ b/opm/core/utility/compressedToCartesian.cpp
@@ -17,10 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef OPM_COMPRESSEDTOCARTESIAN_HEADER_INCLUDED
-#define OPM_COMPRESSEDTOCARTESIAN_HEADER_INCLUDED
 
-#include <vector>
+#include <opm/core/utility/compressedToCartesian.hpp>
 #include <numeric>
 
 namespace Opm
@@ -34,8 +32,17 @@ namespace Opm
     //                         or the sequence { 0, 1, ... , num_cells - 1 } if
     //                         global_cell was null.
     std::vector<int> compressedToCartesian(const int num_cells,
-                                           const int* global_cell);
+                                           const int* global_cell)
+    {
+        std::vector<int> retval;
+        if (global_cell) {
+            retval.assign(global_cell, global_cell + num_cells);
+        } else {
+            retval.resize(num_cells);
+            std::iota(retval.begin(), retval.end(), 0);
+        }
+        return retval;
+    }
+
 
 } // namespace Opm
-
-#endif // OPM_COMPRESSEDTOCARTESIAN_HEADER_INCLUDED

--- a/opm/core/utility/compressedToCartesian.hpp
+++ b/opm/core/utility/compressedToCartesian.hpp
@@ -1,0 +1,53 @@
+/*
+  Copyright 2015 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_COMPRESSEDTOCARTESIAN_HEADER_INCLUDED
+#define OPM_COMPRESSEDTOCARTESIAN_HEADER_INCLUDED
+
+#include <vector>
+#include <numeric>
+
+namespace Opm
+{
+
+    // Construct explicit mapping from active/compressed to logical cartesian
+    // indices, either as given in global_cell or as { 0, 1, 2, ....} if null.
+    // \param[in] num_cells    The number of active cells.
+    // \param[in] global_cell  Either null, or an array of size num_cells.
+    // \return                 A vector containing the same data as global_cell,
+    //                         or the sequence { 0, 1, ... , num_cells - 1 } if
+    //                         global_cell was null.
+    inline
+    std::vector<int> compressedToCartesian(const int num_cells,
+                                           const int* global_cell)
+    {
+        std::vector<int> retval;
+        if (global_cell) {
+            retval.assign(global_cell, global_cell + num_cells);
+        } else {
+            retval.resize(num_cells);
+            std::iota(retval.begin(), retval.end(), 0);
+        }
+        return retval;
+    }
+
+
+} // namespace Opm
+
+#endif // OPM_COMPRESSEDTOCARTESIAN_HEADER_INCLUDED

--- a/opm/core/utility/compressedToCartesian.hpp
+++ b/opm/core/utility/compressedToCartesian.hpp
@@ -21,7 +21,6 @@
 #define OPM_COMPRESSEDTOCARTESIAN_HEADER_INCLUDED
 
 #include <vector>
-#include <numeric>
 
 namespace Opm
 {

--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -2,6 +2,7 @@
 #include <opm/core/grid/GridHelpers.hpp>
 
 #include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/core/utility/compressedToCartesian.hpp>
 
 #include <algorithm>
 #include <array>
@@ -380,8 +381,11 @@ WellsManager::init(const Opm::EclipseStateConstPtr eclipseState,
     // use cell thickness (dz) from eclGrid
     // dz overwrites values calculated by WellDetails::getCubeDim
     std::vector<double> dz(number_of_cells);
-    for (int cell = 0; cell < number_of_cells; ++cell) {
-        dz[cell] = eclGrid->getCellThicknes(global_cell[cell]);
+    {
+        std::vector<int> gc = compressedToCartesian(number_of_cells, global_cell);
+        for (int cell = 0; cell < number_of_cells; ++cell) {
+            dz[cell] = eclGrid->getCellThicknes(gc[cell]);
+        }
     }
 
     createWellsFromSpecs(wells, timeStep, cell_to_faces,


### PR DESCRIPTION
The `compressedToCartesian()` function has been moved to a separate header and used to avoid error in the case a `nullptr` is passed for `global_cell` in `WellsManager`.

I expect that this very minor utility can be useful a few other places as well.