### PR TITLE
Changes in SimulatorState:

### DIFF
--- a/opm/core/pressure/IncompTpfa.cpp
+++ b/opm/core/pressure/IncompTpfa.cpp
@@ -28,7 +28,7 @@
 #include <opm/core/pressure/flow_bc.h>
 #include <opm/core/linalg/LinearSolverInterface.hpp>
 #include <opm/core/linalg/sparse_sys.h>
-#include <opm/core/simulator/TwophaseState.hpp>
+#include <opm/core/simulator/SimulatorState.hpp>
 #include <opm/core/simulator/WellState.hpp>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/core/utility/miscUtilities.hpp>
@@ -155,7 +155,7 @@ namespace Opm
     /// May throw an exception if the number of iterations
     /// exceed maxiter (set in constructor).
     void IncompTpfa::solve(const double dt,
-                           TwophaseState& state,
+                           SimulatorState& state,
                            WellState& well_state)
     {
         if (rock_comp_props_ != 0 && rock_comp_props_->isActive()) {
@@ -169,7 +169,7 @@ namespace Opm
 
     // Solve with no rock compressibility (linear eqn).
     void IncompTpfa::solveIncomp(const double dt,
-                                 TwophaseState& state,
+                                 SimulatorState& state,
                                  WellState& well_state)
     {
         // Set up properties.
@@ -207,7 +207,7 @@ namespace Opm
 
     // Solve with rock compressibility (nonlinear eqn).
     void IncompTpfa::solveRockComp(const double dt,
-                                   TwophaseState& state,
+                                   SimulatorState& state,
                                    WellState& well_state)
     {
         // This function is identical to CompressibleTpfa::solve().
@@ -321,7 +321,7 @@ namespace Opm
 
     /// Compute per-solve dynamic properties.
     void IncompTpfa::computePerSolveDynamicData(const double /*dt*/,
-                                                const TwophaseState& state,
+                                                const SimulatorState& state,
                                                 const WellState& /*well_state*/)
     {
         // Computed here:
@@ -369,7 +369,7 @@ namespace Opm
 
     /// Compute per-iteration dynamic properties.
     void IncompTpfa::computePerIterationDynamicData(const double /*dt*/,
-                                                    const TwophaseState& state,
+                                                    const SimulatorState& state,
                                                     const WellState& well_state)
     {
         // These are the variables that get computed by this function:
@@ -396,7 +396,7 @@ namespace Opm
 
     /// Compute the residual in h_->b and Jacobian in h_->A.
     void IncompTpfa::assemble(const double dt,
-                              const TwophaseState& state,
+                              const SimulatorState& state,
                               const WellState& /*well_state*/)
     {
         const double* pressures = wells_ ? &pressures_[0] : &state.pressure()[0];
@@ -462,7 +462,7 @@ namespace Opm
 
 
     /// Compute the output.
-    void IncompTpfa::computeResults(TwophaseState& state,
+    void IncompTpfa::computeResults(SimulatorState& state,
                                     WellState& well_state) const
     {
         // Make sure h_ contains the direct-solution matrix

--- a/opm/core/pressure/IncompTpfa.hpp
+++ b/opm/core/pressure/IncompTpfa.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_INCOMPTPFA_HEADER_INCLUDED
 #define OPM_INCOMPTPFA_HEADER_INCLUDED
 
+#include <opm/core/simulator/SimulatorState.hpp>
 
 #include <opm/core/pressure/tpfa/ifs_tpfa.h>
 #include <vector>
@@ -34,8 +35,9 @@ namespace Opm
     class IncompPropertiesInterface;
     class RockCompressibility;
     class LinearSolverInterface;
-    class TwophaseState;
     class WellState;
+    class SimulatoreState;
+
 
     /// Encapsulating a tpfa pressure solver for the incompressible-fluid case.
     /// Supports gravity, wells controlled by bhp or reservoir rates,
@@ -112,7 +114,7 @@ namespace Opm
         /// May throw an exception if the number of iterations
         /// exceed maxiter (set in constructor).
         void solve(const double dt,
-                   TwophaseState& state,
+                   SimulatorState& state,
                    WellState& well_state);
 
 
@@ -122,28 +124,28 @@ namespace Opm
     protected:
         // Solve with no rock compressibility (linear eqn).
         void solveIncomp(const double dt,
-                         TwophaseState& state,
+                         SimulatorState& state,
                          WellState& well_state);
         // Solve with rock compressibility (nonlinear eqn).
         void solveRockComp(const double dt,
-                           TwophaseState& state,
+                           SimulatorState& state,
                            WellState& well_state);
     private:
         // Helper functions.
         void computeStaticData();
         virtual void computePerSolveDynamicData(const double dt,
-                                                const TwophaseState& state,
+                                                const SimulatorState& state,
                                                 const WellState& well_state);
         void computePerIterationDynamicData(const double dt,
-                                            const TwophaseState& state,
+                                            const SimulatorState& state,
                                             const WellState& well_state);
         void assemble(const double dt,
-                      const TwophaseState& state,
+                      const SimulatorState& state,
                       const WellState& well_state);
         void solveIncrement();
         double residualNorm() const;
         double incrementNorm() const;
-	void computeResults(TwophaseState& state,
+	void computeResults(SimulatorState& state,
                             WellState& well_state) const;
 
     protected:

--- a/opm/core/simulator/BlackoilState.cpp
+++ b/opm/core/simulator/BlackoilState.cpp
@@ -23,16 +23,6 @@ BlackoilState::init(const UnstructuredGrid& g, int num_phases)
 {
     init(g.number_of_cells, g.number_of_faces, num_phases);
 }
-/// Set the first saturation to either its min or max value in
-/// the indicated cells. The second saturation value s2 is set
-/// to (1.0 - s1) for each cell. Any further saturation values
-/// are unchanged.
-void
-BlackoilState::setFirstSat(const std::vector<int>& cells,
-                           const Opm::BlackoilPropertiesInterface& props,
-                           ExtremalSat es) {
-    SimulatorState::setFirstSat(cells, props, es);
-}
 
 bool
 BlackoilState::equals(const SimulatorState& other,

--- a/opm/core/simulator/BlackoilState.hpp
+++ b/opm/core/simulator/BlackoilState.hpp
@@ -39,14 +39,6 @@ namespace Opm
 
         virtual void init(int number_of_cells, int number_of_faces, int num_phases);
 
-        /// Set the first saturation to either its min or max value in
-        /// the indicated cells. The second saturation value s2 is set
-        /// to (1.0 - s1) for each cell. Any further saturation values
-        /// are unchanged.
-        void setFirstSat(const std::vector<int>& cells,
-                         const Opm::BlackoilPropertiesInterface& props,
-                         ExtremalSat es);
-
         virtual bool equals(const SimulatorState& other,
                             double epsilon = 1e-8) const;
 

--- a/opm/core/simulator/SimulatorState.cpp
+++ b/opm/core/simulator/SimulatorState.cpp
@@ -87,10 +87,10 @@ void SimulatorState::setCellDataComponent( const std::string& name , size_t comp
   auto& data = cellData_[id];
   if (component >= num_phases_)
     throw std::invalid_argument("Invalid component");
-  
+
   if (cells.size() != values.size())
     throw std::invalid_argument("size mismatch between cells and values");
-  
+
   /* This is currently quite broken; the setCellDataComponent
      method assumes that the number of components in the field
      we are currently focusing on has num_phases components in
@@ -99,12 +99,12 @@ void SimulatorState::setCellDataComponent( const std::string& name , size_t comp
   */
   if (data.size() != num_phases_ * num_cells_)
     throw std::invalid_argument("Can currently only be used on fields with num_components == num_phases (i.e. saturation...) ");
-  
+
   for (size_t i = 0; i < cells.size(); i++) {
     if (cells[i] < num_cells_) {
       auto field_index = cells[i] * num_phases_ + component;
       auto value = values[i];
-      
+
       data[field_index] = value;
     } else {
       throw std::invalid_argument("Invalid cell number");
@@ -112,4 +112,19 @@ void SimulatorState::setCellDataComponent( const std::string& name , size_t comp
   }
 }
 
+
+std::vector<double>& SimulatorState::getCellData( const std::string& name )  {
+    const auto iter = std::find( cellDataNames_.begin() , cellDataNames_.end() , name);
+    int id = iter - cellDataNames_.begin();
+    auto& data = cellData_[id];
+    return data;
+}
+
+
+const std::vector<double>& SimulatorState::getCellData( const std::string& name )  const {
+    const auto iter = std::find( cellDataNames_.begin() , cellDataNames_.end() , name);
+    int id = iter - cellDataNames_.begin();
+    const auto& data = cellData_[id];
+    return data;
+}
 

--- a/opm/core/simulator/SimulatorState.hpp
+++ b/opm/core/simulator/SimulatorState.hpp
@@ -70,6 +70,9 @@ namespace Opm
 
         size_t registerCellData( const std::string& name, const int components, const double initialValue = 0.0 );
         size_t registerFaceData( const std::string& name, const int components, const double initialValue = 0.0 );
+
+        std::vector<double>& getCellData( const std::string& name );
+        const std::vector<double>& getCellData( const std::string& name ) const;
     private:
         int num_cells_;
         int num_faces_;

--- a/opm/core/simulator/SimulatorState.hpp
+++ b/opm/core/simulator/SimulatorState.hpp
@@ -17,8 +17,6 @@ namespace Opm
 
         virtual void init(int number_of_cells, int number_of_faces, int num_phases);
 
-        enum ExtremalSat { MinSat, MaxSat };
-
     protected:
         /// \brief pressure per cell.
         static const int pressureId_ = 0;
@@ -32,19 +30,12 @@ namespace Opm
         /// \brief The fluxes at the faces.
         static const int faceFluxId_ = 1;
 
-        /**
-         * Initialize the first saturation to maximum value. This method
-         * should be considered deprecated. Avoid to use it!
-         *
-         * \tparam Props Fluid and rock properties that pertain to this
-         *               kind of simulation. Currently, only Blackoil-
-         *               and IncompPropertiesInterface are supported.
-         */
-        template <typename Props>
-        void setFirstSat(const std::vector<int>& cells,
-                         const Props& props,
-                         ExtremalSat es);
     public:
+        /// Will set the values of component nr @component in the
+        /// field @key. All the cells in @cells will be set to the
+        /// values in @values.
+        void setCellDataComponent( const std::string& key , size_t component , const std::vector<int>& cells , const std::vector<double>& values);
+
         int numPhases() const { return num_phases_; }
         int numCells () const { return num_cells_; }
         int numFaces () const { return num_faces_; }

--- a/opm/core/simulator/TwophaseState.hpp
+++ b/opm/core/simulator/TwophaseState.hpp
@@ -30,10 +30,6 @@ namespace Opm
     class TwophaseState : public SimulatorState
     {
     public:
-        void setFirstSat(const std::vector<int>& cells,
-                         const Opm::IncompPropertiesInterface& props,
-                         ExtremalSat es);
-
         virtual bool equals (const SimulatorState& other,
                              double epsilon = 1e-8) const;
     };

--- a/opm/core/simulator/TwophaseState_impl.hpp
+++ b/opm/core/simulator/TwophaseState_impl.hpp
@@ -4,13 +4,6 @@
 
 namespace Opm {
 
-inline void
-TwophaseState::setFirstSat(const std::vector<int>& cells,
-                           const Opm::IncompPropertiesInterface& props,
-                           ExtremalSat es) {
-    SimulatorState::setFirstSat(cells, props, es);
-}
-
 inline bool
 TwophaseState::equals (const SimulatorState& other,
                        double epsilon) const {

--- a/opm/core/simulator/initState.hpp
+++ b/opm/core/simulator/initState.hpp
@@ -22,6 +22,7 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
+#include <opm/core/simulator/SimulatorState.hpp>
 struct UnstructuredGrid;
 
 namespace Opm
@@ -34,6 +35,18 @@ namespace Opm
     /// \file
     ///
     /// Functions for initializing a reservoir state.
+
+    /// Will initialize the first and second component of the
+    /// SATURATION field in all the cells in the set @cells. The
+    /// @props object will be queried, and depending on the value
+    /// @satType either the minimum or the maximum saturation is
+    /// applied to thee first component in the SATURATION field.
+    /// For the second component (1 - first_sat) is used.
+
+    enum ExtremalSat { MinSat, MaxSat };
+    template <class Props>
+    static void initSaturation(const std::vector<int>& cells , const Props& props , SimulatorState& state , ExtremalSat satType);
+
 
     /// Initialize a two-phase state from parameters.
     /// The following parameters are accepted (defaults):

--- a/tutorials/tutorial3.cpp
+++ b/tutorials/tutorial3.cpp
@@ -267,7 +267,19 @@ try
     /// \internal [two-phase state]
     TwophaseState state;
     state.init(grid.number_of_cells , grid.number_of_faces, 2);
-    state.setFirstSat(allcells, props, TwophaseState::MinSat);
+    {
+        std::vector<double> min_sat(allcells.size());
+        std::vector<double> max_sat(allcells.size());
+        std::vector<double> second_sat(allcells.size());
+
+        props.satRange(allcells.size() ,allcells.data() , min_sat.data() , max_sat.data());
+
+        std::transform( min_sat.begin() , min_sat.end() , second_sat.begin() , [](double s) { return 1 - s; });
+        state.setCellDataComponent( "SATURATION" , 0 , allcells , min_sat );
+        state.setCellDataComponent( "SATURATION" , 1 , allcells , second_sat );
+
+    }
+
     /// \internal [two-phase state]
     /// \endinternal
 

--- a/tutorials/tutorial3.cpp
+++ b/tutorials/tutorial3.cpp
@@ -37,6 +37,7 @@
 
 #include <opm/core/transport/reorder/TransportSolverTwophaseReorder.hpp>
 
+#include <opm/core/simulator/initState.hpp>
 #include <opm/core/simulator/TwophaseState.hpp>
 #include <opm/core/simulator/WellState.hpp>
 
@@ -267,18 +268,7 @@ try
     /// \internal [two-phase state]
     TwophaseState state;
     state.init(grid.number_of_cells , grid.number_of_faces, 2);
-    {
-        std::vector<double> min_sat(allcells.size());
-        std::vector<double> max_sat(allcells.size());
-        std::vector<double> second_sat(allcells.size());
-
-        props.satRange(allcells.size() ,allcells.data() , min_sat.data() , max_sat.data());
-
-        std::transform( min_sat.begin() , min_sat.end() , second_sat.begin() , [](double s) { return 1 - s; });
-        state.setCellDataComponent( "SATURATION" , 0 , allcells , min_sat );
-        state.setCellDataComponent( "SATURATION" , 1 , allcells , second_sat );
-
-    }
+    initSaturation( allcells , props , state , MinSat );
 
     /// \internal [two-phase state]
     /// \endinternal

--- a/tutorials/tutorial4.cpp
+++ b/tutorials/tutorial4.cpp
@@ -214,7 +214,20 @@ try
     /// \internal[two-phase state]
     TwophaseState state;
     state.init(grid.number_of_cells , grid.number_of_faces, 2);
-    state.setFirstSat(allcells, props, TwophaseState::MinSat);
+    {
+        std::vector<double> min_sat(allcells.size());
+        std::vector<double> max_sat(allcells.size());
+        std::vector<double> second_sat(allcells.size());
+
+        props.satRange(allcells.size() ,allcells.data() , min_sat.data() , max_sat.data());
+
+        std::transform( min_sat.begin() , min_sat.end() , second_sat.begin() , [](double s) { return 1 - s; });
+        state.setCellDataComponent( "SATURATION" , 0 , allcells , min_sat );
+        state.setCellDataComponent( "SATURATION" , 1 , allcells , second_sat );
+
+    }
+
+
     /// \internal[two-phase state]
     /// \endinternal
 

--- a/tutorials/tutorial4.cpp
+++ b/tutorials/tutorial4.cpp
@@ -37,6 +37,7 @@
 
 #include <opm/core/transport/reorder/TransportSolverTwophaseReorder.hpp>
 
+#include <opm/core/simulator/initState.hpp>
 #include <opm/core/simulator/TwophaseState.hpp>
 #include <opm/core/simulator/WellState.hpp>
 
@@ -214,18 +215,7 @@ try
     /// \internal[two-phase state]
     TwophaseState state;
     state.init(grid.number_of_cells , grid.number_of_faces, 2);
-    {
-        std::vector<double> min_sat(allcells.size());
-        std::vector<double> max_sat(allcells.size());
-        std::vector<double> second_sat(allcells.size());
-
-        props.satRange(allcells.size() ,allcells.data() , min_sat.data() , max_sat.data());
-
-        std::transform( min_sat.begin() , min_sat.end() , second_sat.begin() , [](double s) { return 1 - s; });
-        state.setCellDataComponent( "SATURATION" , 0 , allcells , min_sat );
-        state.setCellDataComponent( "SATURATION" , 1 , allcells , second_sat );
-
-    }
+    initSaturation( allcells , props , state , MinSat );
 
 
     /// \internal[two-phase state]


### PR DESCRIPTION
Have removed the `setFirstSat()` method, which had a dependency on `template <class Props>` and instead moved the property lookup to the `initState_impl.hpp` file. The initialisation of saturations is now based on a genereric `SimulatorState::setCellDataComponent()` function.

This is not necessarily a perfect API - but with this in place it should be possible to use the `SimulationDataContainer` from opm-common as drop in replacement for `SimulatorState`.

Currently this PR and: https://github.com/OPM/opm-common/pull/76 can be merged independently.