### PR TITLE
Fixes includes wrt opm-parser PR-656

### DIFF
--- a/examples/compute_eikonal_from_files.cpp
+++ b/examples/compute_eikonal_from_files.cpp
@@ -34,6 +34,7 @@
 #include <memory>
 #include <algorithm>
 #include <iostream>
+#include <fstream>
 #include <vector>
 #include <numeric>
 #include <iterator>

--- a/opm/core/grid/GridManager.cpp
+++ b/opm/core/grid/GridManager.cpp
@@ -25,6 +25,7 @@
 #include <opm/core/grid/cornerpoint_grid.h>
 #include <opm/core/grid/MinpvProcessor.hpp>
 #include <opm/common/ErrorMacros.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
 #include <array>

--- a/opm/core/io/eclipse/EclipseReader.cpp
+++ b/opm/core/io/eclipse/EclipseReader.cpp
@@ -25,6 +25,11 @@
 #include <opm/core/grid/GridHelpers.hpp>
 #include <opm/core/io/eclipse/EclipseIOUtil.hpp>
 
+#include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+
 #include <algorithm>
 
 #include <ert/ecl/ecl_file.h>

--- a/opm/core/io/eclipse/EclipseWriteRFTHandler.cpp
+++ b/opm/core/io/eclipse/EclipseWriteRFTHandler.cpp
@@ -28,6 +28,7 @@
 #include <opm/core/utility/miscUtilities.hpp>
 
 
+#include <opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/WellSet.hpp>
 

