### PR TITLE
Prevent WellsManager from subscripting empty container.

### DIFF
--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -289,8 +289,8 @@ void WellsManager::createWellsFromSpecs(std::vector<WellConstPtr>& wells, size_t
                      well_data[w].reference_bhp_depth,
                      w_num_perf,
                      comp_frac,
-                     & perf_cells  [0],
-                     & perf_prodind[0],
+                     perf_cells.data(),
+                     perf_prodind.data(),
                      well_names[w].c_str(),
                      w_);
 


### PR DESCRIPTION
While hopefully not a bug it raises an exception with gcc's
libc debugging mode. Therefore we resort to using C++11's
std::vector::data instead.

The exception was raised when running SPE9 in parallel.