### PR TITLE
Fix minor issues with RelpermDiagnostics

### DIFF
--- a/opm/core/props/satfunc/RelpermDiagnostics.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics.hpp
@@ -145,4 +145,6 @@ namespace Opm {
 
 } //namespace Opm
 
+#include <opm/core/props/satfunc/RelpermDiagnostics_impl.hpp>
+
 #endif // OPM_RELPERMDIAGNOSTICS_HEADER_INCLUDED

--- a/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
@@ -23,10 +23,6 @@
 #include <vector>
 #include <utility>
 
-#if HAVE_CONFIG_H
-#include "config.h"
-#endif // HAVE_CONFIG_H
-
 #include <opm/core/props/satfunc/RelpermDiagnostics.hpp>
 #include <opm/core/utility/compressedToCartesian.hpp>
 

--- a/tests/test_relpermdiagnostics.cpp
+++ b/tests/test_relpermdiagnostics.cpp
@@ -39,7 +39,6 @@
 #include <opm/core/grid/GridManager.hpp>
 
 #include <opm/core/props/satfunc/RelpermDiagnostics.hpp>
-#include <opm/core/props/satfunc/RelpermDiagnostics_impl.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseMode.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>


### PR DESCRIPTION
This fixes a few issues resulting from the change to make two of the methods templates.