### PR TITLE
[bugfix] Fixes copyOwnerToAll.

### DIFF
--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -144,8 +144,9 @@ public:
     void copyOwnerToAll (const T& source, T& dest) const
     {
         typedef Dune::Combine<Dune::EnumItem<Dune::OwnerOverlapCopyAttributeSet::AttributeSet,Dune::OwnerOverlapCopyAttributeSet::owner>,Dune::EnumItem<Dune::OwnerOverlapCopyAttributeSet::AttributeSet,Dune::OwnerOverlapCopyAttributeSet::overlap>,Dune::OwnerOverlapCopyAttributeSet::AttributeSet> OwnerOverlapSet;
+        typedef Dune::EnumItem<Dune::OwnerOverlapCopyAttributeSet::AttributeSet,Dune::OwnerOverlapCopyAttributeSet::owner> OwnerSet;
         typedef Dune::Combine<OwnerOverlapSet, Dune::EnumItem<Dune::OwnerOverlapCopyAttributeSet::AttributeSet,Dune::OwnerOverlapCopyAttributeSet::copy>,Dune::OwnerOverlapCopyAttributeSet::AttributeSet> AllSet;
-      OwnerOverlapSet sourceFlags;
+      OwnerSet sourceFlags;
       AllSet destFlags;
       Dune::Interface interface(communicator_);
       if( !remoteIndices_->isSynced() )


### PR DESCRIPTION
Previously, we copied owner/overlap to all which is clearly wrong.
Now we copy from owner to all as the function name says.

As this is a bugfix and it would make sense to include it in the release.