### PR TITLE
Change Deck access methods/types to references

### DIFF
--- a/examples/mirror_grid.cpp
+++ b/examples/mirror_grid.cpp
@@ -89,7 +89,7 @@ void printKeywordValues(std::ofstream& out, std::string keyword, std::vector<T> 
 std::vector<double> getMapaxesValues(Opm::DeckConstPtr deck);
 
 /// Mirror keyword MAPAXES in deck
-void mirror_mapaxes(Opm::DeckConstPtr deck, std::string direction, std::ofstream& out) {
+void mirror_mapaxes( std::shared_ptr< const Opm::Deck > deck, std::string direction, std::ofstream& out) {
     // Assumes axis aligned with x/y-direction
     std::cout << "Warning: Keyword MAPAXES not fully understood. Result should be verified manually." << std::endl;
     if (deck->hasKeyword("MAPAXES")) {
@@ -107,31 +107,31 @@ void mirror_mapaxes(Opm::DeckConstPtr deck, std::string direction, std::ofstream
 }
 
 /// Mirror keyword SPECGRID in deck
-void mirror_specgrid(Opm::DeckConstPtr deck, std::string direction, std::ofstream& out) {
+void mirror_specgrid(std::shared_ptr< const Opm::Deck > deck, std::string direction, std::ofstream& out) {
     // We only need to multiply the dimension by 2 in the correct direction.
-    Opm::DeckRecordConstPtr specgridRecord = deck->getKeyword("SPECGRID")->getRecord(0);
+    const auto& specgridRecord = deck->getKeyword("SPECGRID").getRecord(0);
     std::vector<int> dimensions(3);
-    dimensions[0] = specgridRecord->getItem("NX")->getInt(0);
-    dimensions[1] = specgridRecord->getItem("NY")->getInt(0);
-    dimensions[2] = specgridRecord->getItem("NZ")->getInt(0);
+    dimensions[0] = specgridRecord.getItem("NX").get< int >(0);
+    dimensions[1] = specgridRecord.getItem("NY").get< int >(0);
+    dimensions[2] = specgridRecord.getItem("NZ").get< int >(0);
     if (direction == "x")      {dimensions[0] *= 2;}
     else if (direction == "y") {dimensions[1] *= 2;}
     else                       {std::cerr << "Direction should be either x or y" << std::endl; exit(1);}
     out << "SPECGRID" << std::endl << dimensions[0] << " " << dimensions[1] << " " << dimensions[2] << " "
-        << specgridRecord->getItem("NUMRES")->getInt(0) << " "
-        << specgridRecord->getItem("COORD_TYPE")->getString(0) << " "
+        << specgridRecord.getItem("NUMRES").get< int >(0) << " "
+        << specgridRecord.getItem("COORD_TYPE").get< std::string >(0) << " "
         << std::endl << "/" << std::endl << std::endl;
 }
 
 /// Mirror keyword COORD in deck
-void mirror_coord(Opm::DeckConstPtr deck, std::string direction, std::ofstream& out) {
+void mirror_coord(std::shared_ptr< const Opm::Deck > deck, std::string direction, std::ofstream& out) {
     // We assume uniform spacing in x and y directions and parallel top and bottom faces
-    Opm::DeckRecordConstPtr specgridRecord = deck->getKeyword("SPECGRID")->getRecord(0);
+    const auto& specgridRecord = deck->getKeyword("SPECGRID").getRecord(0);
     std::vector<int> dimensions(3);
-    dimensions[0] = specgridRecord->getItem("NX")->getInt(0);
-    dimensions[1] = specgridRecord->getItem("NY")->getInt(0);
-    dimensions[2] = specgridRecord->getItem("NZ")->getInt(0);
-    std::vector<double> coord = deck->getKeyword("COORD")->getRawDoubleData();
+    dimensions[0] = specgridRecord.getItem("NX").get< int >(0);
+    dimensions[1] = specgridRecord.getItem("NY").get< int >(0);
+    dimensions[2] = specgridRecord.getItem("NZ").get< int >(0);
+    std::vector<double> coord = deck->getKeyword("COORD").getRawDoubleData();
     const int entries_per_pillar = 6;
     std::vector<double> coord_mirrored;
     // Handle the two directions differently due to ordering of the pillars.
@@ -190,13 +190,13 @@ void mirror_coord(Opm::DeckConstPtr deck, std::string direction, std::ofstream& 
 }
 
 /// Mirror keyword ZCORN in deck
-void mirror_zcorn(Opm::DeckConstPtr deck, std::string direction, std::ofstream& out) {
-    Opm::DeckRecordConstPtr specgridRecord = deck->getKeyword("SPECGRID")->getRecord(0);
+void mirror_zcorn(std::shared_ptr< const Opm::Deck > deck, std::string direction, std::ofstream& out) {
+    const auto& specgridRecord = deck->getKeyword("SPECGRID").getRecord(0);
     std::vector<int> dimensions(3);
-    dimensions[0] = specgridRecord->getItem("NX")->getInt(0);
-    dimensions[1] = specgridRecord->getItem("NY")->getInt(0);
-    dimensions[2] = specgridRecord->getItem("NZ")->getInt(0);
-    std::vector<double> zcorn = deck->getKeyword("ZCORN")->getRawDoubleData();
+    dimensions[0] = specgridRecord.getItem("NX").get< int >(0);
+    dimensions[1] = specgridRecord.getItem("NY").get< int >(0);
+    dimensions[2] = specgridRecord.getItem("NZ").get< int >(0);
+    std::vector<double> zcorn = deck->getKeyword("ZCORN").getRawDoubleData();
     std::vector<double> zcorn_mirrored;
     // Handle the two directions differently due to ordering of the pillars.
     if (direction == "x") {
@@ -257,23 +257,23 @@ void mirror_zcorn(Opm::DeckConstPtr deck, std::string direction, std::ofstream& 
     printKeywordValues(out, "ZCORN", zcorn_mirrored, 8);
 }
 
-std::vector<int> getKeywordValues(std::string keyword, Opm::DeckConstPtr deck, int /*dummy*/) {
-    return deck->getKeyword(keyword)->getIntData();
+std::vector<int> getKeywordValues(std::string keyword, std::shared_ptr< const Opm::Deck > deck, int /*dummy*/) {
+    return deck->getKeyword(keyword).getIntData();
 }
 
-std::vector<double> getKeywordValues(std::string keyword, Opm::DeckConstPtr deck, double /*dummy*/) {
-    return deck->getKeyword(keyword)->getRawDoubleData();
+std::vector<double> getKeywordValues(std::string keyword, std::shared_ptr< const Opm::Deck > deck, double /*dummy*/) {
+    return deck->getKeyword(keyword).getRawDoubleData();
 }
 
 std::vector<double> getMapaxesValues(Opm::DeckConstPtr deck)
 {
-    Opm::DeckRecordConstPtr mapaxesRecord = deck->getKeyword("MAPAXES")->getRecord(0);
+    const auto& mapaxesRecord = deck->getKeyword("MAPAXES").getRecord(0);
     std::vector<double> result;
-    for (size_t itemIdx = 0; itemIdx < mapaxesRecord->size(); ++itemIdx) {
-        Opm::DeckItemConstPtr curItem = mapaxesRecord->getItem(itemIdx);
+    for (size_t itemIdx = 0; itemIdx < mapaxesRecord.size(); ++itemIdx) {
+        const auto& curItem = mapaxesRecord.getItem(itemIdx);
 
-        for (size_t dataItemIdx = 0; dataItemIdx < curItem->size(); ++dataItemIdx) {
-            result.push_back(curItem->getRawDouble(dataItemIdx));
+        for (size_t dataItemIdx = 0; dataItemIdx < curItem.size(); ++dataItemIdx) {
+            result.push_back(curItem.get< double >(dataItemIdx));
         }
     }
     return result;
@@ -287,11 +287,11 @@ void mirror_celldata(std::string keyword, Opm::DeckConstPtr deck, std::string di
         return;
     }
     // Get data from eclipse deck
-    Opm::DeckRecordConstPtr specgridRecord = deck->getKeyword("SPECGRID")->getRecord(0);
+    const auto& specgridRecord = deck->getKeyword("SPECGRID").getRecord(0);
     std::vector<int> dimensions(3);
-    dimensions[0] = specgridRecord->getItem("NX")->getInt(0);
-    dimensions[1] = specgridRecord->getItem("NY")->getInt(0);
-    dimensions[2] = specgridRecord->getItem("NZ")->getInt(0);
+    dimensions[0] = specgridRecord.getItem("NX").get< int >(0);
+    dimensions[1] = specgridRecord.getItem("NY").get< int >(0);
+    dimensions[2] = specgridRecord.getItem("NZ").get< int >(0);
     std::vector<T> values = getKeywordValues(keyword, deck, T(0.0));
     std::vector<T> values_mirrored(2*dimensions[0]*dimensions[1]*dimensions[2], 0.0);
     // Handle the two directions differently due to ordering of the pillars.

--- a/opm/core/grid/GridManager.cpp
+++ b/opm/core/grid/GridManager.cpp
@@ -182,24 +182,24 @@ namespace Opm
     void GridManager::createGrdecl(Opm::DeckConstPtr deck, struct grdecl &grdecl)
     {
         // Extract data from deck.
-        const std::vector<double>& zcorn = deck->getKeyword("ZCORN")->getSIDoubleData();
-        const std::vector<double>& coord = deck->getKeyword("COORD")->getSIDoubleData();
+        const std::vector<double>& zcorn = deck->getKeyword("ZCORN").getSIDoubleData();
+        const std::vector<double>& coord = deck->getKeyword("COORD").getSIDoubleData();
         const int* actnum = NULL;
         if (deck->hasKeyword("ACTNUM")) {
-            actnum = &(deck->getKeyword("ACTNUM")->getIntData()[0]);
+            actnum = &(deck->getKeyword("ACTNUM").getIntData()[0]);
         }
 
         std::array<int, 3> dims;
         if (deck->hasKeyword("DIMENS")) {
-            Opm::DeckKeywordConstPtr dimensKeyword = deck->getKeyword("DIMENS");
-            dims[0] = dimensKeyword->getRecord(0)->getItem(0)->getInt(0);
-            dims[1] = dimensKeyword->getRecord(0)->getItem(1)->getInt(0);
-            dims[2] = dimensKeyword->getRecord(0)->getItem(2)->getInt(0);
+            const auto& dimensKeyword = deck->getKeyword("DIMENS");
+            dims[0] = dimensKeyword.getRecord(0).getItem(0).get< int >(0);
+            dims[1] = dimensKeyword.getRecord(0).getItem(1).get< int >(0);
+            dims[2] = dimensKeyword.getRecord(0).getItem(2).get< int >(0);
         } else if (deck->hasKeyword("SPECGRID")) {
-            Opm::DeckKeywordConstPtr specgridKeyword = deck->getKeyword("SPECGRID");
-            dims[0] = specgridKeyword->getRecord(0)->getItem(0)->getInt(0);
-            dims[1] = specgridKeyword->getRecord(0)->getItem(1)->getInt(0);
-            dims[2] = specgridKeyword->getRecord(0)->getItem(2)->getInt(0);
+            const auto& specgridKeyword = deck->getKeyword("SPECGRID");
+            dims[0] = specgridKeyword.getRecord(0).getItem(0).get< int >(0);
+            dims[1] = specgridKeyword.getRecord(0).getItem(1).get< int >(0);
+            dims[2] = specgridKeyword.getRecord(0).getItem(2).get< int >(0);
         } else {
             OPM_THROW(std::runtime_error, "Deck must have either DIMENS or SPECGRID.");
         }
@@ -214,16 +214,16 @@ namespace Opm
         grdecl.dims[2] = dims[2];
 
         if (deck->hasKeyword("MAPAXES")) {
-            Opm::DeckKeywordConstPtr mapaxesKeyword = deck->getKeyword("MAPAXES");
-            Opm::DeckRecordConstPtr mapaxesRecord = mapaxesKeyword->getRecord(0);
+            const auto& mapaxesKeyword = deck->getKeyword("MAPAXES");
+            const auto& mapaxesRecord = mapaxesKeyword.getRecord(0);
 
             // memleak alert: here we need to make sure that C code
             // can properly take ownership of the grdecl.mapaxes
             // object. if it is not freed, it will result in a
             // memleak...
-            double *cWtfMapaxes = static_cast<double*>(malloc(sizeof(double)*mapaxesRecord->size()));
-            for (unsigned i = 0; i < mapaxesRecord->size(); ++i)
-                cWtfMapaxes[i] = mapaxesRecord->getItem(i)->getSIDouble(0);
+            double *cWtfMapaxes = static_cast<double*>(malloc(sizeof(double)*mapaxesRecord.size()));
+            for (unsigned i = 0; i < mapaxesRecord.size(); ++i)
+                cWtfMapaxes[i] = mapaxesRecord.getItem(i).getSIDouble(0);
             grdecl.mapaxes = cWtfMapaxes;
         } else
             grdecl.mapaxes = NULL;

--- a/opm/core/io/eclipse/EclipseGridInspector.cpp
+++ b/opm/core/io/eclipse/EclipseGridInspector.cpp
@@ -70,17 +70,17 @@ void EclipseGridInspector::init_()
     }
 
     if (deck_->hasKeyword("SPECGRID")) {
-        Opm::DeckRecordConstPtr specgridRecord =
-            deck_->getKeyword("SPECGRID")->getRecord(0);
-        logical_gridsize_[0] = specgridRecord->getItem("NX")->getInt(0);
-        logical_gridsize_[1] = specgridRecord->getItem("NY")->getInt(0);
-        logical_gridsize_[2] = specgridRecord->getItem("NZ")->getInt(0);
+        const auto& specgridRecord =
+            deck_->getKeyword("SPECGRID").getRecord(0);
+        logical_gridsize_[0] = specgridRecord.getItem("NX").get< int >(0);
+        logical_gridsize_[1] = specgridRecord.getItem("NY").get< int >(0);
+        logical_gridsize_[2] = specgridRecord.getItem("NZ").get< int >(0);
     } else if (deck_->hasKeyword("DIMENS")) {
-        Opm::DeckRecordConstPtr dimensRecord =
-            deck_->getKeyword("DIMENS")->getRecord(0);
-        logical_gridsize_[0] = dimensRecord->getItem("NX")->getInt(0);
-        logical_gridsize_[1] = dimensRecord->getItem("NY")->getInt(0);
-        logical_gridsize_[2] = dimensRecord->getItem("NZ")->getInt(0);
+        const auto& dimensRecord =
+            deck_->getKeyword("DIMENS").getRecord(0);
+        logical_gridsize_[0] = dimensRecord.getItem("NX").get< int >(0);
+        logical_gridsize_[1] = dimensRecord.getItem("NY").get< int >(0);
+        logical_gridsize_[2] = dimensRecord.getItem("NZ").get< int >(0);
     } else {
         OPM_THROW(std::runtime_error, "Found neither SPECGRID nor DIMENS in file. At least one is needed.");
     }
@@ -100,13 +100,13 @@ std::pair<double,double> EclipseGridInspector::cellDips(int i, int j, int k) con
 {
     checkLogicalCoords(i, j, k);
     const std::vector<double>& pillc =
-        deck_->getKeyword("COORD")->getSIDoubleData();
+        deck_->getKeyword("COORD").getSIDoubleData();
     int num_pillars = (logical_gridsize_[0] + 1)*(logical_gridsize_[1] + 1);
         if (6*num_pillars != int(pillc.size())) {
         throw std::runtime_error("Wrong size of COORD field.");
     }
     const std::vector<double>& z =
-        deck_->getKeyword("ZCORN")->getSIDoubleData();
+        deck_->getKeyword("ZCORN").getSIDoubleData();
     int num_cells = logical_gridsize_[0]*logical_gridsize_[1]*logical_gridsize_[2];
     if (8*num_cells != int(z.size())) {
         throw std::runtime_error("Wrong size of ZCORN field");
@@ -210,13 +210,13 @@ double EclipseGridInspector::cellVolumeVerticalPillars(int i, int j, int k) cons
     // Checking parameters and obtaining values from parser.
     checkLogicalCoords(i, j, k);
     const std::vector<double>& pillc =
-        deck_->getKeyword("COORD")->getSIDoubleData();
+        deck_->getKeyword("COORD").getSIDoubleData();
     int num_pillars = (logical_gridsize_[0] + 1)*(logical_gridsize_[1] + 1);
     if (6*num_pillars != int(pillc.size())) {
 	throw std::runtime_error("Wrong size of COORD field.");
     }
     const std::vector<double>& z =
-        deck_->getKeyword("ZCORN")->getSIDoubleData();
+        deck_->getKeyword("ZCORN").getSIDoubleData();
     int num_cells = logical_gridsize_[0]*logical_gridsize_[1]*logical_gridsize_[2];
     if (8*num_cells != int(z.size())) {
 	throw std::runtime_error("Wrong size of ZCORN field");
@@ -278,8 +278,8 @@ std::array<double, 6> EclipseGridInspector::getGridLimits() const
         throw std::runtime_error("EclipseGridInspector: Grid does not have SPECGRID, COORD, and ZCORN, can't find dimensions.");
     }
 
-    std::vector<double> coord = deck_->getKeyword("COORD")->getSIDoubleData();
-    std::vector<double> zcorn = deck_->getKeyword("ZCORN")->getSIDoubleData();
+    std::vector<double> coord = deck_->getKeyword("COORD").getSIDoubleData();
+    std::vector<double> zcorn = deck_->getKeyword("ZCORN").getSIDoubleData();
 
     double xmin = +DBL_MAX;
     double xmax = -DBL_MAX;
@@ -328,7 +328,7 @@ std::array<int, 3> EclipseGridInspector::gridSize() const
 std::array<double, 8> EclipseGridInspector::cellZvals(int i, int j, int k) const
 {
     // Get the zcorn field.
-    const std::vector<double>& z = deck_->getKeyword("ZCORN")->getSIDoubleData();
+    const std::vector<double>& z = deck_->getKeyword("ZCORN").getSIDoubleData();
     int num_cells = logical_gridsize_[0]*logical_gridsize_[1]*logical_gridsize_[2];
     if (8*num_cells != int(z.size())) {
 	throw std::runtime_error("Wrong size of ZCORN field");

--- a/opm/core/io/eclipse/EclipseReader.cpp
+++ b/opm/core/io/eclipse/EclipseReader.cpp
@@ -54,8 +54,8 @@ namespace Opm
             float* temperature_data = ecl_kw_get_float_ptr(temperature_kw);
 
             // factor and offset from the temperature values given in the deck to Kelvin
-            double scaling = eclipse_state->getDeckUnitSystem()->parse("Temperature")->getSIScaling();
-            double offset  = eclipse_state->getDeckUnitSystem()->parse("Temperature")->getSIOffset();
+            double scaling = eclipse_state->getDeckUnitSystem().parse("Temperature")->getSIScaling();
+            double offset  = eclipse_state->getDeckUnitSystem().parse("Temperature")->getSIOffset();
 
             for (size_t index = 0; index < simulator_state.temperature().size(); ++index) {
                 simulator_state.temperature()[index] = unit::convert::from((double)temperature_data[index] - offset, scaling);
@@ -81,7 +81,7 @@ namespace Opm
             }
 
             float* pressure_data = ecl_kw_get_float_ptr(pressure_kw);
-            const double deck_pressure_unit = (eclipse_state->getDeckUnitSystem()->getType() == UnitSystem::UNIT_TYPE_METRIC) ? Opm::unit::barsa : Opm::unit::psia;
+            const double deck_pressure_unit = (eclipse_state->getDeckUnitSystem().getType() == UnitSystem::UNIT_TYPE_METRIC) ? Opm::unit::barsa : Opm::unit::psia;
             for (size_t index = 0; index < simulator_state.pressure().size(); ++index) {
                 simulator_state.pressure()[index] = unit::convert::from((double)pressure_data[index], deck_pressure_unit);
             }

--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -565,7 +565,7 @@ public:
         // finally, write the grid to disk
         IOConfigConstPtr ioConfig = eclipseState->getIOConfigConst();
         if (ioConfig->getWriteEGRIDFile()) {
-            if (eclipseState->getDeckUnitSystem()->getType() == UnitSystem::UNIT_TYPE_METRIC){
+            if (eclipseState->getDeckUnitSystem().getType() == UnitSystem::UNIT_TYPE_METRIC){
                 eclGrid->fwriteEGRID(egridFileName_.ertHandle(), true);
             }else{
                 eclGrid->fwriteEGRID(egridFileName_.ertHandle(), false);
@@ -1029,8 +1029,7 @@ void Summary::addAllWells(Opm::EclipseStateConstPtr eclipseState,
                           const PhaseUsage& uses)
 {
     eclipseState_ = eclipseState;
-    std::shared_ptr<const UnitSystem> unitsystem = eclipseState_->getDeckUnitSystem();
-    auto deckUnitType = unitsystem->getType();
+    auto deckUnitType = eclipseState_->getDeckUnitSystem().getType();
 
     // TODO: Only create report variables that are requested with keywords
     // (e.g. "WOPR") in the input files, and only for those wells that are
@@ -1203,8 +1202,7 @@ void EclipseWriter::writeInit(const SimulatorTimerInterface &timer)
        since it requires knowledge of the start time). */
     {
       auto eclGrid = eclipseState_->getEclipseGrid();
-      std::shared_ptr<const UnitSystem> unitsystem = eclipseState_->getDeckUnitSystem();
-      auto deckUnitType = unitsystem->getType();
+      auto deckUnitType = eclipseState_->getDeckUnitSystem().getType();
       bool time_in_days = true;
 
       if (deckUnitType == UnitSystem::UNIT_TYPE_LAB)
@@ -1370,8 +1368,8 @@ void EclipseWriter::writeTimeStep(const SimulatorTimerInterface& timer,
                                                       ECL_RFT_FILE,
                                                       ioConfig->getFMTOUT(),
                                                       0);
-        std::shared_ptr<const UnitSystem> unitsystem = eclipseState_->getDeckUnitSystem();
-        ert_ecl_unit_enum ecl_unit = convertUnitTypeErtEclUnitEnum(unitsystem->getType());
+        auto unit_type = eclipseState_->getDeckUnitSystem().getType();
+        ert_ecl_unit_enum ecl_unit = convertUnitTypeErtEclUnitEnum(unit_type);
         std::vector<WellConstPtr> wells = eclipseState_->getSchedule()->getWells(timer.reportStepNum());
         eclipseWriteRFTHandler->writeTimeStep(rft_filename,
                                               ecl_unit,
@@ -1444,13 +1442,13 @@ EclipseWriter::EclipseWriter(const parameter::ParameterGroup& params,
 
     // factor from the pressure values given in the deck to Pascals
     deckToSiPressure_ =
-        eclipseState->getDeckUnitSystem()->parse("Pressure")->getSIScaling();
+        eclipseState->getDeckUnitSystem().parse("Pressure")->getSIScaling();
 
     // factor and offset from the temperature values given in the deck to Kelvin
     deckToSiTemperatureFactor_ =
-        eclipseState->getDeckUnitSystem()->parse("Temperature")->getSIScaling();
+        eclipseState->getDeckUnitSystem().parse("Temperature")->getSIScaling();
     deckToSiTemperatureOffset_ =
-        eclipseState->getDeckUnitSystem()->parse("Temperature")->getSIOffset();
+        eclipseState->getDeckUnitSystem().parse("Temperature")->getSIOffset();
 
     init(params);
 }

--- a/opm/core/props/IncompPropertiesSinglePhase.cpp
+++ b/opm/core/props/IncompPropertiesSinglePhase.cpp
@@ -38,8 +38,8 @@ namespace Opm
         rock_.init(eclState, grid.number_of_cells, grid.global_cell, grid.cartdims);
 
         if (deck->hasKeyword("DENSITY")) {
-            Opm::DeckRecordConstPtr densityRecord = deck->getKeyword("DENSITY")->getRecord(0);
-            surface_density_ = densityRecord->getItem("OIL")->getSIDouble(0);
+            const auto& densityRecord = deck->getKeyword("DENSITY").getRecord(0);
+            surface_density_ = densityRecord.getItem("OIL").getSIDouble(0);
         } else {
             surface_density_ = 1000.0;
             OPM_MESSAGE("Input is missing DENSITY -- using a standard density of "
@@ -50,13 +50,13 @@ namespace Opm
         reservoir_density_ = surface_density_;
 
         if (deck->hasKeyword("PVCDO")) {
-            Opm::DeckRecordConstPtr pvcdoRecord = deck->getKeyword("PVCDO")->getRecord(0);
-            if (pvcdoRecord->getItem("OIL_COMPRESSIBILITY")->getSIDouble(0) != 0.0 ||
-                pvcdoRecord->getItem("OIL_VISCOSIBILITY")->getSIDouble(0) != 0.0) {
+            const auto& pvcdoRecord = deck->getKeyword("PVCDO").getRecord(0);
+            if (pvcdoRecord.getItem("OIL_COMPRESSIBILITY").getSIDouble(0) != 0.0 ||
+                pvcdoRecord.getItem("OIL_VISCOSIBILITY").getSIDouble(0) != 0.0) {
                 OPM_MESSAGE("Compressibility effects in PVCDO are ignored.");
             }
-            reservoir_density_ /= pvcdoRecord->getItem("OIL_VOL_FACTOR")->getSIDouble(0);
-            viscosity_ = pvcdoRecord->getItem("OIL_VISCOSITY")->getSIDouble(0);
+            reservoir_density_ /= pvcdoRecord.getItem("OIL_VOL_FACTOR").getSIDouble(0);
+            viscosity_ = pvcdoRecord.getItem("OIL_VISCOSITY").getSIDouble(0);
         } else {
             viscosity_ = 1.0 * prefix::centi*unit::Poise;
             OPM_MESSAGE("Input is missing PVCDO -- using a standard viscosity of "

--- a/opm/core/props/pvt/BlackoilPvtProperties.cpp
+++ b/opm/core/props/pvt/BlackoilPvtProperties.cpp
@@ -49,22 +49,22 @@ namespace Opm
         phase_usage_ = phaseUsageFromDeck(deck);
 
         // Surface densities. Accounting for different orders in eclipse and our code.
-        Opm::DeckKeywordConstPtr densityKeyword = deck->getKeyword("DENSITY");
-        int numRegions = densityKeyword->size();
+        const auto& densityKeyword = deck->getKeyword("DENSITY");
+        int numRegions = densityKeyword.size();
 
         densities_.resize(numRegions);
         for (int regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
             if (phase_usage_.phase_used[Liquid]) {
                 densities_[regionIdx][phase_usage_.phase_pos[Liquid]]
-                    = densityKeyword->getRecord(regionIdx)->getItem("OIL")->getSIDouble(0);
+                    = densityKeyword.getRecord(regionIdx).getItem("OIL").getSIDouble(0);
             }
             if (phase_usage_.phase_used[Aqua]) {
                 densities_[regionIdx][phase_usage_.phase_pos[Aqua]]
-                    = densityKeyword->getRecord(regionIdx)->getItem("WATER")->getSIDouble(0);
+                    = densityKeyword.getRecord(regionIdx).getItem("WATER").getSIDouble(0);
             }
             if (phase_usage_.phase_used[Vapour]) {
                 densities_[regionIdx][phase_usage_.phase_pos[Vapour]]
-                    = densityKeyword->getRecord(regionIdx)->getItem("GAS")->getSIDouble(0);
+                    = densityKeyword.getRecord(regionIdx).getItem("GAS").getSIDouble(0);
             }
         }
 

--- a/opm/core/props/pvt/PvtConstCompr.hpp
+++ b/opm/core/props/pvt/PvtConstCompr.hpp
@@ -50,9 +50,9 @@ namespace Opm
         PvtConstCompr()
         {}
 
-        void initFromWater(Opm::DeckKeywordConstPtr pvtwKeyword)
+        void initFromWater(const Opm::DeckKeyword& pvtwKeyword)
         {
-            int numRegions = pvtwKeyword->size();
+            int numRegions = pvtwKeyword.size();
 
             ref_press_.resize(numRegions);
             ref_B_.resize(numRegions);
@@ -61,19 +61,19 @@ namespace Opm
             visc_comp_.resize(numRegions);
 
             for (int regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
-                Opm::DeckRecordConstPtr pvtwRecord = pvtwKeyword->getRecord(regionIdx);
+                const auto& pvtwRecord = pvtwKeyword.getRecord(regionIdx);
 
-                ref_press_[regionIdx] = pvtwRecord->getItem("P_REF")->getSIDouble(0);
-                ref_B_[regionIdx]     = pvtwRecord->getItem("WATER_VOL_FACTOR")->getSIDouble(0);
-                comp_[regionIdx]      = pvtwRecord->getItem("WATER_COMPRESSIBILITY")->getSIDouble(0);
-                viscosity_[regionIdx] = pvtwRecord->getItem("WATER_VISCOSITY")->getSIDouble(0);
-                visc_comp_[regionIdx] = pvtwRecord->getItem("WATER_VISCOSIBILITY")->getSIDouble(0);
+                ref_press_[regionIdx] = pvtwRecord.getItem("P_REF").getSIDouble(0);
+                ref_B_[regionIdx]     = pvtwRecord.getItem("WATER_VOL_FACTOR").getSIDouble(0);
+                comp_[regionIdx]      = pvtwRecord.getItem("WATER_COMPRESSIBILITY").getSIDouble(0);
+                viscosity_[regionIdx] = pvtwRecord.getItem("WATER_VISCOSITY").getSIDouble(0);
+                visc_comp_[regionIdx] = pvtwRecord.getItem("WATER_VISCOSIBILITY").getSIDouble(0);
             }
         }
 
-        void initFromOil(Opm::DeckKeywordConstPtr pvcdoKeyword)
+        void initFromOil(const DeckKeyword& pvcdoKeyword)
         {
-            int numRegions = pvcdoKeyword->size();
+            int numRegions = pvcdoKeyword.size();
 
             ref_press_.resize(numRegions);
             ref_B_.resize(numRegions);
@@ -82,13 +82,13 @@ namespace Opm
             visc_comp_.resize(numRegions);
 
             for (int regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
-                Opm::DeckRecordConstPtr pvcdoRecord = pvcdoKeyword->getRecord(regionIdx);
+                const auto& pvcdoRecord = pvcdoKeyword.getRecord(regionIdx);
 
-                ref_press_[regionIdx] = pvcdoRecord->getItem("P_REF")->getSIDouble(0);
-                ref_B_[regionIdx]     = pvcdoRecord->getItem("OIL_VOL_FACTOR")->getSIDouble(0);
-                comp_[regionIdx]      = pvcdoRecord->getItem("OIL_COMPRESSIBILITY")->getSIDouble(0);
-                viscosity_[regionIdx] = pvcdoRecord->getItem("OIL_VISCOSITY")->getSIDouble(0);
-                visc_comp_[regionIdx] = pvcdoRecord->getItem("OIL_VISCOSIBILITY")->getSIDouble(0);
+                ref_press_[regionIdx] = pvcdoRecord.getItem("P_REF").getSIDouble(0);
+                ref_B_[regionIdx]     = pvcdoRecord.getItem("OIL_VOL_FACTOR").getSIDouble(0);
+                comp_[regionIdx]      = pvcdoRecord.getItem("OIL_COMPRESSIBILITY").getSIDouble(0);
+                viscosity_[regionIdx] = pvcdoRecord.getItem("OIL_VISCOSITY").getSIDouble(0);
+                visc_comp_[regionIdx] = pvcdoRecord.getItem("OIL_VISCOSIBILITY").getSIDouble(0);
             }
         }
 

--- a/opm/core/props/pvt/PvtPropertiesIncompFromDeck.cpp
+++ b/opm/core/props/pvt/PvtPropertiesIncompFromDeck.cpp
@@ -50,9 +50,9 @@ namespace Opm
 
         // Surface densities. Accounting for different orders in eclipse and our code.
         if (deck->hasKeyword("DENSITY")) {
-            Opm::DeckRecordConstPtr densityRecord = deck->getKeyword("DENSITY")->getRecord(region_number);
-            surface_density_[phase_usage.phase_pos[PhaseUsage::Aqua]]   = densityRecord->getItem("OIL")->getSIDouble(0);
-            surface_density_[phase_usage.phase_pos[PhaseUsage::Liquid]] = densityRecord->getItem("WATER")->getSIDouble(0);
+            const auto& densityRecord = deck->getKeyword("DENSITY").getRecord(region_number);
+            surface_density_[phase_usage.phase_pos[PhaseUsage::Aqua]]   = densityRecord.getItem("OIL").getSIDouble(0);
+            surface_density_[phase_usage.phase_pos[PhaseUsage::Liquid]] = densityRecord.getItem("WATER").getSIDouble(0);
         } else {
             OPM_THROW(std::runtime_error, "Input is missing DENSITY\n");
         }
@@ -63,13 +63,13 @@ namespace Opm
 
         // Water viscosity.
         if (deck->hasKeyword("PVTW")) {
-            Opm::DeckRecordConstPtr pvtwRecord = deck->getKeyword("PVTW")->getRecord(region_number);
-            if (pvtwRecord->getItem("WATER_COMPRESSIBILITY")->getSIDouble(0) != 0.0 ||
-                pvtwRecord->getItem("WATER_VISCOSIBILITY")->getSIDouble(0) != 0.0) {
+            const auto& pvtwRecord = deck->getKeyword("PVTW").getRecord(region_number);
+            if (pvtwRecord.getItem("WATER_COMPRESSIBILITY").getSIDouble(0) != 0.0 ||
+                pvtwRecord.getItem("WATER_VISCOSIBILITY").getSIDouble(0) != 0.0) {
                 OPM_MESSAGE("Compressibility effects in PVTW are ignored.");
             }
-            reservoir_density_[phase_usage.phase_pos[PhaseUsage::Aqua]] /= pvtwRecord->getItem("WATER_VOL_FACTOR")->getSIDouble(0);
-            viscosity_[phase_usage.phase_pos[PhaseUsage::Aqua]] = pvtwRecord->getItem("WATER_VISCOSITY")->getSIDouble(0);
+            reservoir_density_[phase_usage.phase_pos[PhaseUsage::Aqua]] /= pvtwRecord.getItem("WATER_VOL_FACTOR").getSIDouble(0);
+            viscosity_[phase_usage.phase_pos[PhaseUsage::Aqua]] = pvtwRecord.getItem("WATER_VISCOSITY").getSIDouble(0);
         } else {
             // Eclipse 100 default.
             // viscosity_[phase_usage.phase_pos[PhaseUsage::Aqua]] = 0.5*Opm::prefix::centi*Opm::unit::Poise;
@@ -78,14 +78,14 @@ namespace Opm
 
         // Oil viscosity.
         if (deck->hasKeyword("PVCDO")) {
-            Opm::DeckRecordConstPtr pvcdoRecord = deck->getKeyword("PVCDO")->getRecord(region_number);
+            const auto& pvcdoRecord = deck->getKeyword("PVCDO").getRecord(region_number);
 
-            if (pvcdoRecord->getItem("OIL_COMPRESSIBILITY")->getSIDouble(0) != 0.0 ||
-                pvcdoRecord->getItem("OIL_VISCOSIBILITY")->getSIDouble(0) != 0.0) {
+            if (pvcdoRecord.getItem("OIL_COMPRESSIBILITY").getSIDouble(0) != 0.0 ||
+                pvcdoRecord.getItem("OIL_VISCOSIBILITY").getSIDouble(0) != 0.0) {
                 OPM_MESSAGE("Compressibility effects in PVCDO are ignored.");
             }
-            reservoir_density_[phase_usage.phase_pos[PhaseUsage::Liquid]] /= pvcdoRecord->getItem("OIL_VOL_FACTOR")->getSIDouble(0);
-            viscosity_[phase_usage.phase_pos[PhaseUsage::Liquid]] = pvcdoRecord->getItem("OIL_VISCOSITY")->getSIDouble(0);
+            reservoir_density_[phase_usage.phase_pos[PhaseUsage::Liquid]] /= pvcdoRecord.getItem("OIL_VOL_FACTOR").getSIDouble(0);
+            viscosity_[phase_usage.phase_pos[PhaseUsage::Liquid]] = pvcdoRecord.getItem("OIL_VISCOSITY").getSIDouble(0);
         } else {
             OPM_THROW(std::runtime_error, "Input is missing PVCDO\n");
         }

--- a/opm/core/props/pvt/ThermalGasPvtWrapper.hpp
+++ b/opm/core/props/pvt/ThermalGasPvtWrapper.hpp
@@ -60,13 +60,13 @@ namespace Opm
                 assert(int(gasvisctTables_->size()) == numRegions);
                 static_cast<void>(numRegions); //Silence compiler warning
 
-                gasCompIdx_ = deck->getKeyword("GCOMPIDX")->getRecord(0)->getItem("GAS_COMPONENT_INDEX")->getInt(0) - 1;
+                gasCompIdx_ = deck->getKeyword("GCOMPIDX").getRecord(0).getItem("GAS_COMPONENT_INDEX").get< int >(0) - 1;
                 gasvisctColumnName_ = "Viscosity"+std::to_string(static_cast<long long>(gasCompIdx_));
             }
 
             // density
             if (deck->hasKeyword("TREF")) {
-                tref_ = deck->getKeyword("TREF")->getRecord(0)->getItem("TEMPERATURE")->getSIDouble(0);
+                tref_ = deck->getKeyword("TREF").getRecord(0).getItem("TEMPERATURE").getSIDouble(0);
             }
         }
 

--- a/opm/core/props/pvt/ThermalOilPvtWrapper.hpp
+++ b/opm/core/props/pvt/ThermalOilPvtWrapper.hpp
@@ -54,25 +54,25 @@ namespace Opm
             else if (deck->hasKeyword("PVDO"))
                 numRegions = tables->getPvdoTables().size();
             else if (deck->hasKeyword("PVCDO"))
-                numRegions = deck->getKeyword("PVCDO")->size();
+                numRegions = deck->getKeyword("PVCDO").size();
             else
                 OPM_THROW(std::runtime_error, "Oil phase was not initialized using a known way");
 
             // viscosity
             if (deck->hasKeyword("VISCREF")) {
                 oilvisctTables_ = &tables->getOilvisctTables();
-                Opm::DeckKeywordConstPtr viscrefKeyword = deck->getKeyword("VISCREF");
+                const auto& viscrefKeyword = deck->getKeyword("VISCREF");
 
                 assert(int(oilvisctTables_->size()) == numRegions);
-                assert(int(viscrefKeyword->size()) == numRegions);
+                assert(int(viscrefKeyword.size()) == numRegions);
 
                 viscrefPress_.resize(numRegions);
                 viscrefRs_.resize(numRegions);
                 muRef_.resize(numRegions);
                 for (int regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
-                    DeckRecordConstPtr viscrefRecord = viscrefKeyword->getRecord(regionIdx);
-                    viscrefPress_[regionIdx] = viscrefRecord->getItem("REFERENCE_PRESSURE")->getSIDouble(0);
-                    viscrefRs_[regionIdx] = viscrefRecord->getItem("REFERENCE_RS")->getSIDouble(0);
+                    const auto& viscrefRecord = viscrefKeyword.getRecord(regionIdx);
+                    viscrefPress_[regionIdx] = viscrefRecord.getItem("REFERENCE_PRESSURE").getSIDouble(0);
+                    viscrefRs_[regionIdx] = viscrefRecord.getItem("REFERENCE_RS").getSIDouble(0);
 
                     // temperature used to calculate the reference viscosity [K]. the
                     // value does not really matter if the underlying PVT object really
@@ -96,13 +96,13 @@ namespace Opm
             // for the first EOS. (since EOS != PVT region.)
             tref_ = 0.0;
             if (deck->hasKeyword("THERMEX1")) {
-                oilCompIdx_ = deck->getKeyword("OCOMPIDX")->getRecord(0)->getItem("OIL_COMPONENT_INDEX")->getInt(0) - 1;
+                oilCompIdx_ = deck->getKeyword("OCOMPIDX").getRecord(0).getItem("OIL_COMPONENT_INDEX").get< int >(0) - 1;
 
                 // always use the values of the first EOS
-                tref_ = deck->getKeyword("TREF")->getRecord(0)->getItem("TEMPERATURE")->getSIDouble(oilCompIdx_);
-                pref_ = deck->getKeyword("PREF")->getRecord(0)->getItem("PRESSURE")->getSIDouble(oilCompIdx_);
-                cref_ = deck->getKeyword("CREF")->getRecord(0)->getItem("COMPRESSIBILITY")->getSIDouble(oilCompIdx_);
-                thermex1_ = deck->getKeyword("THERMEX1")->getRecord(0)->getItem("EXPANSION_COEFF")->getSIDouble(oilCompIdx_);
+                tref_ = deck->getKeyword("TREF").getRecord(0).getItem("TEMPERATURE").getSIDouble(oilCompIdx_);
+                pref_ = deck->getKeyword("PREF").getRecord(0).getItem("PRESSURE").getSIDouble(oilCompIdx_);
+                cref_ = deck->getKeyword("CREF").getRecord(0).getItem("COMPRESSIBILITY").getSIDouble(oilCompIdx_);
+                thermex1_ = deck->getKeyword("THERMEX1").getRecord(0).getItem("EXPANSION_COEFF").getSIDouble(oilCompIdx_);
             }
         }
 

--- a/opm/core/props/pvt/ThermalWaterPvtWrapper.hpp
+++ b/opm/core/props/pvt/ThermalWaterPvtWrapper.hpp
@@ -48,19 +48,19 @@ namespace Opm
             watvisctTables_ = 0;
 
             // stuff which we need to get from the PVTW keyword
-            Opm::DeckKeywordConstPtr pvtwKeyword = deck->getKeyword("PVTW");
-            int numRegions = pvtwKeyword->size();
+            const auto& pvtwKeyword = deck->getKeyword("PVTW");
+            int numRegions = pvtwKeyword.size();
             pvtwRefPress_.resize(numRegions);
             pvtwRefB_.resize(numRegions);
             pvtwCompressibility_.resize(numRegions);
             pvtwViscosity_.resize(numRegions);
             pvtwViscosibility_.resize(numRegions);
             for (int regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
-                Opm::DeckRecordConstPtr pvtwRecord = pvtwKeyword->getRecord(regionIdx);
-                pvtwRefPress_[regionIdx] = pvtwRecord->getItem("P_REF")->getSIDouble(0);
-                pvtwRefB_[regionIdx] = pvtwRecord->getItem("WATER_VOL_FACTOR")->getSIDouble(0);
-                pvtwViscosity_[regionIdx] = pvtwRecord->getItem("WATER_VISCOSITY")->getSIDouble(0);
-                pvtwViscosibility_[regionIdx] = pvtwRecord->getItem("WATER_VISCOSIBILITY")->getSIDouble(0);
+                const auto& pvtwRecord = pvtwKeyword.getRecord(regionIdx);
+                pvtwRefPress_[regionIdx] = pvtwRecord.getItem("P_REF").getSIDouble(0);
+                pvtwRefB_[regionIdx] = pvtwRecord.getItem("WATER_VOL_FACTOR").getSIDouble(0);
+                pvtwViscosity_[regionIdx] = pvtwRecord.getItem("WATER_VISCOSITY").getSIDouble(0);
+                pvtwViscosibility_[regionIdx] = pvtwRecord.getItem("WATER_VISCOSIBILITY").getSIDouble(0);
             }
 
             // quantities required for the temperature dependence of the viscosity
@@ -68,34 +68,34 @@ namespace Opm
             if (deck->hasKeyword("VISCREF")) {
                 auto tables = eclipseState->getTableManager();
                 watvisctTables_ = &tables->getWatvisctTables();
-                Opm::DeckKeywordConstPtr viscrefKeyword = deck->getKeyword("VISCREF");
+                const auto& viscrefKeyword = deck->getKeyword("VISCREF");
 
                 assert(int(watvisctTables_->size()) == numRegions);
-                assert(int(viscrefKeyword->size()) == numRegions);
+                assert(int(viscrefKeyword.size()) == numRegions);
 
                 viscrefPress_.resize(numRegions);
                 for (int regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
-                    Opm::DeckRecordConstPtr viscrefRecord = viscrefKeyword->getRecord(regionIdx);
+                    const auto& viscrefRecord = viscrefKeyword.getRecord(regionIdx);
 
-                    viscrefPress_[regionIdx] = viscrefRecord->getItem("REFERENCE_PRESSURE")->getSIDouble(0);
+                    viscrefPress_[regionIdx] = viscrefRecord.getItem("REFERENCE_PRESSURE").getSIDouble(0);
                 }
             }
 
             // quantities required for the temperature dependence of the density
             if (deck->hasKeyword("WATDENT")) {
-                DeckKeywordConstPtr watdentKeyword = deck->getKeyword("WATDENT");
+                const auto& watdentKeyword = deck->getKeyword("WATDENT");
 
-                assert(int(watdentKeyword->size()) == numRegions);
+                assert(int(watdentKeyword.size()) == numRegions);
 
                 watdentRefTemp_.resize(numRegions);
                 watdentCT1_.resize(numRegions);
                 watdentCT2_.resize(numRegions);
                 for (int regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
-                    Opm::DeckRecordConstPtr watdentRecord = watdentKeyword->getRecord(regionIdx);
+                    const auto& watdentRecord = watdentKeyword.getRecord(regionIdx);
 
-                    watdentRefTemp_[regionIdx] = watdentRecord->getItem("REFERENCE_TEMPERATURE")->getSIDouble(0);
-                    watdentCT1_[regionIdx] = watdentRecord->getItem("EXPANSION_COEFF_LINEAR")->getSIDouble(0);
-                    watdentCT2_[regionIdx] = watdentRecord->getItem("EXPANSION_COEFF_QUADRATIC")->getSIDouble(0);
+                    watdentRefTemp_[regionIdx] = watdentRecord.getItem("REFERENCE_TEMPERATURE").getSIDouble(0);
+                    watdentCT1_[regionIdx] = watdentRecord.getItem("EXPANSION_COEFF_LINEAR").getSIDouble(0);
+                    watdentCT2_[regionIdx] = watdentRecord.getItem("EXPANSION_COEFF_QUADRATIC").getSIDouble(0);
                 }
             }
         }

--- a/opm/core/props/rock/RockCompressibility.cpp
+++ b/opm/core/props/rock/RockCompressibility.cpp
@@ -60,16 +60,16 @@ namespace Opm
                 transmult_ =  rocktabTable.getColumn("PV_MULT_TRANX").vectorCopy();
             }
         } else if (deck->hasKeyword("ROCK")) {
-            Opm::DeckKeywordConstPtr rockKeyword = deck->getKeyword("ROCK");
-            if (rockKeyword->size() != 1) {
+            const auto& rockKeyword = deck->getKeyword("ROCK");
+            if (rockKeyword.size() != 1) {
                 // here it would be better not to use std::cout directly but to add the
                 // warning to some "warning list"...
-                std::cout << "Can only handle a single region in ROCK ("<<rockKeyword->size()<<" regions specified)."
+                std::cout << "Can only handle a single region in ROCK ("<<rockKeyword.size()<<" regions specified)."
                           << " Ignoring all except for the first.\n";
             }
 
-            pref_ = rockKeyword->getRecord(0)->getItem("PREF")->getSIDouble(0);
-            rock_comp_ = rockKeyword->getRecord(0)->getItem("COMPRESSIBILITY")->getSIDouble(0);
+            pref_ = rockKeyword.getRecord(0).getItem("PREF").getSIDouble(0);
+            rock_comp_ = rockKeyword.getRecord(0).getItem("COMPRESSIBILITY").getSIDouble(0);
         } else {
             std::cout << "**** warning: no rock compressibility data found in deck (ROCK or ROCKTAB)." << std::endl;
         }

--- a/opm/core/props/satfunc/RelpermDiagnostics.cpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics.cpp
@@ -190,9 +190,9 @@ namespace Opm{
  
 
     void RelpermDiagnostics::tableCheck_(EclipseStateConstPtr eclState, 
-                                         DeckConstPtr deck)
+                                         std::shared_ptr< const Deck > deck)
     {
-        const int numSatRegions = deck->getKeyword("TABDIMS")->getRecord(0)->getItem("NTSFUN")->getInt(0);
+        const int numSatRegions = deck->getKeyword("TABDIMS").getRecord(0).getItem("NTSFUN").get< int >(0);
         const std::string msg = "Number of saturation regions: " + std::to_string(numSatRegions) + "\n";
         std::cout << msg << std::endl;
         streamLog_->addMessage(Log::MessageType::Info, msg);
@@ -583,7 +583,7 @@ namespace Opm{
                                                      EclipseStateConstPtr eclState)
     {
         // get the number of saturation regions and the number of cells in the deck
-        const int numSatRegions = deck->getKeyword("TABDIMS")->getRecord(0)->getItem("NTSFUN")->getInt(0);
+        const int numSatRegions = deck->getKeyword("TABDIMS").getRecord(0).getItem("NTSFUN").get< int >(0);
         unscaledEpsInfo_.resize(numSatRegions);
 
         const auto tables = eclState->getTableManager();

--- a/opm/core/simulator/initState_impl.hpp
+++ b/opm/core/simulator/initState_impl.hpp
@@ -612,7 +612,7 @@ namespace Opm
             // Set saturations from SWAT/SGAS, pressure from PRESSURE.
             std::vector<double>& s = state.saturation();
             std::vector<double>& p = state.pressure();
-            const std::vector<double>& p_deck = deck->getKeyword("PRESSURE")->getSIDoubleData();
+            const std::vector<double>& p_deck = deck->getKeyword("PRESSURE").getSIDoubleData();
             const int num_cells = number_of_cells;
             if (num_phases == 2) {
                 if (!pu.phase_used[BlackoilPhases::Aqua]) {
@@ -620,7 +620,7 @@ namespace Opm
                     if (!deck->hasKeyword("SGAS")) {
                         OPM_THROW(std::runtime_error, "initStateFromDeck(): missing SGAS keyword in 2-phase init");
                     }
-                    const std::vector<double>& sg_deck = deck->getKeyword("SGAS")->getSIDoubleData();
+                    const std::vector<double>& sg_deck = deck->getKeyword("SGAS").getSIDoubleData();
                     const int gpos = pu.phase_pos[BlackoilPhases::Vapour];
                     const int opos = pu.phase_pos[BlackoilPhases::Liquid];
                     for (int c = 0; c < num_cells; ++c) {
@@ -634,7 +634,7 @@ namespace Opm
                     if (!deck->hasKeyword("SWAT")) {
                         OPM_THROW(std::runtime_error, "initStateFromDeck(): missing SWAT keyword in 2-phase init");
                     }
-                    const std::vector<double>& sw_deck = deck->getKeyword("SWAT")->getSIDoubleData();
+                    const std::vector<double>& sw_deck = deck->getKeyword("SWAT").getSIDoubleData();
                     const int wpos = pu.phase_pos[BlackoilPhases::Aqua];
                     const int nwpos = (wpos + 1) % 2;
                     for (int c = 0; c < num_cells; ++c) {
@@ -652,8 +652,8 @@ namespace Opm
                 const int wpos = pu.phase_pos[BlackoilPhases::Aqua];
                 const int gpos = pu.phase_pos[BlackoilPhases::Vapour];
                 const int opos = pu.phase_pos[BlackoilPhases::Liquid];
-                const std::vector<double>& sw_deck = deck->getKeyword("SWAT")->getSIDoubleData();
-                const std::vector<double>& sg_deck = deck->getKeyword("SGAS")->getSIDoubleData();
+                const std::vector<double>& sw_deck = deck->getKeyword("SWAT").getSIDoubleData();
+                const std::vector<double>& sg_deck = deck->getKeyword("SGAS").getSIDoubleData();
                 for (int c = 0; c < num_cells; ++c) {
                     int c_deck = (global_cell == NULL) ? c : global_cell[c];
                     s[3*c + wpos] = sw_deck[c_deck];
@@ -884,7 +884,7 @@ namespace Opm
                           face_cells, begin_face_centroids, begin_cell_centroids,
                           dimensions, props, deck, gravity, state);
         if (deck->hasKeyword("RS")) {
-            const std::vector<double>& rs_deck = deck->getKeyword("RS")->getSIDoubleData();
+            const std::vector<double>& rs_deck = deck->getKeyword("RS").getSIDoubleData();
             const int num_cells = number_of_cells;
             for (int c = 0; c < num_cells; ++c) {
                 int c_deck = (global_cell == NULL) ? c : global_cell[c];
@@ -893,7 +893,7 @@ namespace Opm
             initBlackoilSurfvolUsingRSorRV(number_of_cells, props, state);
             computeSaturation(props,state);
         } else if (deck->hasKeyword("RV")){
-            const std::vector<double>& rv_deck = deck->getKeyword("RV")->getSIDoubleData();
+            const std::vector<double>& rv_deck = deck->getKeyword("RV").getSIDoubleData();
             const int num_cells = number_of_cells;
             for (int c = 0; c < num_cells; ++c) {
                 int c_deck = (global_cell == NULL) ? c : global_cell[c];

--- a/opm/core/utility/thresholdPressures.hpp
+++ b/opm/core/utility/thresholdPressures.hpp
@@ -60,7 +60,7 @@ void computeMaxDp(std::map<std::pair<int, int>, double>& maxDp,
 
     const int numPhases = initialState.numPhases();
     const int numCells = UgGridHelpers::numCells(grid);
-    const int numPvtRegions = deck->getKeyword("TABDIMS")->getRecord(0)->getItem("NTPVT")->getInt(0);
+    const int numPvtRegions = deck->getKeyword("TABDIMS").getRecord(0).getItem("NTPVT").get< int >(0);
 
     // retrieve the minimum (residual!?) and the maximum saturations for all cells
     std::vector<double> minSat(numPhases*numCells);
@@ -73,26 +73,26 @@ void computeMaxDp(std::map<std::pair<int, int>, double>& maxDp,
 
     // retrieve the surface densities
     std::vector<std::vector<double> > surfaceDensity(numPvtRegions);
-    Opm::DeckKeywordConstPtr densityKw = deck->getKeyword("DENSITY");
+    const auto& densityKw = deck->getKeyword("DENSITY");
     for (int regionIdx = 0; regionIdx < numPvtRegions; ++regionIdx) {
         surfaceDensity[regionIdx].resize(numPhases);
 
         if (pu.phase_used[BlackoilPhases::Aqua]) {
             const int wpos = pu.phase_pos[BlackoilPhases::Aqua];
             surfaceDensity[regionIdx][wpos] =
-                densityKw->getRecord(regionIdx)->getItem("WATER")->getSIDouble(0);
+                densityKw.getRecord(regionIdx).getItem("WATER").getSIDouble(0);
         }
 
         if (pu.phase_used[BlackoilPhases::Liquid]) {
             const int opos = pu.phase_pos[BlackoilPhases::Liquid];
             surfaceDensity[regionIdx][opos] =
-                densityKw->getRecord(regionIdx)->getItem("OIL")->getSIDouble(0);
+                densityKw.getRecord(regionIdx).getItem("OIL").getSIDouble(0);
         }
 
         if (pu.phase_used[BlackoilPhases::Vapour]) {
             const int gpos = pu.phase_pos[BlackoilPhases::Vapour];
             surfaceDensity[regionIdx][gpos] =
-                densityKw->getRecord(regionIdx)->getItem("GAS")->getSIDouble(0);
+                densityKw.getRecord(regionIdx).getItem("GAS").getSIDouble(0);
         }
     }
 

--- a/tests/test_EclipseWriter.cpp
+++ b/tests/test_EclipseWriter.cpp
@@ -260,7 +260,7 @@ void checkInitFile()
         std::string keywordName(ecl_kw_get_header(eclKeyword));
 
         if (keywordName == "PORO") {
-            const std::vector<double> &sourceData = deck->getKeyword("PORO")->getSIDoubleData();
+            const std::vector<double> &sourceData = deck->getKeyword("PORO").getSIDoubleData();
             std::vector<double> resultData;
             getErtData(eclKeyword, resultData);
 
@@ -268,7 +268,7 @@ void checkInitFile()
         }
 
         if (keywordName == "PERMX") {
-            std::vector<double> sourceData = deck->getKeyword("PERMX")->getSIDoubleData();
+            std::vector<double> sourceData = deck->getKeyword("PERMX").getSIDoubleData();
             std::vector<double> resultData;
             getErtData(eclKeyword, resultData);
 

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -33,7 +33,6 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
-#include <opm/parser/eclipse/Deck/DeckDoubleItem.hpp>
 
 #include <string>
 #include <iostream>
@@ -48,10 +47,10 @@ BOOST_AUTO_TEST_CASE(CreateParser)
     Opm::DeckConstPtr deck = parser->parseFile( filename1 , parseMode);
 
     BOOST_CHECK_EQUAL( 6U , deck->size() );
-    Opm::DeckItemConstPtr actnum = deck->getKeyword("ACTNUM")->getRecord(0)->getItem(0);
-    const std::vector<int>& actnum_data = actnum->getIntData();
+    const auto& actnum = deck->getKeyword("ACTNUM").getRecord(0).getItem(0);
+    const std::vector<int>& actnum_data = actnum.getData< int >();
 
-    BOOST_CHECK_EQUAL( 1000U , actnum->size() );
+    BOOST_CHECK_EQUAL( 1000U , actnum.size() );
     BOOST_CHECK_EQUAL( 1, actnum_data[0] );
     BOOST_CHECK_EQUAL( 2, actnum_data[400] );
     BOOST_CHECK_EQUAL( 3, actnum_data[999] );

--- a/tests/test_ug.cpp
+++ b/tests/test_ug.cpp
@@ -88,18 +88,18 @@ BOOST_AUTO_TEST_CASE(EqualEclipseGrid) {
     struct UnstructuredGrid * cgrid2;
     {
         struct grdecl g;
-        Opm::DeckKeywordConstPtr dimens = deck->getKeyword("DIMENS");
-        Opm::DeckKeywordConstPtr coord = deck->getKeyword("COORD");
-        Opm::DeckKeywordConstPtr zcorn = deck->getKeyword("ZCORN");
-        Opm::DeckKeywordConstPtr actnum = deck->getKeyword("ACTNUM");
+        const auto& dimens = deck->getKeyword("DIMENS");
+        const auto& coord = deck->getKeyword("COORD");
+        const auto& zcorn = deck->getKeyword("ZCORN");
+        const auto& actnum = deck->getKeyword("ACTNUM");
         
-        g.dims[0] = dimens->getRecord(0)->getItem("NX")->getInt(0);
-        g.dims[1] = dimens->getRecord(0)->getItem("NY")->getInt(0);
-        g.dims[2] = dimens->getRecord(0)->getItem("NZ")->getInt(0);
+        g.dims[0] = dimens.getRecord(0).getItem("NX").get< int >(0);
+        g.dims[1] = dimens.getRecord(0).getItem("NY").get< int >(0);
+        g.dims[2] = dimens.getRecord(0).getItem("NZ").get< int >(0);
 
-        g.coord  = coord->getSIDoubleData().data();
-        g.zcorn  = zcorn->getSIDoubleData().data();
-        g.actnum = actnum->getIntData().data();
+        g.coord  = coord.getSIDoubleData().data();
+        g.zcorn  = zcorn.getSIDoubleData().data();
+        g.actnum = actnum.getIntData().data();
         g.mapaxes = NULL;
     
         


### PR DESCRIPTION
OPM/opm-parser#677 changes the return types for the Deck family of classes.
This patch fixes all broken code from that patch set.

https://github.com/OPM/opm-parser/pull/677