### PR TITLE
Renamed memcmp_double -> opm_memcmp_double

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -131,7 +131,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/core/utility/VelocityInterpolation.cpp
 	opm/core/utility/WachspressCoord.cpp
 	opm/core/utility/miscUtilities.cpp
-       opm/core/utility/memcmp_double.c
+       opm/core/utility/opm_memcmp_double.c
 	opm/core/utility/miscUtilitiesBlackoil.cpp
 	opm/core/utility/NullStream.cpp
 	opm/core/utility/parameters/Parameter.cpp
@@ -424,7 +424,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/core/utility/Exceptions.hpp
 	opm/core/utility/Factory.hpp
 	opm/core/utility/MonotCubicInterpolator.hpp
-	opm/core/utility/memcmp_double.h
+	opm/core/utility/opm_memcmp_double.h
 	opm/core/utility/NonuniformTableLinear.hpp
 	opm/core/utility/NullStream.hpp
 	opm/core/utility/RegionMapping.hpp

--- a/opm/core/grid/grid.c
+++ b/opm/core/grid/grid.c
@@ -19,7 +19,7 @@
 
 #include "config.h"
 #include <opm/core/grid.h>
-#include <opm/core/utility/memcmp_double.h>
+#include <opm/core/utility/opm_memcmp_double.h>
 
 #include <assert.h>
 #include <errno.h>
