### PR TITLE
Allow the rock properties to be zero initialized without a deck.

### DIFF
--- a/opm/core/props/rock/RockFromDeck.cpp
+++ b/opm/core/props/rock/RockFromDeck.cpp
@@ -72,6 +72,13 @@ namespace Opm
     {
     }
 
+    RockFromDeck::RockFromDeck(std::size_t number_of_cells)
+        : porosity_(number_of_cells, 0),
+          permeability_(number_of_cells*9, 0.0),
+          permfield_valid_(number_of_cells, false)
+    {
+    }
+
     void RockFromDeck::init(Opm::EclipseStateConstPtr eclState,
                             int number_of_cells, const int* global_cell,
                             const int* cart_dims)

--- a/opm/core/props/rock/RockFromDeck.cpp
+++ b/opm/core/props/rock/RockFromDeck.cpp
@@ -74,6 +74,7 @@ namespace Opm
 
     RockFromDeck::RockFromDeck(std::size_t number_of_cells)
         : porosity_(number_of_cells, 0),
+          // full permeability tensor in 3D stores 9 scalars
           permeability_(number_of_cells*9, 0.0),
           permfield_valid_(number_of_cells, false)
     {

--- a/opm/core/props/rock/RockFromDeck.hpp
+++ b/opm/core/props/rock/RockFromDeck.hpp
@@ -31,10 +31,16 @@ namespace Opm
 
     class RockFromDeck
     {
+        // BlackoilPropsDataHandle needs mutable
+        // access to porosity and permeability
+        friend class BlackoilPropsDataHandle;
+
     public:
         /// Default constructor.
         RockFromDeck();
-
+        /// Creates rock properties with zero porosity and permeability
+        /// \param number_of_cells The number of cells
+        RockFromDeck(std::size_t number_of_cells);
         /// Initialize from deck and cell mapping.
         /// \param  eclState        The EclipseState (processed deck) produced by the opm-parser code
         /// \param  number_of_cells The number of cells in the grid.

--- a/opm/core/props/rock/RockFromDeck.hpp
+++ b/opm/core/props/rock/RockFromDeck.hpp
@@ -40,7 +40,7 @@ namespace Opm
         RockFromDeck();
         /// Creates rock properties with zero porosity and permeability
         /// \param number_of_cells The number of cells
-        RockFromDeck(std::size_t number_of_cells);
+        explicit RockFromDeck(std::size_t number_of_cells);
         /// Initialize from deck and cell mapping.
         /// \param  eclState        The EclipseState (processed deck) produced by the opm-parser code
         /// \param  number_of_cells The number of cells in the grid.


### PR DESCRIPTION
This is needed in parallel runs where a the rock properties will not
be read from the deck but be communicated from a master process. Nevertheless
we need to be able to initialize the data structures with the correct
container size. In addition we need to be able to change the container values
from opm-autodiff's BlackoilPropsDataHandle.