### PR TITLE
Return a constant reference to the mask for ParallelISTLInformation::updateOwnerMask

### DIFF
--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -160,7 +160,7 @@ public:
       communicator.free();
     }
     template<class T>
-    void updateOwnerMask(const T& container) const
+    const std::vector<double>& updateOwnerMask(const T& container) const
     {
         if( ! indexSet_ )
         {
@@ -177,6 +177,7 @@ public:
                 }
             }
         }
+        return ownerMask_;
     }
     /// \brief Compute one or more global reductions.
     ///


### PR DESCRIPTION
Thus we can actually access the mask in external code. This is for
example needed when calculating averages in RateConverter of opm-autodiff.