### PR TITLE
Change the number of integration points in the initialization

### DIFF
--- a/opm/core/simulator/initStateEquil_impl.hpp
+++ b/opm/core/simulator/initStateEquil_impl.hpp
@@ -366,9 +366,9 @@ namespace Opm
                 typedef Details::RK4IVP<ODE> WPress;
                 std::array<WPress,2> wpress = {
                     {
-                        WPress(drho, up  , p0, 100)
+                        WPress(drho, up  , p0, 2000)
                         ,
-                        WPress(drho, down, p0, 100)
+                        WPress(drho, down, p0, 2000)
                     }
                 };
 
@@ -426,9 +426,9 @@ namespace Opm
                 typedef Details::RK4IVP<ODE> OPress;
                 std::array<OPress,2> opress = {
                     {
-                        OPress(drho, up  , p0, 100)
+                        OPress(drho, up  , p0, 2000)
                         ,
-                        OPress(drho, down, p0, 100)
+                        OPress(drho, down, p0, 2000)
                     }
                 };
 
@@ -488,9 +488,9 @@ namespace Opm
                 typedef Details::RK4IVP<ODE> GPress;
                 std::array<GPress,2> gpress = {
                     {
-                        GPress(drho, up  , p0, 100)
+                        GPress(drho, up  , p0, 2000)
                         ,
-                        GPress(drho, down, p0, 100)
+                        GPress(drho, down, p0, 2000)
                     }
                 };
 


### PR DESCRIPTION
The number is changed from 100->2000 to increase accuracy.

According to @osae this is necessary to get match for the new model. 

An alternative fix that would require less integration points would be to compute the span of the integration pr. pillar instead and to make the number of integration points dependent on the size of the integration span.  
     