### PR TITLE
Follow class renaming.

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -34,7 +34,7 @@ namespace Opm {
     namespace detail
     {
         template <class Solver, class State>
-        class SolutionTimeErrorSolverWrapper : public SolutionTimeErrorInterface
+        class SolutionTimeErrorSolverWrapper : public RelativeChangeInterface
         {
             const Solver& solver_;
             const State&  previous_;


### PR DESCRIPTION
With this, opm-autodiff builds again.

Will self-merge, as it is a small fix for a build-failure.