### PR TITLE
fix the build

### DIFF
--- a/opm/core/utility/CompressedPropertyAccess.hpp
+++ b/opm/core/utility/CompressedPropertyAccess.hpp
@@ -205,13 +205,13 @@ namespace Opm {
                      * \return Data values for property \c kw.
                      */
                     template <class PropertyContainer>
-                    static std::shared_ptr< GridProperty<double> >
+                    static std::shared_ptr<const GridProperty<double> >
                     value(PropertyContainer& ecl,
                           const std::string& kw);
                 };
 
                 template <class PropertyContainer>
-                std::shared_ptr< GridProperty<double> >
+                std::shared_ptr<const GridProperty<double> >
                 GetProperty<double>::value(PropertyContainer& ecl,
                                            const std::string& kw)
                 {
@@ -245,18 +245,18 @@ namespace Opm {
                  * an empty \code shared_ptr<> \endcode if not.
                  */
                 template <class PropertyContainer>
-                static std::shared_ptr< GridProperty<T> >
+                static std::shared_ptr<const GridProperty<T> >
                 value(PropertyContainer& ecl,
                       const std::string& kw);
             };
 
             template <typename T>
             template <class PropertyContainer>
-            std::shared_ptr< GridProperty<T> >
+            std::shared_ptr<const GridProperty<T> >
             EclipsePropertyArray<T>::value(PropertyContainer& ecl,
                                            const std::string& kw)
             {
-                std::shared_ptr< GridProperty<T> > x;
+                std::shared_ptr<const GridProperty<T> > x;
 
                 if (EclPropImpl::HasProperty<T>::p(ecl, kw)) {
                     x = EclPropImpl::GetProperty<T>::value(ecl, kw);
@@ -349,7 +349,7 @@ namespace Opm {
                  *
                  * Null if data not defined.
                  */
-                std::shared_ptr< GridProperty<T> > x_;
+                std::shared_ptr<const GridProperty<T> > x_;
 
                 /**
                  * Fall-back data element value if data not defined.

--- a/opm/core/utility/thresholdPressures.hpp
+++ b/opm/core/utility/thresholdPressures.hpp
@@ -55,7 +55,7 @@ void computeMaxDp(std::map<std::pair<int, int>, double>& maxDp,
 
     const PhaseUsage& pu = props.phaseUsage();
 
-    std::shared_ptr<GridProperty<int>> eqlnum = eclipseState->getIntGridProperty("EQLNUM");
+    std::shared_ptr<const GridProperty<int>> eqlnum = eclipseState->getIntGridProperty("EQLNUM");
     const auto& eqlnumData = eqlnum->getData();
 
     const int numPhases = initialState.numPhases();
@@ -324,7 +324,7 @@ void computeMaxDp(std::map<std::pair<int, int>, double>& maxDp,
         std::vector<double> thpres_vals;
         if (simulationConfig->hasThresholdPressure()) {
             std::shared_ptr<const ThresholdPressure> thresholdPressure = simulationConfig->getThresholdPressure();
-            std::shared_ptr<GridProperty<int>> eqlnum = eclipseState->getIntGridProperty("EQLNUM");
+            std::shared_ptr<const GridProperty<int>> eqlnum = eclipseState->getIntGridProperty("EQLNUM");
             const auto& eqlnumData = eqlnum->getData();
 
             // Set threshold pressure values for each cell face.
@@ -382,7 +382,7 @@ void computeMaxDp(std::map<std::pair<int, int>, double>& maxDp,
         std::vector<double> thpres_vals;
         if (simulationConfig->hasThresholdPressure()) {
             std::shared_ptr<const ThresholdPressure> thresholdPressure = simulationConfig->getThresholdPressure();
-            std::shared_ptr<GridProperty<int>> eqlnum = eclipseState->getIntGridProperty("EQLNUM");
+            std::shared_ptr<const GridProperty<int>> eqlnum = eclipseState->getIntGridProperty("EQLNUM");
             auto eqlnumData = eqlnum->getData();
 
             // Set values for each NNC


### PR DESCRIPTION
it broke because EclipseState::get*GridProperty() now returns a
pointer to a constant object.

this patch us thus required as a follow-up of OPM/opm-parser#687