### PR TITLE
OPM-163: Use EclipseState instead of Deck for PvtInterface

### DIFF
--- a/opm/core/props/BlackoilPropertiesFromDeck.cpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck.cpp
@@ -128,7 +128,7 @@ namespace Opm
     {
         // retrieve the cell specific PVT table index from the deck
         // and using the grid...
-        extractPvtTableIndex(cellPvtRegionIdx_, deck, number_of_cells, global_cell);
+        extractPvtTableIndex(cellPvtRegionIdx_, eclState, number_of_cells, global_cell);
 
         if (init_rock){
            rock_.init(eclState, number_of_cells, global_cell, cart_dims);
@@ -156,7 +156,7 @@ namespace Opm
     {
         // retrieve the cell specific PVT table index from the deck
         // and using the grid...
-        extractPvtTableIndex(cellPvtRegionIdx_, deck, number_of_cells, global_cell);
+        extractPvtTableIndex(cellPvtRegionIdx_, eclState, number_of_cells, global_cell);
 
         if(init_rock){
             rock_.init(eclState, number_of_cells, global_cell, cart_dims);

--- a/opm/core/props/pvt/PvtInterface.cpp
+++ b/opm/core/props/pvt/PvtInterface.cpp
@@ -46,33 +46,20 @@ namespace Opm
     }
 
     void extractPvtTableIndex(std::vector<int> &pvtTableIdx,
-                              Opm::DeckConstPtr deck,
+                              Opm::EclipseStateConstPtr eclState,
                               size_t numCompressed,
                               const int *compressedToCartesianCellIdx)
     {
-        if (deck->hasKeyword("PVTNUM")) {
-            // we have a "real" multi-pvt deck.
-
-            // get the PVT number from the deck
-            Opm::DeckKeywordConstPtr pvtnumKeyword = deck->getKeyword("PVTNUM");
-            const std::vector<int> &pvtnumData = pvtnumKeyword->getIntData();
-
-            // convert this into an array of compressed cells. since
-            // Eclipse uses Fortran-style indices which start at 1
-            // instead of 0, we subtract 1.
-            pvtTableIdx.resize(numCompressed);
-            for (size_t cellIdx = 0; cellIdx < numCompressed; ++ cellIdx) {
-                size_t cartesianCellIdx = compressedToCartesianCellIdx?compressedToCartesianCellIdx[cellIdx]:cellIdx;
-                assert(cartesianCellIdx < pvtnumData.size());
-
-                pvtTableIdx[cellIdx] = pvtnumData[cartesianCellIdx] - 1;
-            }
-        }
-        else {
-            // create the pvtIdxArray: all cells use the one and only
-            // PVT table...
-            pvtTableIdx.resize(numCompressed);
-            std::fill(pvtTableIdx.begin(), pvtTableIdx.end(), 0);
+        //Get the PVTNUM data
+        const std::vector<int>& pvtnumData = eclState->getIntGridProperty("PVTNUM")->getData();
+        // Convert this into an array of compressed cells
+        // Eclipse uses Fortran-style indices which start at 1
+        // instead of 0, we subtract 1.
+        pvtTableIdx.resize(numCompressed);
+        for (size_t cellIdx = 0; cellIdx < numCompressed; ++ cellIdx) {
+            size_t cartesianCellIdx = compressedToCartesianCellIdx ? compressedToCartesianCellIdx[cellIdx]:cellIdx;
+            assert(cartesianCellIdx < pvtnumData.size());
+            pvtTableIdx[cellIdx] = pvtnumData[cartesianCellIdx] - 1;
         }
     }
 

--- a/opm/core/props/pvt/PvtInterface.hpp
+++ b/opm/core/props/pvt/PvtInterface.hpp
@@ -21,7 +21,7 @@
 #define OPM_PVTINTERFACE_HEADER_INCLUDED
 
 #include <opm/core/props/BlackoilPhases.hpp>
-#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
 
 namespace Opm
@@ -175,7 +175,7 @@ namespace Opm
      * implementations usually use compressed cells.
      */
     void extractPvtTableIndex(std::vector<int>& pvtTableIdx,
-                              Opm::DeckConstPtr deck,
+                              Opm::EclipseStateConstPtr eclState,
                               size_t numCompressed,
                               const int* compressedToCartesianIdx);
 


### PR DESCRIPTION
Minor refactor - use EclipseState instead of Deck for PvtInterface. 
If PVTNUM is not present, getIntGridProperty() returns a vector with pvtnum 1 for each gridcell/box. 

Due to changes in extractPvtTableIndex() method signature, the PR https://github.com/OPM/opm-autodiff/pull/569 should be merged at the same time. 