### PR TITLE
Silence some warnings.

### DIFF
--- a/opm/core/grid/GridHelpers.hpp
+++ b/opm/core/grid/GridHelpers.hpp
@@ -20,8 +20,13 @@
 */
 #ifndef OPM_CORE_GRIDHELPERS_HEADER_INCLUDED
 #define OPM_CORE_GRIDHELPERS_HEADER_INCLUDED
+
 #include <opm/core/grid.h>
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/range/iterator_range.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
 
 namespace Opm
 {

--- a/opm/core/utility/thresholdPressures.hpp
+++ b/opm/core/utility/thresholdPressures.hpp
@@ -314,7 +314,7 @@ void computeMaxDp(std::map<std::pair<int, int>, double>& maxDp,
 
 
     template <class Grid>
-    std::vector<double> thresholdPressures(const DeckConstPtr& deck,
+    std::vector<double> thresholdPressures(const DeckConstPtr& /* deck */,
                                            EclipseStateConstPtr eclipseState,
                                            const Grid& grid,
                                            const std::map<std::pair<int, int>, double>& maxDp)


### PR DESCRIPTION
The thresholdPressures() should probably be changed to not take a deck, but that requires cross-module changes so I'll not do it here.

I consider this trivial enough to self-merge.