### PR TITLE
Fix timestep bug

### DIFF
--- a/opm/core/io/eclipse/EclipseWriteRFTHandler.cpp
+++ b/opm/core/io/eclipse/EclipseWriteRFTHandler.cpp
@@ -60,7 +60,7 @@ namespace EclipseWriterDetails {
         std::vector<ecl_rft_node_type *> rft_nodes;
         for (std::vector<WellConstPtr>::const_iterator ci = wells.begin(); ci != wells.end(); ++ci) {
             WellConstPtr well = *ci;
-            if ((well->getRFTActive(simulatorTimer.currentStepNum())) || (well->getPLTActive(simulatorTimer.currentStepNum()))) {
+            if ((well->getRFTActive(simulatorTimer.reportStepNum())) || (well->getPLTActive(simulatorTimer.reportStepNum()))) {
                 ecl_rft_node_type * ecl_node = createEclRFTNode(well,
                                                                  simulatorTimer,
                                                                  eclipseGrid,
@@ -70,7 +70,7 @@ namespace EclipseWriterDetails {
 
                 // TODO: replace this silenced warning with an appropriate
                 //       use of the OpmLog facilities.
-                // if (well->getPLTActive(simulatorTimer.currentStepNum())) {
+                // if (well->getPLTActive(simulatorTimer.reportStepNum())) {
                 //     std::cerr << "PLT not supported, writing RFT data" << std::endl;
                 // }
 
@@ -99,7 +99,7 @@ namespace EclipseWriterDetails {
 
 
         const std::string& well_name      = well->name();
-        size_t             timestep       = (size_t)simulatorTimer.currentStepNum();
+        size_t             timestep       = (size_t)simulatorTimer.reportStepNum();
         time_t             recording_date = simulatorTimer.currentPosixTime();
         double             days           = Opm::unit::convert::to(simulatorTimer.simulationTimeElapsed(), Opm::unit::day);
 

--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -1356,7 +1356,7 @@ void EclipseWriter::writeTimeStep(const SimulatorTimerInterface& timer,
                                                       0);
         std::shared_ptr<const UnitSystem> unitsystem = eclipseState_->getDeckUnitSystem();
         ert_ecl_unit_enum ecl_unit = convertUnitTypeErtEclUnitEnum(unitsystem->getType());
-        std::vector<WellConstPtr> wells = eclipseState_->getSchedule()->getWells(timer.currentStepNum());
+        std::vector<WellConstPtr> wells = eclipseState_->getSchedule()->getWells(timer.reportStepNum());
         eclipseWriteRFTHandler->writeTimeStep(rft_filename,
                                               ecl_unit,
                                               timer,

--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -1347,32 +1347,26 @@ void EclipseWriter::writeTimeStep(const SimulatorTimerInterface& timer,
                                                                                                                       numCells_,
                                                                                                                       eclipseState_->getEclipseGrid()->getCartesianSize());
 
-
-    char * rft_filename = ecl_util_alloc_filename(outputDir_.c_str(),
-                                                  baseName_.c_str(),
-                                                  ECL_RFT_FILE,
-                                                  ioConfig->getFMTOUT(),
-                                                  0);
-
-    std::shared_ptr<const UnitSystem> unitsystem = eclipseState_->getDeckUnitSystem();
-    ert_ecl_unit_enum ecl_unit = convertUnitTypeErtEclUnitEnum(unitsystem->getType());
-
-    std::vector<WellConstPtr> wells = eclipseState_->getSchedule()->getWells(timer.currentStepNum());
-
-
-    eclipseWriteRFTHandler->writeTimeStep(rft_filename,
-                                          ecl_unit,
-                                          timer,
-                                          wells,
-                                          eclipseState_->getEclipseGrid(),
-                                          pressure,
-                                          saturation_water,
-                                          saturation_gas);
-
-
-
-    free( rft_filename );
-
+    // Write RFT file.
+    {
+        char * rft_filename = ecl_util_alloc_filename(outputDir_.c_str(),
+                                                      baseName_.c_str(),
+                                                      ECL_RFT_FILE,
+                                                      ioConfig->getFMTOUT(),
+                                                      0);
+        std::shared_ptr<const UnitSystem> unitsystem = eclipseState_->getDeckUnitSystem();
+        ert_ecl_unit_enum ecl_unit = convertUnitTypeErtEclUnitEnum(unitsystem->getType());
+        std::vector<WellConstPtr> wells = eclipseState_->getSchedule()->getWells(timer.currentStepNum());
+        eclipseWriteRFTHandler->writeTimeStep(rft_filename,
+                                              ecl_unit,
+                                              timer,
+                                              wells,
+                                              eclipseState_->getEclipseGrid(),
+                                              pressure,
+                                              saturation_water,
+                                              saturation_gas);
+        free( rft_filename );
+    }
 
     /* Summary variables (well reporting) */
     // TODO: instead of writing the header (smspec) every time, it should


### PR DESCRIPTION
The currentStepNum() method was used (wrongly) instead of reportStepNum() in the RFT-related parts of EclipseWriter and in EclipseWriteRFTHandler.

Also improved formatting in that part of the EclipseWriter (separate commit).

@joakim-hove I have assigned you to review/merge this.