### PR TITLE
Fix PERM[XYZ] output

### DIFF
--- a/opm/core/io/eclipse/EclipseWriter.cpp
+++ b/opm/core/io/eclipse/EclipseWriter.cpp
@@ -1184,16 +1184,19 @@ void EclipseWriter::writeInit(const SimulatorTimerInterface &timer)
         if (eclipseState_->hasDeckDoubleGridProperty("PERMX")) {
             auto data = eclipseState_->getDoubleGridProperty("PERMX")->getData();
             EclipseWriterDetails::convertFromSiTo(data, Opm::prefix::milli * Opm::unit::darcy);
+            EclipseWriterDetails::restrictAndReorderToActiveCells(data, gridToEclipseIdx_.size(), gridToEclipseIdx_.data());
             fortio.writeKeyword("PERMX", data);
         }
         if (eclipseState_->hasDeckDoubleGridProperty("PERMY")) {
             auto data = eclipseState_->getDoubleGridProperty("PERMY")->getData();
             EclipseWriterDetails::convertFromSiTo(data, Opm::prefix::milli * Opm::unit::darcy);
+            EclipseWriterDetails::restrictAndReorderToActiveCells(data, gridToEclipseIdx_.size(), gridToEclipseIdx_.data());
             fortio.writeKeyword("PERMY", data);
         }
         if (eclipseState_->hasDeckDoubleGridProperty("PERMZ")) {
             auto data = eclipseState_->getDoubleGridProperty("PERMZ")->getData();
             EclipseWriterDetails::convertFromSiTo(data, Opm::prefix::milli * Opm::unit::darcy);
+            EclipseWriterDetails::restrictAndReorderToActiveCells(data, gridToEclipseIdx_.size(), gridToEclipseIdx_.data());
             fortio.writeKeyword("PERMZ", data);
         }
     }


### PR DESCRIPTION
this *might* fix the PERM[XYZ] fields in the ECL restart files. notice the emphasis on the *might*: this is because I could not properly test the patch because ResInsight seems to have issues with the restart file produced by `flow`. (I haven't found a way to make it display the PERM[XYZ] fields. I have tested that this is the case for both this PR's branch as well as well as the current opm-core and opm-autodiff master versions.) So:

Before you merge this, please test carefully
==
