### PR TITLE
Allow SimulatorTimers to be copied.

### DIFF
--- a/opm/core/simulator/AdaptiveSimulatorTimer.cpp
+++ b/opm/core/simulator/AdaptiveSimulatorTimer.cpp
@@ -153,4 +153,13 @@ namespace Opm
         return start_date_time_;
     }
 
+    /// return copy of object
+    std::unique_ptr< SimulatorTimerInterface >
+    AdaptiveSimulatorTimer::clone() const
+    {
+        return std::unique_ptr< SimulatorTimerInterface > (new AdaptiveSimulatorTimer( *this ));
+    }
+
+
+
 } // namespace Opm

--- a/opm/core/simulator/AdaptiveSimulatorTimer.hpp
+++ b/opm/core/simulator/AdaptiveSimulatorTimer.hpp
@@ -93,6 +93,9 @@ namespace Opm
         /// \brief start date time of simulation
         boost::posix_time::ptime startDateTime() const;
 
+        /// return copy of object
+        virtual std::unique_ptr< SimulatorTimerInterface > clone() const;
+
     protected:
         const boost::posix_time::ptime start_date_time_;
         const double start_time_;

--- a/opm/core/simulator/SimulatorTimer.cpp
+++ b/opm/core/simulator/SimulatorTimer.cpp
@@ -148,5 +148,13 @@ namespace Opm
         return int(timesteps_.size()) == current_step_;
     }
 
+    /// return copy of object
+    std::unique_ptr< SimulatorTimerInterface >
+    SimulatorTimer::clone() const
+    {
+       return std::unique_ptr< SimulatorTimerInterface > (new SimulatorTimer( *this ));
+    }
+
+
 
 } // namespace Opm

--- a/opm/core/simulator/SimulatorTimer.hpp
+++ b/opm/core/simulator/SimulatorTimer.hpp
@@ -104,6 +104,9 @@ namespace Opm
         /// Return true if op++() has been called numSteps() times.
         bool done() const;
 
+        /// return copy of object
+        virtual std::unique_ptr< SimulatorTimerInterface > clone() const;
+
     private:
         std::vector<double> timesteps_;
         int current_step_;

--- a/opm/core/simulator/SimulatorTimerInterface.hpp
+++ b/opm/core/simulator/SimulatorTimerInterface.hpp
@@ -20,6 +20,8 @@
 #ifndef OPM_SIMULATORTIMERINTERFACE_HEADER_INCLUDED
 #define OPM_SIMULATORTIMERINTERFACE_HEADER_INCLUDED
 
+#include <memory>
+
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/date_time/posix_time/conversion.hpp>

--- a/opm/core/simulator/SimulatorTimerInterface.hpp
+++ b/opm/core/simulator/SimulatorTimerInterface.hpp
@@ -98,6 +98,9 @@ namespace Opm
             tm t = boost::posix_time::to_tm(currentDateTime());
             return std::mktime(&t);
         }
+
+        /// return copy of current timer instance
+        virtual std::unique_ptr< SimulatorTimerInterface > clone () const = 0;
     };
 
 


### PR DESCRIPTION
Since we are dealing with a virtual interface here we needed to add a method clone that creates a copy of the real object. This is needed in an upcoming PR in opm-autodiff.