### PR TITLE
PvtLiveGas: do not special case in the extrapolation code

### DIFF
--- a/opm/core/props/pvt/PvtLiveGas.cpp
+++ b/opm/core/props/pvt/PvtLiveGas.cpp
@@ -574,12 +574,6 @@ namespace Opm
                                                  press);
             } else {  // Undersaturated case
                 int is = tableIndex(saturatedGasTable[0], press);
-                // Extrapolate from first table section
-                if (is == 0 && press < saturatedGasTable[0][0]) {
-                    return linearInterpolation(undersatGasTables[0][0],
-                                                     undersatGasTables[0][item],
-                                                     r);
-                }
 
                 // Extrapolate from last table section
                 //int ltp = saturatedGasTable[0].size() - 1;


### PR DESCRIPTION
at least, don't special case that much: the  condition seems fishy to me because it only applies for the fist PVT region (i.e., `is == 0`), and the generic code below the if works just fine as well.

This caused a discrepancy with the opm-material PVT relations for Norne after 23 report steps. (which takes an hour or two to get to with debugging options on my machine.) As you can probably imagine, finding this was *a lot* of fun...