@@ -585,22 +585,22 @@ grid_equal(const struct UnstructuredGrid * grid1 , const struct UnstructuredGrid
         
         // Floating point comparisons.
         {
-            if (memcmp_double( grid1->node_coordinates , grid2->node_coordinates , grid1->dimensions * grid1->number_of_nodes) != 0)
+            if (opm_memcmp_double( grid1->node_coordinates , grid2->node_coordinates , grid1->dimensions * grid1->number_of_nodes) != 0)
                 return false;
             
-            if (memcmp_double( grid1->face_centroids , grid2->face_centroids , grid1->dimensions * grid1->number_of_faces) != 0)
+            if (opm_memcmp_double( grid1->face_centroids , grid2->face_centroids , grid1->dimensions * grid1->number_of_faces) != 0)
                 return false;
             
-            if (memcmp_double( grid1->face_areas , grid2->face_areas , grid1->number_of_faces) != 0)
+            if (opm_memcmp_double( grid1->face_areas , grid2->face_areas , grid1->number_of_faces) != 0)
                 return false;
             
-            if (memcmp_double( grid1->face_normals , grid2->face_normals , grid1->dimensions * grid1->number_of_faces) != 0)
+            if (opm_memcmp_double( grid1->face_normals , grid2->face_normals , grid1->dimensions * grid1->number_of_faces) != 0)
                 return false;
             
-            if (memcmp_double( grid1->cell_centroids , grid2->cell_centroids , grid1->dimensions * grid1->number_of_cells) != 0)
+            if (opm_memcmp_double( grid1->cell_centroids , grid2->cell_centroids , grid1->dimensions * grid1->number_of_cells) != 0)
                 return false;
             
-            if (memcmp_double( grid1->cell_volumes , grid2->cell_volumes , grid1->number_of_cells) != 0)
+            if (opm_memcmp_double( grid1->cell_volumes , grid2->cell_volumes , grid1->number_of_cells) != 0)
                 return false;
         }
         return true;

--- a/opm/core/utility/opm_memcmp_double.c
+++ b/opm/core/utility/opm_memcmp_double.c
@@ -8,7 +8,7 @@
    http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
 */
 
-int memcmp_double(const double * p1 , const double *p2 , size_t num_elements) {
+int opm_memcmp_double(const double * p1 , const double *p2 , size_t num_elements) {
     if (memcmp(p1 , p2 , num_elements * sizeof * p1) == 0)
         return 0;
     else {

--- a/opm/core/utility/opm_memcmp_double.h
+++ b/opm/core/utility/opm_memcmp_double.h
@@ -4,15 +4,15 @@
   otherwise it will return 1.
 */
 
-#ifndef MEMCMP_DOUBLE_H
-#define MEMCMP_DOUBLE_H
+#ifndef OPM_MEMCMP_DOUBLE_H
+#define OPM_MEMCMP_DOUBLE_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 
-int memcmp_double(const double * p1 , const double *p2 , size_t num_elements);
+int opm_memcmp_double(const double * p1 , const double *p2 , size_t num_elements);
 
 
 #ifdef __cplusplus

--- a/tests/test_ug.cpp
+++ b/tests/test_ug.cpp
@@ -19,7 +19,7 @@
 #include <algorithm>
 #include <vector>
 #include <opm/core/grid.h>
-#include <opm/core/utility/memcmp_double.h>
+#include <opm/core/utility/opm_memcmp_double.h>
 #include <opm/core/grid/cornerpoint_grid.h>  /* compute_geometry */
 #include <opm/core/grid/GridManager.hpp>  /* compute_geometry */
 #include <opm/core/grid/cpgpreprocess/preprocess.h>
@@ -177,54 +177,54 @@ BOOST_AUTO_TEST_CASE(compare_double) {
     {
         v1 = 0.0;
         v2 = 0.0;
-        BOOST_CHECK_EQUAL( memcmp_double( &v1 , &v2 , 1 ) , 0 );
+        BOOST_CHECK_EQUAL( opm_memcmp_double( &v1 , &v2 , 1 ) , 0 );
 
         v1 = 1e-12;
         v2 = v1 + 0.5*abs_epsilon;
-        BOOST_CHECK_EQUAL( memcmp_double( &v1 , &v2 , 1 ) , 0 );
+        BOOST_CHECK_EQUAL( opm_memcmp_double( &v1 , &v2 , 1 ) , 0 );
 
         v1 = 7.0;
         v2 = 7.0;
-        BOOST_CHECK_EQUAL( memcmp_double( &v1 , &v2 , 1 ) , 0 );
+        BOOST_CHECK_EQUAL( opm_memcmp_double( &v1 , &v2 , 1 ) , 0 );
 
         v1 = -7.0;
         v2 = -7.0;
-        BOOST_CHECK_EQUAL( memcmp_double( &v1 , &v2 , 1 ) , 0 );
+        BOOST_CHECK_EQUAL( opm_memcmp_double( &v1 , &v2 , 1 ) , 0 );
 
         v1 = 0;
         v2 = 0.5 * abs_epsilon;
-        BOOST_CHECK_EQUAL( memcmp_double( &v1 , &v2 , 1 ) , 0 );
+        BOOST_CHECK_EQUAL( opm_memcmp_double( &v1 , &v2 , 1 ) , 0 );
 
 
         v1 = 1e7;
         v2 = 1e7 + 2*abs_epsilon;
-        BOOST_CHECK_EQUAL( memcmp_double( &v1 , &v2 , 1 ) , 0 );
+        BOOST_CHECK_EQUAL( opm_memcmp_double( &v1 , &v2 , 1 ) , 0 );
 
         v1 = 1e7;
         v2 = 1e7*(1 + 2*rel_epsilon);
-        BOOST_CHECK_EQUAL( memcmp_double( &v1 , &v2 , 1 ) , 0 );
+        BOOST_CHECK_EQUAL( opm_memcmp_double( &v1 , &v2 , 1 ) , 0 );
     }
 
     /* Should be different: */
     {
         v1 = 0;
         v2 = 1.5 * abs_epsilon;
-        BOOST_CHECK_EQUAL( memcmp_double( &v1 , &v2 , 1 ) , 1 );
+        BOOST_CHECK_EQUAL( opm_memcmp_double( &v1 , &v2 , 1 ) , 1 );
 
         v1 = 1e-8;
         v2 = v1 + 1.5*abs_epsilon;
-        BOOST_CHECK_EQUAL( memcmp_double( &v1 , &v2 , 1 ) , 1 );
+        BOOST_CHECK_EQUAL( opm_memcmp_double( &v1 , &v2 , 1 ) , 1 );
 
         v1 = 1;
         v2 = v1*(1 + 2*rel_epsilon + abs_epsilon);
-        BOOST_CHECK_EQUAL( memcmp_double( &v1 , &v2 , 1 ) , 1 );
+        BOOST_CHECK_EQUAL( opm_memcmp_double( &v1 , &v2 , 1 ) , 1 );
 
         v1 = 10;
         v2 = v1*(1 + 2*rel_epsilon + abs_epsilon);
-        BOOST_CHECK_EQUAL( memcmp_double( &v1 , &v2 , 1 ) , 1 );
+        BOOST_CHECK_EQUAL( opm_memcmp_double( &v1 , &v2 , 1 ) , 1 );
 
         v1 = 1e7;
         v2 = 1e7*(1 + 2*rel_epsilon + abs_epsilon);
-        BOOST_CHECK_EQUAL( memcmp_double( &v1 , &v2 , 1 ) , 1 );
+        BOOST_CHECK_EQUAL( opm_memcmp_double( &v1 , &v2 , 1 ) , 1 );
     }
 }


### PR DESCRIPTION
The prefix `mem` is supposedly reserved for standard functions.