### PR TITLE
Fix build

### DIFF
--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -1181,17 +1181,17 @@ void EclipseWriter::writeInit(const SimulatorTimerInterface &timer)
     IOConfigConstPtr ioConfig = eclipseState_->getIOConfigConst();
 
     if (ioConfig->getWriteINITFile()) {
-        if (eclipseState_->hasDoubleGridProperty("PERMX")) {
+        if (eclipseState_->hasDeckDoubleGridProperty("PERMX")) {
             auto data = eclipseState_->getDoubleGridProperty("PERMX")->getData();
             EclipseWriterDetails::convertFromSiTo(data, Opm::prefix::milli * Opm::unit::darcy);
             fortio.writeKeyword("PERMX", data);
         }
-        if (eclipseState_->hasDoubleGridProperty("PERMY")) {
+        if (eclipseState_->hasDeckDoubleGridProperty("PERMY")) {
             auto data = eclipseState_->getDoubleGridProperty("PERMY")->getData();
             EclipseWriterDetails::convertFromSiTo(data, Opm::prefix::milli * Opm::unit::darcy);
             fortio.writeKeyword("PERMY", data);
         }
-        if (eclipseState_->hasDoubleGridProperty("PERMZ")) {
+        if (eclipseState_->hasDeckDoubleGridProperty("PERMZ")) {
             auto data = eclipseState_->getDoubleGridProperty("PERMZ")->getData();
             EclipseWriterDetails::convertFromSiTo(data, Opm::prefix::milli * Opm::unit::darcy);
             fortio.writeKeyword("PERMZ", data);

--- a/opm/core/props/rock/RockFromDeck.cpp
+++ b/opm/core/props/rock/RockFromDeck.cpp
@@ -183,16 +183,16 @@ namespace Opm
         ///        Invalid        invalid set of components given.
         PermeabilityKind classifyPermeability(Opm::EclipseStateConstPtr eclState)
         {
-            const bool xx = eclState->hasDoubleGridProperty("PERMX" );
-            const bool xy = eclState->hasDoubleGridProperty("PERMXY");
+            const bool xx = eclState->hasDeckDoubleGridProperty("PERMX" );
+            const bool xy = eclState->hasDeckDoubleGridProperty("PERMXY");
             const bool yx = xy;
 
-            const bool yy = eclState->hasDoubleGridProperty("PERMY" );
-            const bool yz = eclState->hasDoubleGridProperty("PERMYZ");
+            const bool yy = eclState->hasDeckDoubleGridProperty("PERMY" );
+            const bool yz = eclState->hasDeckDoubleGridProperty("PERMYZ");
             const bool zy = yz;
 
-            const bool zz = eclState->hasDoubleGridProperty("PERMZ" );
-            const bool zx = eclState->hasDoubleGridProperty("PERMZX");
+            const bool zz = eclState->hasDeckDoubleGridProperty("PERMZ" );
+            const bool zx = eclState->hasDeckDoubleGridProperty("PERMZX");
             const bool xz = zx;
 
             int num_cross_comp = xy + xz + yx + yz + zx + zy;
@@ -309,7 +309,7 @@ namespace Opm
 
             // -----------------------------------------------------------
             // 1st row: [ kxx, kxy ], kxz handled in kzx
-            if (eclState->hasDoubleGridProperty("PERMX" )) {
+            if (eclState->hasDeckDoubleGridProperty("PERMX" )) {
                 kmap[xx] = tensor.size();
                 tensor.push_back(extractPermComponent(eclState, "PERMX", global_cell));
 
@@ -322,7 +322,7 @@ namespace Opm
 
             // -----------------------------------------------------------
             // 2nd row: [ kyy, kyz ], kyx handled in kxy
-            if (eclState->hasDoubleGridProperty("PERMY" )) {
+            if (eclState->hasDeckDoubleGridProperty("PERMY" )) {
                 kmap[yy] = tensor.size();
                 tensor.push_back(extractPermComponent(eclState, "PERMY", global_cell));
 
@@ -339,7 +339,7 @@ namespace Opm
                 kmap[zx] = kmap[xz] = tensor.size();  // Enforce symmetry.
                 tensor.push_back(extractPermComponent(eclState, "PERMZX", global_cell));
             }
-            if (eclState->hasDoubleGridProperty("PERMZ" )) {
+            if (eclState->hasDeckDoubleGridProperty("PERMZ" )) {
                 kmap[zz] = tensor.size();
                 tensor.push_back(extractPermComponent(eclState, "PERMZ", global_cell));
 

--- a/opm/core/utility/CompressedPropertyAccess.hpp
+++ b/opm/core/utility/CompressedPropertyAccess.hpp
@@ -90,7 +90,7 @@ namespace Opm {
                      * \tparam PropertyContainer Pointer type
                      * representing collection of (global) grid
                      * properties.  Must implement method \c
-                     * hasIntGridProperty.
+                     * hasDeckIntGridProperty.
                      *
                      * \param[in] ecl Property container.
                      *
@@ -110,7 +110,7 @@ namespace Opm {
                 HasProperty<int>::p(PropertyContainer& ecl,
                                     const std::string& kw)
                 {
-                    return ecl->hasIntGridProperty(kw);
+                    return ecl->hasDeckIntGridProperty(kw);
                 }
 
                 /**
@@ -125,7 +125,7 @@ namespace Opm {
                      * \tparam PropertyContainer Pointer type
                      * representing collection of (global) grid
                      * properties.  Must implement method \c
-                     * hasDoubleGridProperty.
+                     * hasDeckDoubleGridProperty.
                      *
                      * \param[in] ecl Property container.
                      *
@@ -145,7 +145,7 @@ namespace Opm {
                 HasProperty<double>::p(PropertyContainer& ecl,
                                        const std::string& kw)
                 {
-                    return ecl->hasDoubleGridProperty(kw);
+                    return ecl->hasDeckDoubleGridProperty(kw);
                 }
 
                 /**
@@ -291,9 +291,9 @@ namespace Opm {
                  * \tparam PropertyContainer Pointer type representing
                  * collection of (global) grid properties.  Typically
                  * \c EclipseStatePtr or \c EclipseStateConstPtr.
-                 * Must implement methods \c hasIntGridProperty and \c
+                 * Must implement methods \c hasDeckIntGridProperty and \c
                  * getIntGridProperty if \c T is \c int, or \c
-                 * hasDoubleGridProperty and \c getDoubleGridProperty
+                 * hasDeckDoubleGridProperty and \c getDoubleGridProperty
                  * if \c T is \c double.
                  *
                  * \param[in] ecl Property container.

--- a/opm/core/utility/CompressedPropertyAccess.hpp
+++ b/opm/core/utility/CompressedPropertyAccess.hpp
@@ -169,13 +169,13 @@ namespace Opm {
                      * \return Data values for property \c kw.
                      */
                     template <class PropertyContainer>
-                    static std::shared_ptr< GridProperty<int> >
+                    static std::shared_ptr<const GridProperty<int> >
                     value(PropertyContainer& ecl,
                           const std::string& kw);
                 };
 
                 template <class PropertyContainer>
-                std::shared_ptr< GridProperty<int> >
+                std::shared_ptr<const GridProperty<int> >
                 GetProperty<int>::value(PropertyContainer& ecl,
                                         const std::string& kw)
                 {


### PR DESCRIPTION
this is some fallout of OPM/opm-parser#687. the first patch fixes the deprecation warnings whilst the second one fixes a build issue.

While the second patch is quite trivial (some forgotten 'const'), the havoc was caused because I usually configure my modules with --disable-tests (to get much better turn-around times when switching all modules from debug to optimization flags) and the usual way to force them to compile ('make test-suite') does not work for opm-core...