### PR TITLE
Removed SimulatorState::init( UnstructureGrid& )

### DIFF
--- a/opm/core/simulator/SimulatorState.cpp
+++ b/opm/core/simulator/SimulatorState.cpp
@@ -1,6 +1,5 @@
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/core/simulator/SimulatorState.hpp>
-#include <opm/core/grid.h>
 
 #include <cmath>
 #include <cassert>
@@ -41,11 +40,7 @@ SimulatorState::vectorApproxEqual(const std::vector<double>& v1,
     return true;
 }
 
-void
-SimulatorState::init(const UnstructuredGrid& g, int num_phases)
-{
-    init(g.number_of_cells, g.number_of_faces, num_phases);
-}
+
 void
 SimulatorState::init(int number_of_cells, int number_of_faces, int num_phases)
 {

--- a/opm/core/simulator/SimulatorState.hpp
+++ b/opm/core/simulator/SimulatorState.hpp
@@ -8,16 +8,12 @@
 #include <vector>
 #include <string>
 
-// forward declaration
-struct UnstructuredGrid;
 
 namespace Opm
 {
     class SimulatorState
     {
     public:
-
-        virtual void init(const UnstructuredGrid& g, int num_phases);
 
         virtual void init(int number_of_cells, int number_of_faces, int num_phases);
 

--- a/tutorials/tutorial3.cpp
+++ b/tutorials/tutorial3.cpp
@@ -266,7 +266,7 @@ try
     /// \snippet tutorial3.cpp two-phase state
     /// \internal [two-phase state]
     TwophaseState state;
-    state.init(grid, 2);
+    state.init(grid.number_of_cells , grid.number_of_faces, 2);
     state.setFirstSat(allcells, props, TwophaseState::MinSat);
     /// \internal [two-phase state]
     /// \endinternal

--- a/tutorials/tutorial4.cpp
+++ b/tutorials/tutorial4.cpp
@@ -213,7 +213,7 @@ try
     /// \snippet tutorial4.cpp two-phase state
     /// \internal[two-phase state]
     TwophaseState state;
-    state.init(grid, 2);
+    state.init(grid.number_of_cells , grid.number_of_faces, 2);
     state.setFirstSat(allcells, props, TwophaseState::MinSat);
     /// \internal[two-phase state]
     /// \endinternal


### PR DESCRIPTION
When this overload has been removed the `SimulatorState` class has no dependencies to other parts of opm-core, and it can be moved to opm-common.

The overload seemed to be only used in the tutorials.