--- a/opm/core/io/eclipse/EclipseWriteRFTHandler.hpp
+++ b/opm/core/io/eclipse/EclipseWriteRFTHandler.hpp
@@ -31,6 +31,9 @@
 
 
 namespace Opm {
+    class EclipseGrid;
+    class Well;
+
 namespace EclipseWriterDetails {
 
 
@@ -43,8 +46,8 @@ namespace EclipseWriterDetails {
     void writeTimeStep(const std::string& filename,
                        const ert_ecl_unit_enum ecl_unit,
                        const SimulatorTimerInterface& simulatorTimer,
-                       std::vector<WellConstPtr>& wells,
-                       EclipseGridConstPtr eclipseGrid,
+                       std::vector<std::shared_ptr< const Well >>& wells,
+                       std::shared_ptr< const EclipseGrid > eclipseGrid,
                        std::vector<double>& pressure,
                        std::vector<double>& swat,
                        std::vector<double>& sgas);
@@ -53,9 +56,9 @@ namespace EclipseWriterDetails {
 
     private:
 
-    ecl_rft_node_type * createEclRFTNode(WellConstPtr well,
+    ecl_rft_node_type * createEclRFTNode(std::shared_ptr< const Well > well,
                                          const SimulatorTimerInterface& simulatorTimer,
-                                         EclipseGridConstPtr eclipseGrid,
+                                         std::shared_ptr< const EclipseGrid > eclipseGrid,
                                          const std::vector<double>& pressure,
                                          const std::vector<double>& swat,
                                          const std::vector<double>& sgas);

--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -40,9 +40,13 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Utility/SpecgridWrapper.hpp>
 #include <opm/parser/eclipse/Utility/WelspecsWrapper.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
+#include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
-#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
 #include <boost/algorithm/string/case_conv.hpp> // to_upper_copy
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/opm/core/io/eclipse/EclipseWriter.hpp
+++ b/opm/core/io/eclipse/EclipseWriter.hpp
@@ -28,6 +28,10 @@
 #include <opm/core/simulator/SimulatorTimerInterface.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+
+#include <ert/ecl/ecl_util.h>
 
 #include <string>
 #include <vector>

--- a/opm/core/props/IncompPropertiesSinglePhase.cpp
+++ b/opm/core/props/IncompPropertiesSinglePhase.cpp
@@ -24,7 +24,8 @@
 #include <opm/core/grid.h>
 #include <opm/core/utility/Units.hpp>
 #include <opm/common/ErrorMacros.hpp>
-// #include <iostream>
+
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 
 namespace Opm
 {

--- a/opm/core/props/pvt/BlackoilPvtProperties.cpp
+++ b/opm/core/props/pvt/BlackoilPvtProperties.cpp
@@ -33,6 +33,7 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 
 namespace Opm
 {

--- a/opm/core/props/pvt/PvtConstCompr.hpp
+++ b/opm/core/props/pvt/PvtConstCompr.hpp
@@ -22,6 +22,7 @@
 
 #include <opm/core/props/pvt/PvtInterface.hpp>
 #include <opm/common/ErrorMacros.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 
 #include <vector>
 #include <algorithm>

--- a/opm/core/props/pvt/PvtDead.cpp
+++ b/opm/core/props/pvt/PvtDead.cpp
@@ -20,6 +20,8 @@
 
 #include "config.h"
 #include <opm/core/props/pvt/PvtDead.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp>
 #include <algorithm>
 
 // Extra includes for debug dumping of tables.

--- a/opm/core/props/pvt/PvtDeadSpline.cpp
+++ b/opm/core/props/pvt/PvtDeadSpline.cpp
@@ -20,6 +20,8 @@
 #include "config.h"
 #include <opm/core/props/pvt/PvtDeadSpline.hpp>
 #include <opm/core/utility/buildUniformMonotoneTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp>
 
 
 #include <algorithm>

--- a/opm/core/props/pvt/PvtInterface.cpp
+++ b/opm/core/props/pvt/PvtInterface.cpp
@@ -19,6 +19,7 @@
 
 #include "config.h"
 #include <opm/core/props/pvt/PvtInterface.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
 
 #include <cassert>
 

--- a/opm/core/props/pvt/PvtLiveGas.cpp
+++ b/opm/core/props/pvt/PvtLiveGas.cpp
@@ -33,6 +33,8 @@
 #include <opm/core/props/pvt/PvtLiveGas.hpp>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/core/utility/linearInterpolation.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp>
 
 #include <algorithm>
 #include <iostream>

--- a/opm/core/props/pvt/PvtLiveGas.hpp
+++ b/opm/core/props/pvt/PvtLiveGas.hpp
@@ -28,6 +28,8 @@
 
 namespace Opm
 {
+    class PvtgTable;
+
     /// Class for miscible wet gas (with vaporized oil in vapour phase).
     /// The PVT properties can either be given as a function of pressure (p), temperature (T) and surface volume (z)
     /// or pressure (p), temperature (T) and gas resolution factor (r).

--- a/opm/core/props/pvt/PvtLiveOil.cpp
+++ b/opm/core/props/pvt/PvtLiveOil.cpp
@@ -21,6 +21,8 @@
 #include <opm/core/props/pvt/PvtLiveOil.hpp>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/core/utility/linearInterpolation.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp>
 
 #include <algorithm>
 

--- a/opm/core/props/pvt/PvtLiveOil.hpp
+++ b/opm/core/props/pvt/PvtLiveOil.hpp
@@ -29,6 +29,9 @@
 
 namespace Opm
 {
+
+    class PvtoTable;
+
     /// Class for miscible live oil (with dissolved gas in liquid phase).
     /// The PVT properties can either be given as a function of pressure (p), temperature (T) and surface volume (z)
     /// or pressure (p), temperature (T) and gas resolution factor (r).

--- a/opm/core/props/pvt/PvtPropertiesIncompFromDeck.cpp
+++ b/opm/core/props/pvt/PvtPropertiesIncompFromDeck.cpp
@@ -24,6 +24,7 @@
 #include <opm/core/utility/Units.hpp>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/core/props/BlackoilPhases.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 
 
 namespace Opm

--- a/opm/core/props/pvt/ThermalGasPvtWrapper.hpp
+++ b/opm/core/props/pvt/ThermalGasPvtWrapper.hpp
@@ -23,6 +23,7 @@
 #include <opm/common/ErrorMacros.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp>
 
 #include <vector>
 

--- a/opm/core/props/pvt/ThermalOilPvtWrapper.hpp
+++ b/opm/core/props/pvt/ThermalOilPvtWrapper.hpp
@@ -24,6 +24,7 @@
 #include <opm/common/ErrorMacros.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp>
 
 #include <vector>
 

--- a/opm/core/props/pvt/ThermalWaterPvtWrapper.hpp
+++ b/opm/core/props/pvt/ThermalWaterPvtWrapper.hpp
@@ -24,6 +24,7 @@
 #include <opm/common/ErrorMacros.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
 
 #include <vector>
 

--- a/opm/core/props/rock/RockCompressibility.cpp
+++ b/opm/core/props/rock/RockCompressibility.cpp
@@ -24,6 +24,8 @@
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/core/utility/linearInterpolation.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 
 #include <iostream>
 

--- a/opm/core/props/satfunc/RelpermDiagnostics.cpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics.cpp
@@ -19,6 +19,8 @@
 
 #include <opm/core/props/satfunc/RelpermDiagnostics.hpp>
 #include <opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SgwfnTable.hpp>
 
 namespace Opm{
 

--- a/opm/core/props/satfunc/RelpermDiagnostics.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics.hpp
@@ -40,6 +40,9 @@
 
 namespace Opm {
 
+    class Sof2Table;
+    class SgwfnTable;
+
     ///This class is intend to be a relpmer diganostics, to detect
     ///wrong input of relperm table and endpoints.
     class RelpermDiagnostics 

--- a/opm/core/simulator/initStateEquil.hpp
+++ b/opm/core/simulator/initStateEquil.hpp
@@ -31,6 +31,9 @@
 #include <opm/core/utility/Units.hpp>
 #include <opm/parser/eclipse/Utility/EquilWrapper.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp>
 
 #include <array>
 #include <cassert>

--- a/opm/core/wells/WellsManager.hpp
+++ b/opm/core/wells/WellsManager.hpp
@@ -35,6 +35,9 @@ struct UnstructuredGrid;
 
 namespace Opm
 {
+
+    class Schedule;
+
     struct WellData
     {
         WellType type;
@@ -175,7 +178,7 @@ namespace Opm
                                    const NTG& ntg,
                                    std::vector<int>& wells_on_proc);
 
-        void addChildGroups(GroupTreeNodeConstPtr parentNode, ScheduleConstPtr schedule, size_t timeStep, const PhaseUsage& phaseUsage);
+        void addChildGroups(GroupTreeNodeConstPtr parentNode, std::shared_ptr< const Schedule > schedule, size_t timeStep, const PhaseUsage& phaseUsage);
         void setupGuideRates(std::vector<WellConstPtr>& wells, const size_t timeStep, std::vector<WellData>& well_data, std::map<std::string, int>& well_names_to_index);
 
 

--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -3,6 +3,8 @@
 
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/core/utility/compressedToCartesian.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 
 #include <algorithm>
 #include <array>
@@ -141,7 +143,7 @@ void WellsManager::createWellsFromSpecs(std::vector<WellConstPtr>& wells, size_t
         }
 
         {   // COMPDAT handling
-            CompletionSetConstPtr completionSet = well->getCompletions(timeStep);
+            auto completionSet = well->getCompletions(timeStep);
             // shut completions and open ones stored in this process will have 1 others 0.
             std::vector<std::size_t> completion_on_proc(completionSet->size(), 1);
             std::size_t shut_completions_number = 0;
@@ -372,7 +374,7 @@ WellsManager::init(const Opm::EclipseStateConstPtr eclipseState,
     // For easy lookup:
     std::map<std::string, int> well_names_to_index;
 
-    ScheduleConstPtr          schedule = eclipseState->getSchedule();
+    auto schedule = eclipseState->getSchedule();
     std::vector<WellConstPtr> wells    = schedule->getWells(timeStep);
     std::vector<int>          wells_on_proc;
 

--- a/tests/test_EclipseWriter.cpp
+++ b/tests/test_EclipseWriter.cpp
@@ -37,6 +37,8 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 
 // ERT stuff
 #include <ert/ecl/ecl_kw.h>

--- a/tests/test_norne_pvt.cpp
+++ b/tests/test_norne_pvt.cpp
@@ -37,6 +37,7 @@
 #include <opm/parser/eclipse/Parser/ParseMode.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 
 #include <opm/core/props/pvt/PvtLiveOil.hpp>
 

--- a/tests/test_pinchprocessor.cpp
+++ b/tests/test_pinchprocessor.cpp
@@ -40,6 +40,7 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
 #include <opm/core/pressure/tpfa/TransTpfa.hpp>
 #include <opm/core/grid/PinchProcessor.hpp>
 #include <opm/core/props/rock/RockFromDeck.hpp>

--- a/tests/test_timer.cpp
+++ b/tests/test_timer.cpp
@@ -27,6 +27,7 @@
 
 #define BOOST_TEST_MODULE OPM-TimerTest
 #include <boost/test/unit_test.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseMode.hpp>

--- a/tests/test_wellcollection.cpp
+++ b/tests/test_wellcollection.cpp
@@ -33,8 +33,9 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/GroupTreeNode.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/GroupTree.hpp>
 
 using namespace Opm;
 

--- a/tests/test_wellsgroup.cpp
+++ b/tests/test_wellsgroup.cpp
@@ -39,8 +39,9 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseMode.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/GroupTreeNode.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/GroupTree.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -37,6 +37,7 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseMode.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>


### PR DESCRIPTION
Several files stopped compiling due to relying on opm-parser headers
doing includes. From opm-parser PR-656
https://github.com/OPM/opm-parser/pull/656 this assumption is no longer
valid.