### PR TITLE
Add boolean flag to determine whether crossflow is allowed in a well

### DIFF
--- a/opm/core/wells.h
+++ b/opm/core/wells.h
@@ -106,6 +106,11 @@ struct Wells
      * Internal management structure.
      */
     void *data;
+
+    /**
+     * Array of booleans, if true crossflow is allowed in the well.
+     */
+    bool *allow_cf;
 };
 
 
@@ -185,6 +190,7 @@ create_wells(int nphases, int nwells, int nperf);
  *                       ideally be track ordered.
  * \param[in] WI         Well production index per perforation, or NULL.
  * \param[in] name       Name of new well. NULL if no name.
+ * \param[in] allow_cf   Boolean flag to determine whether crossflow is allowed or not.
  * \param[in,out] W      Existing set of wells to which new well will
  *                       be added.
  *
@@ -198,6 +204,7 @@ add_well(enum WellType  type     ,
          const int     *cells    ,
          const double  *WI       ,
          const char    *name     ,
+         bool           allow_cf ,
          struct Wells  *W        );
 
 

--- a/opm/core/wells.h
+++ b/opm/core/wells.h
@@ -103,14 +103,16 @@ struct Wells
     char **name;
 
     /**
+     * Array of flags indicating whether crossflow is allowed or not
+     * if allow_cf[w] == 0 (false) then crossflow is not allowed in well w.
+     */
+    int *allow_cf;
+
+    /**
      * Internal management structure.
      */
     void *data;
 
-    /**
-     * Array of booleans, if true crossflow is allowed in the well.
-     */
-    bool *allow_cf;
 };
 
 
@@ -190,7 +192,7 @@ create_wells(int nphases, int nwells, int nperf);
  *                       ideally be track ordered.
  * \param[in] WI         Well production index per perforation, or NULL.
  * \param[in] name       Name of new well. NULL if no name.
- * \param[in] allow_cf   Boolean flag to determine whether crossflow is allowed or not.
+ * \param[in] allow_cf   Flag to determine whether crossflow is allowed or not.
  * \param[in,out] W      Existing set of wells to which new well will
  *                       be added.
  *
@@ -204,7 +206,7 @@ add_well(enum WellType  type     ,
          const int     *cells    ,
          const double  *WI       ,
          const char    *name     ,
-         bool           allow_cf ,
+         int            allow_cf ,
          struct Wells  *W        );
 
 

--- a/opm/core/wells/WellsManager.hpp
+++ b/opm/core/wells/WellsManager.hpp
@@ -38,6 +38,7 @@ namespace Opm
     struct WellData
     {
         WellType type;
+        bool allowCrossFlow;
         // WellControlType control;
         // double target;
         double reference_bhp_depth;

--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -248,11 +248,7 @@ void WellsManager::createWellsFromSpecs(std::vector<WellConstPtr>& wells, size_t
                 else
                     wd.type = PRODUCER;
 
-                if (well->getAllowCrossFlow()) {
-                    wd.allowCrossFlow = true;
-                } else {
-                    wd.allowCrossFlow = false;
-                }
+                wd.allowCrossFlow = well->getAllowCrossFlow();
                 well_data.push_back(wd);
             }
         }

--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -247,6 +247,12 @@ void WellsManager::createWellsFromSpecs(std::vector<WellConstPtr>& wells, size_t
                     wd.type = INJECTOR;
                 else
                     wd.type = PRODUCER;
+
+                if (well->getAllowCrossFlow()) {
+                    wd.allowCrossFlow = true;
+                } else {
+                    wd.allowCrossFlow = false;
+                }
                 well_data.push_back(wd);
             }
         }
