### PR TITLE
Changed Table code to use TableContainer

### DIFF
--- a/opm/core/props/pvt/PvtDead.cpp
+++ b/opm/core/props/pvt/PvtDead.cpp
@@ -34,7 +34,7 @@ namespace Opm
     // Member functions
     //-------------------------------------------------------------------------
     /// Constructor
-    void PvtDead::initFromOil(const std::vector<Opm::PvdoTable>& pvdoTables)
+    void PvtDead::initFromOil(const TableContainer& pvdoTables)
     {
         int numRegions = pvdoTables.size();
 
@@ -44,7 +44,7 @@ namespace Opm
         inverseBmu_.resize(numRegions);
 
         for (int regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
-            const Opm::PvdoTable& pvdoTable = pvdoTables[regionIdx];
+            const Opm::PvdoTable& pvdoTable = pvdoTables.getTable<PvdoTable>(regionIdx);
 
             // Copy data
             const std::vector<double>& press = pvdoTable.getPressureColumn();
@@ -69,7 +69,7 @@ namespace Opm
     }
 
 
-    void PvtDead::initFromGas(const std::vector<Opm::PvdgTable>& pvdgTables)
+    void PvtDead::initFromGas(const TableContainer& pvdgTables)
     {
         int numRegions = pvdgTables.size();
 
@@ -79,7 +79,7 @@ namespace Opm
         inverseBmu_.resize(numRegions);
 
         for (int regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
-            const Opm::PvdgTable& pvdgTable = pvdgTables[regionIdx];
+            const Opm::PvdgTable& pvdgTable = pvdgTables.getTable<PvdgTable>(regionIdx);
 
             // Copy data
             const std::vector<double>& press = pvdgTable.getPressureColumn();

--- a/opm/core/props/pvt/PvtDead.hpp
+++ b/opm/core/props/pvt/PvtDead.hpp
@@ -24,6 +24,7 @@
 #include <opm/core/utility/NonuniformTableLinear.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp>
 
 #include <vector>
 
@@ -46,8 +47,8 @@ namespace Opm
     public:
         PvtDead() {};
 
-        void initFromOil(const std::vector<Opm::PvdoTable>& pvdoTables);
-        void initFromGas(const std::vector<Opm::PvdgTable>& pvdgTables);
+        void initFromOil(const TableContainer& pvdoTables);
+        void initFromGas(const TableContainer& pvdgTables);
         virtual ~PvtDead();
 
         /// Viscosity as a function of p, T and z.

--- a/opm/core/props/pvt/PvtDeadSpline.cpp
+++ b/opm/core/props/pvt/PvtDeadSpline.cpp
@@ -38,7 +38,7 @@ namespace Opm
     PvtDeadSpline::PvtDeadSpline()
     {}
 
-    void PvtDeadSpline::initFromOil(const std::vector<Opm::PvdoTable>& pvdoTables,
+    void PvtDeadSpline::initFromOil(const TableContainer& pvdoTables,
                                     int numSamples)
     {
         int numRegions = pvdoTables.size();
@@ -48,7 +48,7 @@ namespace Opm
         viscosity_.resize(numRegions);
 
         for (int regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
-            const Opm::PvdoTable& pvdoTable = pvdoTables[regionIdx];
+            const Opm::PvdoTable& pvdoTable = pvdoTables.getTable<PvdoTable>(regionIdx);
 
             int numRows = pvdoTable.numRows();
 
@@ -67,7 +67,7 @@ namespace Opm
         }
     }
 
-    void PvtDeadSpline::initFromGas(const std::vector<Opm::PvdgTable>& pvdgTables,
+    void PvtDeadSpline::initFromGas(const TableContainer& pvdgTables,
                                     int numSamples)
     {
         int numRegions = pvdgTables.size();
@@ -77,7 +77,7 @@ namespace Opm
         viscosity_.resize(numRegions);
 
         for (int regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
-            const Opm::PvdgTable& pvdgTable = pvdgTables[regionIdx];
+            const Opm::PvdgTable& pvdgTable = pvdgTables.getTable<PvdgTable>(regionIdx);
 
             int numRows = pvdgTable.numRows();
 

--- a/opm/core/props/pvt/PvtDeadSpline.hpp
+++ b/opm/core/props/pvt/PvtDeadSpline.hpp
@@ -24,6 +24,7 @@
 #include <opm/core/utility/UniformTableLinear.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp>
 
 #include <vector>
 
@@ -42,9 +43,9 @@ namespace Opm
     public:
         PvtDeadSpline();
 
-        void initFromOil(const std::vector<Opm::PvdoTable>& pvdoTables,
+        void initFromOil(const TableContainer& pvdoTables,
                          int numSamples);
-        void initFromGas(const std::vector<Opm::PvdgTable>& pvdgTables,
+        void initFromGas(const TableContainer& pvdgTables,
                          int numSamples);
 
         virtual ~PvtDeadSpline();

--- a/opm/core/props/pvt/ThermalGasPvtWrapper.hpp
+++ b/opm/core/props/pvt/ThermalGasPvtWrapper.hpp
@@ -102,8 +102,14 @@ namespace Opm
                     // pressure dependence of gas. (This does not make much sense, but it
                     // seems to be what the documentation for the GASVISCT keyword in the
                     // RM says.)
+
+
                     int regionIdx = getPvtRegionIndex_(pvtRegionIdx, i);
-                    double muGasvisct = (*gasvisctTables_)[regionIdx].evaluate(gasvisctColumnName_, T[i]);
+                    double muGasvisct;
+                    {
+                        const GasvisctTable& gasvisctTable = gasvisctTables_->getTable<GasvisctTable>(regionIdx);
+                        muGasvisct = gasvisctTable.evaluate(gasvisctColumnName_, T[i]);
+                    }
 
                     output_mu[i] = muGasvisct;
                     output_dmudp[i] = 0.0;
@@ -136,7 +142,11 @@ namespace Opm
                     // seems to be what the documentation for the GASVISCT keyword in the
                     // RM says.)
                     int regionIdx = getPvtRegionIndex_(pvtRegionIdx, i);
-                    double muGasvisct = (*gasvisctTables_)[regionIdx].evaluate(gasvisctColumnName_, T[i]);
+                    double muGasvisct;
+                    {
+                        const GasvisctTable& gasvisctTable = gasvisctTables_->getTable<GasvisctTable>(regionIdx);
+                        muGasvisct = gasvisctTable.evaluate(gasvisctColumnName_, T[i]);
+                    }
 
                     output_mu[i] = muGasvisct;
                     output_dmudp[i] = 0.0;
@@ -297,7 +307,7 @@ namespace Opm
 
         // The PVT properties needed for temperature dependence of the viscosity. We need
         // to store one value per PVT region.
-        const std::vector<Opm::GasvisctTable>* gasvisctTables_;
+        const TableContainer* gasvisctTables_;
         std::string gasvisctColumnName_;
         int gasCompIdx_;
 

--- a/opm/core/props/pvt/ThermalOilPvtWrapper.hpp
+++ b/opm/core/props/pvt/ThermalOilPvtWrapper.hpp
@@ -147,8 +147,12 @@ namespace Opm
                 double muRef = muRef_[regionIdx];
 
                 // compute the viscosity deviation due to temperature
-                double muOilvisct = (*oilvisctTables_)[regionIdx].evaluate("Viscosity", T[i]);
-                double alpha = muOilvisct/muRef;
+                double alpha;
+                {
+                    const OilvisctTable& oilvisctTable = oilvisctTables_->getTable<OilvisctTable>(regionIdx);
+                    double muOilvisct = oilvisctTable.evaluate("Viscosity", T[i]);
+                    alpha = muOilvisct/muRef;
+                }
 
                 output_mu[i] *= alpha;
                 output_dmudp[i] *= alpha;
@@ -183,9 +187,12 @@ namespace Opm
                 double muRef = muRef_[regionIdx];
 
                 // compute the viscosity deviation due to temperature
-                double muOilvisct = (*oilvisctTables_)[regionIdx].evaluate("Viscosity", T[i]);
-                double alpha = muOilvisct/muRef;
-
+                double alpha;
+                {
+                    const OilvisctTable& oilvisctTable = oilvisctTables_->getTable<OilvisctTable>(regionIdx);
+                    double muOilvisct = oilvisctTable.evaluate("Viscosity", T[i]);
+                    alpha = muOilvisct/muRef;
+                }
                 output_mu[i] *= alpha;
                 output_dmudp[i] *= alpha;
                 output_dmudr[i] *= alpha;
@@ -367,7 +374,7 @@ namespace Opm
         std::vector<double> viscrefRs_;
         std::vector<double> muRef_;
 
-        const std::vector<Opm::OilvisctTable>* oilvisctTables_;
+        const TableContainer* oilvisctTables_;
 
         // The PVT properties needed for temperature dependence of the density. This is
         // specified as one value per EOS in the manual, but we unconditionally use the

--- a/opm/core/props/pvt/ThermalWaterPvtWrapper.hpp
+++ b/opm/core/props/pvt/ThermalWaterPvtWrapper.hpp
@@ -142,8 +142,12 @@ namespace Opm
                 double muRef = pvtwViscosity_[tableIdx]/(1.0 + x + 0.5*x*x);
 
                 // compute the viscosity deviation due to temperature
-                double muWatvisct = (*watvisctTables_)[tableIdx].evaluate("Viscosity", T[i]);
-                double alpha = muWatvisct/muRef;
+                double alpha;
+                {
+                    const WatvisctTable& watVisctTable = watvisctTables_->getTable<WatvisctTable>(tableIdx);
+                    double muWatvisct = watVisctTable.evaluate("Viscosity", T[i]);
+                    alpha = muWatvisct/muRef;
+                }
 
                 output_mu[i] *= alpha;
                 output_dmudp[i] *= alpha;
@@ -179,9 +183,12 @@ namespace Opm
                 double muRef = pvtwViscosity_[tableIdx]/(1.0 + x + 0.5*x*x);
 
                 // compute the viscosity deviation due to temperature
-                double muWatvisct = (*watvisctTables_)[tableIdx].evaluate("Viscosity", T[i]);
-                double alpha = muWatvisct/muRef;
-
+                double alpha;
+                {
+                    const WatvisctTable& watVisctTable = watvisctTables_->getTable<WatvisctTable>(tableIdx);
+                    double muWatvisct = watVisctTable.evaluate("Viscosity", T[i]);
+                    alpha = muWatvisct/muRef;
+                }
                 output_mu[i] *= alpha;
                 output_dmudp[i] *= alpha;
                 output_dmudr[i] *= alpha;
@@ -382,7 +389,7 @@ namespace Opm
         std::vector<double> pvtwViscosity_;
         std::vector<double> pvtwViscosibility_;
 
-        const std::vector<Opm::WatvisctTable>* watvisctTables_;
+        const TableContainer* watvisctTables_;
     };
 
 }

--- a/opm/core/props/rock/RockCompressibility.cpp
+++ b/opm/core/props/rock/RockCompressibility.cpp
@@ -46,12 +46,13 @@ namespace Opm
         const auto tables = eclipseState->getTableManager();
         const auto& rocktabTables = tables->getRocktabTables();
         if (rocktabTables.size() > 0) {
+            const auto& rocktabTable = rocktabTables.getTable<RocktabTable>(0);
             if (rocktabTables.size() != 1)
                 OPM_THROW(std::runtime_error, "Can only handle a single region in ROCKTAB.");
 
-            p_ = rocktabTables[0].getPressureColumn();
-            poromult_ = rocktabTables[0].getPoreVolumeMultiplierColumn();
-            transmult_ =  rocktabTables[0].getTransmissibilityMultiplierColumn();
+            p_ = rocktabTable.getPressureColumn();
+            poromult_ = rocktabTable.getPoreVolumeMultiplierColumn();
+            transmult_ =  rocktabTable.getTransmissibilityMultiplierColumn();
         } else if (deck->hasKeyword("ROCK")) {
             Opm::DeckKeywordConstPtr rockKeyword = deck->getKeyword("ROCK");
             if (rockKeyword->size() != 1) {

--- a/opm/core/simulator/initStateEquil.hpp
+++ b/opm/core/simulator/initStateEquil.hpp
@@ -288,15 +288,17 @@ namespace Opm
                     // Create Rs functions.
                     rs_func_.reserve(rec.size());
                     if (deck->hasKeyword("DISGAS")) {                    
-                        const std::vector<RsvdTable>& rsvdTables = tables->getRsvdTables();
+                        const TableContainer& rsvdTables = tables->getRsvdTables();
                         for (size_t i = 0; i < rec.size(); ++i) {
+                            const RsvdTable& rsvdTable = rsvdTables.getTable<RsvdTable>(i);
                             const int cell = *(eqlmap.cells(i).begin());                   
                             if (rec[i].live_oil_table_index > 0) {
                                 if (rsvdTables.size() > 0 && size_t(rec[i].live_oil_table_index) <= rsvdTables.size()) { 
+                                    
                                     rs_func_.push_back(std::make_shared<Miscibility::RsVD>(props,
                                                                                            cell,
-                                                                                           rsvdTables[i].getDepthColumn(),
-                                                                                           rsvdTables[i].getRsColumn()));
+                                                                                           rsvdTable.getDepthColumn(),
+                                                                                           rsvdTable.getRsColumn()));
                                 } else {
                                     OPM_THROW(std::runtime_error, "Cannot initialise: RSVD table " << (rec[i].live_oil_table_index) << " not available.");
                                 }
@@ -320,15 +322,16 @@ namespace Opm
 
                     rv_func_.reserve(rec.size());
                     if (deck->hasKeyword("VAPOIL")) {                    
-                        const std::vector<RvvdTable>& rvvdTables = tables->getRvvdTables();
+                        const TableContainer& rvvdTables = tables->getRvvdTables();
                         for (size_t i = 0; i < rec.size(); ++i) {
                             const int cell = *(eqlmap.cells(i).begin());                   
                             if (rec[i].wet_gas_table_index > 0) {
                                 if (rvvdTables.size() > 0 && size_t(rec[i].wet_gas_table_index) <= rvvdTables.size()) { 
+                                    const RvvdTable& rvvdTable = rvvdTables.getTable<RvvdTable>(i);
                                     rv_func_.push_back(std::make_shared<Miscibility::RvVD>(props,
                                                                                            cell,
-                                                                                           rvvdTables[i].getDepthColumn(),
-                                                                                           rvvdTables[i].getRvColumn()));
+                                                                                           rvvdTable.getDepthColumn(),
+                                                                                           rvvdTable.getRvColumn()));
                                 } else {
                                     OPM_THROW(std::runtime_error, "Cannot initialise: RVVD table " << (rec[i].wet_gas_table_index) << " not available.");
                                 }


### PR DESCRIPTION
Followup to: https://github.com/OPM/opm-parser/pull/585

Comments are welcome - but this should *not* be merged before the opm-parser PR is merged.

With this PR the `DeckWithLiveOil` test in `test_equil.cpp` fails. To me it seems that the test should have failed all along, but that out of bounds access to the previous `std::vector<RsvdTable>` implementation failed silently?  