### PR TITLE
AdaptiveTimeStepping: allow for more flexible error computation in the future.

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping.hpp
@@ -43,7 +43,6 @@ namespace Opm {
         //! \param pinfo The information about the data distribution
         //!              and communication for a parallel run.
         AdaptiveTimeStepping( const parameter::ParameterGroup& param,
-                              const boost::any& pinfo=boost::any(),
                               const bool terminal_output = true );
 
         /** \brief  step method that acts like the solver::step method

--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -49,9 +49,9 @@ namespace Opm {
             {}
 
             /// return || u^n+1 - u^n || / || u^n+1 ||
-            double timeError() const
+            double relativeChange() const
             {
-                return solver_.model().computeTimeError( previous_, current_ );
+                return solver_.model().relativeChange( previous_, current_ );
             }
         };
     }
@@ -195,11 +195,11 @@ namespace Opm {
 
                 // create object to compute the time error, simply forwards the call to the model
                 detail::SolutionTimeErrorSolverWrapper< Solver, State >
-                    timeError( solver, last_state, state );
+                    relativeChange( solver, last_state, state );
 
                 // compute new time step estimate
                 double dtEstimate =
-                    timeStepControl_->computeTimeStepSize( dt, linearIterations, timeError );
+                    timeStepControl_->computeTimeStepSize( dt, linearIterations, relativeChange );
 
                 // limit the growth of the timestep size by the growth factor
                 dtEstimate = std::min( dtEstimate, double(max_growth_ * dt) );

--- a/opm/core/simulator/TimeStepControl.cpp
+++ b/opm/core/simulator/TimeStepControl.cpp
@@ -55,7 +55,7 @@ namespace Opm
     }
 
     double SimpleIterationCountTimeStepControl::
-    computeTimeStepSize( const double dt, const int iterations, const SolutionTimeErrorInterface& /* timeError */ ) const
+    computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& /* relativeChange */ ) const
     {
         double dtEstimate = dt ;
 
@@ -90,7 +90,7 @@ namespace Opm
     {}
 
     double PIDTimeStepControl::
-    computeTimeStepSize( const double dt, const int /* iterations */, const SolutionTimeErrorInterface& errorObj ) const
+    computeTimeStepSize( const double dt, const int /* iterations */, const RelativeChangeInterface& relChange ) const
     {
         // shift errors
         for( int i=0; i<2; ++i ) {
@@ -98,7 +98,7 @@ namespace Opm
         }
 
         // store new error
-        const double error = errorObj.timeError();
+        const double error = relChange.relativeChange();
         errors_[ 2 ] = error;
 
         if( error > tol_ )
@@ -141,9 +141,9 @@ namespace Opm
     {}
 
     double PIDAndIterationCountTimeStepControl::
-    computeTimeStepSize( const double dt, const int iterations, const SolutionTimeErrorInterface& errorObj ) const
+    computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& relChange ) const
     {
-        double dtEstimate = BaseType :: computeTimeStepSize( dt, iterations, errorObj );
+        double dtEstimate = BaseType :: computeTimeStepSize( dt, iterations, relChange );
 
         // further reduce step size if to many iterations were used
         if( iterations > target_iterations_ )

--- a/opm/core/simulator/TimeStepControl.hpp
+++ b/opm/core/simulator/TimeStepControl.hpp
@@ -26,7 +26,6 @@
 #include <boost/any.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <opm/core/simulator/TimeStepControlInterface.hpp>
-#include <opm/core/linalg/ParallelIstlInformation.hpp>
 
 namespace Opm
 {
@@ -49,7 +48,7 @@ namespace Opm
                                              const bool verbose = false);
 
         /// \brief \copydoc TimeStepControlInterface::computeTimeStepSize
-        double computeTimeStepSize( const double dt, const int iterations, const SolutionTimeErrorInterface& /* timeError */ ) const;
+        double computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& /* relativeChange */ ) const;
 
     protected:
         const int     target_iterations_;
@@ -78,22 +77,18 @@ namespace Opm
         /// \brief constructor
         /// \param tol      tolerance for the relative changes of the numerical solution to be accepted
         ///                 in one time step (default is 1e-3)
-        /// \paramm pinfo   The information about the parallel information. Needed to
-        ///                 compute parallel scalarproducts.
         /// \param verbose  if true get some output (default = false)
         PIDTimeStepControl( const double tol = 1e-3,
                             const bool verbose = false );
 
         /// \brief \copydoc TimeStepControlInterface::computeTimeStepSize
-        double computeTimeStepSize( const double dt, const int /* iterations */, const SolutionTimeErrorInterface& timeError ) const;
+        double computeTimeStepSize( const double dt, const int /* iterations */, const RelativeChangeInterface& relativeChange ) const;
 
     protected:
         const double tol_;
         mutable std::vector< double > errors_;
 
         const bool verbose_;
-    private:
-    //    const boost::any parallel_information_;
     };
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -110,16 +105,13 @@ namespace Opm
         /// \param target_iterations  number of desired iterations per time step
         /// \param tol        tolerance for the relative changes of the numerical solution to be accepted
         ///                   in one time step (default is 1e-3)
