### PR TITLE
WARN instead of THROW if completion is not found in the grid

### DIFF
--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -159,8 +159,9 @@ void WellsManager::createWellsFromSpecs(std::vector<WellConstPtr>& wells, size_t
                         }
                         else
                         {
-                            OPM_THROW(std::runtime_error, "Cell with i,j,k indices " << i << ' ' << j << ' '
-                                      << k << " not found in grid (well = " << well->name() << ')');
+                            OPM_MESSAGE("****Warning: Cell with i,j,k indices " << i << ' ' << j << ' '
+                                      << k << " not found in grid. The completion will be igored (well = "
+                                      << well->name() << ')');
                         }
                     }
                     else


### PR DESCRIPTION
Completions that are not found in the grid are ignored. 

This is a necessary fix to make Model 2 run. 
