### PR TITLE
fix build for newish boost versions

### DIFF
--- a/tests/DuneIstlTestHelpers.hpp
+++ b/tests/DuneIstlTestHelpers.hpp
@@ -61,7 +61,7 @@ struct MPIFixture {
 };
 
 
-BOOST_GLOBAL_FIXTURE(MPIFixture)
+BOOST_GLOBAL_FIXTURE(MPIFixture);
 
 struct MyMatrix
 {


### PR DESCRIPTION
my boost is 1.58. once more, boost seemed to have become more picky on
where a semicolon must be placed and where not.