@@ -293,6 +299,7 @@ void WellsManager::createWellsFromSpecs(std::vector<WellConstPtr>& wells, size_t
                      perf_cells.data(),
                      perf_prodind.data(),
                      well_names[w].c_str(),
+                     well_data[w].allowCrossFlow,
                      w_);
 
         if (!ok) {

--- a/opm/core/wells/wells.c
+++ b/opm/core/wells/wells.c
@@ -85,7 +85,7 @@ wells_allocate(int nwells, struct Wells *W)
     void *type, *depth_ref, *comp_frac;
     void *well_connpos;
     void *ctrls, *name;
-    bool *allow_cf;
+    void *allow_cf;
 
     np = W->number_of_phases;
 
@@ -146,7 +146,7 @@ initialise_new_wells(int nwells, struct Wells *W)
         W->type     [w]        = PRODUCER;
         W->depth_ref[w]        = -1.0;
         W->name     [w]        = NULL;
-        W->allow_cf [w]        = false;
+        W->allow_cf [w]        = 1;
 
         for (p = 0; p < W->number_of_phases; ++p) {
             W->comp_frac[W->number_of_phases*w + p] = 0.0;
@@ -278,7 +278,7 @@ create_wells(int nphases, int nwells, int nperf)
 
         W->ctrls           = NULL;
         W->name            = NULL;
-        W->allow_cf        = false;
+        W->allow_cf        = NULL;
 
         W->data            = create_well_mgmt();
 
@@ -364,7 +364,7 @@ add_well(enum WellType  type     ,
          const int     *cells    ,
          const double  *WI       , /* Well index per perf (or NULL) */
          const char    *name     , /* Well name (or NULL) */
-         bool           allow_cf ,
+         int            allow_cf ,
          struct Wells  *W        )
 /* ---------------------------------------------------------------------- */
 {

--- a/tests/test_wells.cpp
+++ b/tests/test_wells.cpp
@@ -56,11 +56,11 @@ BOOST_AUTO_TEST_CASE(Construction)
         const double ifrac[] = { 1.0, 0.0 };
 
         const bool ok0 = add_well(INJECTOR, 0.0, 1, &ifrac[0], &cells[0],
-                                  &WI, "INJECTOR", W.get());
+                                  &WI, "INJECTOR", true, W.get());
 
         const double pfrac[] = { 0.0, 0.0 };
         const bool ok1 = add_well(PRODUCER, 0.0, 1, &pfrac[0], &cells[1],
-                                  &WI, "PRODUCER", W.get());
+                                  &WI, "PRODUCER", true, W.get());
 
         if (ok0 && ok1) {
             BOOST_CHECK_EQUAL(W->number_of_phases, nphases);
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(Controls)
         const double ifrac[] = { 1.0, 0.0 };
 
         const bool ok = add_well(INJECTOR, 0.0, nperfs, &ifrac[0], &cells[0],
-                                 &WI[0], "INJECTOR", W.get());
+                                 &WI[0], "INJECTOR", true, W.get());
 
         if (ok) {
             const double distr[] = { 1.0, 0.0 };
@@ -151,11 +151,11 @@ BOOST_AUTO_TEST_CASE(Copy)
         const double ifrac[] = { 1.0, 0.0 };
 
         const bool ok0 = add_well(INJECTOR, 0.0, 1, &ifrac[0], &cells[0],
-                                  &WI, "INJECTOR", W1.get());
+                                  &WI, "INJECTOR", true, W1.get());
 
         const double pfrac[] = { 0.0, 0.0 };
         const bool ok1 = add_well(PRODUCER, 0.0, 1, &pfrac[0], &cells[1],
-                                  &WI, "PRODUCER", W1.get());
+                                  &WI, "PRODUCER", true, W1.get());
 
         bool ok = ok0 && ok1;
         for (int w = 0; ok && (w < W1->number_of_wells); ++w) {

--- a/tutorials/tutorial4.cpp
+++ b/tutorials/tutorial4.cpp
@@ -319,8 +319,9 @@ try
         const double well_index = 1;
         std::stringstream well_name;
         well_name << "well" << i;
+        bool allowCrossFlow = true;
         add_well(PRODUCER, 0, 1, NULL, &well_cells, &well_index,
-                 well_name.str().c_str(), wells);
+                 well_name.str().c_str(), allowCrossFlow, wells);
     }
     /// \internal[well cells]
     /// \endinternal


### PR DESCRIPTION
This PR adds allow_cf to the wells structure that determine whether
crossflow is allowed or not. An extra argument is added to addWell(..)
to specify the allow_cf flag.

Should be considered together with OPM/opm-parser#600

@bska I would appreciate if you could take a look at this. I still feel shaky whenever I touching the wells in opm-core.  