-        //  \param maxgrowth  max growth factor for new time step in relation of old time step (default = 3.0)
-        /// \paramm pinfo     The information about the parallel information. Needed to
-        ///                   compute parallel scalarproducts.
         /// \param verbose    if true get some output (default = false)
         PIDAndIterationCountTimeStepControl( const int target_iterations = 20,
                                              const double tol = 1e-3,
                                              const bool verbose = false);
 
         /// \brief \copydoc TimeStepControlInterface::computeTimeStepSize
-        double computeTimeStepSize( const double dt, const int iterations, const SolutionTimeErrorInterface& timeError ) const;
+        double computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& relativeChange ) const;
 
     protected:
         const int     target_iterations_;

--- a/opm/core/simulator/TimeStepControlInterface.hpp
+++ b/opm/core/simulator/TimeStepControlInterface.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2014 IRIS AS 
+  Copyright 2014 IRIS AS
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -19,31 +19,45 @@
 #ifndef OPM_TIMESTEPCONTROLINTERFACE_HEADER_INCLUDED
 #define OPM_TIMESTEPCONTROLINTERFACE_HEADER_INCLUDED
 
-#include <opm/core/simulator/SimulatorState.hpp> 
+#include <opm/core/simulator/SimulatorState.hpp>
 
 namespace Opm
 {
 
     ///////////////////////////////////////////////////////////////////
     ///
-    ///  TimeStepControlInterface 
-    /// 
+    ///  TimeStepControlInterface
+    ///
     ///////////////////////////////////////////////////////////////////
-    class TimeStepControlInterface 
+    class SolutionTimeErrorInterface
     {
-    protected:    
+    protected:
+        SolutionTimeErrorInterface() {}
+    public:
+        /// \return || u^n+1 - u^n || / || u^n+1 ||
+        virtual double timeError() const = 0;
+
+        /// virtual destructor (empty)
+        virtual ~SolutionTimeErrorInterface () {}
+    };
+
+    ///////////////////////////////////////////////////////////////////
+    ///
+    ///  TimeStepControlInterface
+    ///
+    ///////////////////////////////////////////////////////////////////
+    class TimeStepControlInterface
+    {
+    protected:
         TimeStepControlInterface() {}
     public:
-        /// \param state simulation state before computing update in the solver (default is empty)
-        virtual void initialize( const SimulatorState& /*state*/ ) {}
-
         /// compute new time step size suggestions based on the PID controller
         /// \param dt          time step size used in the current step
-        /// \param iterations  number of iterations used (linear/nonlinear) 
-        /// \param state       new solution state
+        /// \param iterations  number of iterations used (linear/nonlinear)
+        /// \param timeError   object to compute || u^n+1 - u^n || / || u^n+1 ||
         ///
         /// \return suggested time step size for the next step
-        virtual double computeTimeStepSize( const double dt, const int iterations, const SimulatorState& ) const = 0;
+        virtual double computeTimeStepSize( const double dt, const int iterations, const SolutionTimeErrorInterface& timeError ) const = 0;
 
         /// virtual destructor (empty)
         virtual ~TimeStepControlInterface () {}

--- a/opm/core/simulator/TimeStepControlInterface.hpp
+++ b/opm/core/simulator/TimeStepControlInterface.hpp
@@ -26,19 +26,19 @@ namespace Opm
 
     ///////////////////////////////////////////////////////////////////
     ///
-    ///  TimeStepControlInterface
+    ///  RelativeChangeInterface
     ///
     ///////////////////////////////////////////////////////////////////
-    class SolutionTimeErrorInterface
+    class RelativeChangeInterface
     {
     protected:
-        SolutionTimeErrorInterface() {}
+        RelativeChangeInterface() {}
     public:
         /// \return || u^n+1 - u^n || / || u^n+1 ||
-        virtual double timeError() const = 0;
+        virtual double relativeChange() const = 0;
 
         /// virtual destructor (empty)
-        virtual ~SolutionTimeErrorInterface () {}
+        virtual ~RelativeChangeInterface() {}
     };
 
     ///////////////////////////////////////////////////////////////////
@@ -57,7 +57,7 @@ namespace Opm
         /// \param timeError   object to compute || u^n+1 - u^n || / || u^n+1 ||
         ///
         /// \return suggested time step size for the next step
-        virtual double computeTimeStepSize( const double dt, const int iterations, const SolutionTimeErrorInterface& timeError ) const = 0;
+        virtual double computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& relativeChange ) const = 0;
 
         /// virtual destructor (empty)
         virtual ~TimeStepControlInterface () {}


### PR DESCRIPTION
This PR revises the TimeStepControl interface such that the computation of the 
error || u^n+ - u^n || / || u^n+1 || is forwarded to the Model class. This allows for more flexible and model dependent implementation. A corresponding PR in opm-autodiff is coming.
