### PR TITLE
fix Equilibration test by adding some fuzz

### DIFF
--- a/opm/core/simulator/EquilibrationHelpers.hpp
+++ b/opm/core/simulator/EquilibrationHelpers.hpp
@@ -350,7 +350,7 @@ namespace Opm
                            const double temp,
                            const double sat_oil = 0.0 ) const
                 {
-                    if (sat_oil > 0.0) {
+                    if (std::abs(sat_oil) > 1e-16) {
                         return satRv(press, temp);
                     } else {
                         return std::min(satRv(press, temp), linearInterpolation(depth_, rv_, depth));


### PR DESCRIPTION
Backports parts of a7b1e69a45c14ec88a82b92ee704424f1ea1b41c

This breaks 'test_equil' on other archs as round-off causes the different branch to be taken, thus altering application behavior significantly.