### PR TITLE
Remove unused 'restart' parameter from SimulatorTimer::init().

### DIFF
--- a/opm/core/simulator/SimulatorTimer.cpp
+++ b/opm/core/simulator/SimulatorTimer.cpp
@@ -49,7 +49,7 @@ namespace Opm
     }
 
     /// Use the SimulatorTimer as a shim around opm-parser's Opm::TimeMap
-    void SimulatorTimer::init(Opm::TimeMapConstPtr timeMap, bool restart, size_t report_step)
+    void SimulatorTimer::init(Opm::TimeMapConstPtr timeMap, size_t report_step)
     {
         total_time_ = timeMap->getTotalTime();
         timesteps_.resize(timeMap->numTimesteps());

--- a/opm/core/simulator/SimulatorTimer.hpp
+++ b/opm/core/simulator/SimulatorTimer.hpp
@@ -47,7 +47,7 @@ namespace Opm
         void init(const parameter::ParameterGroup& param);
 
         /// Use the SimulatorTimer as a shim around opm-parser's Opm::TimeMap
-        void init(TimeMapConstPtr timeMap, bool restart = false, size_t report_step = 0);
+        void init(TimeMapConstPtr timeMap, size_t report_step = 0);
 
         /// Total number of steps.
         int numSteps() const;


### PR DESCRIPTION
Requires follow-up PR in opm-autodiff.