### PR TITLE
BUGFIX. Call setupGuideRates before groupcontrol is applied

### DIFF
--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -427,9 +427,10 @@ WellsManager::init(const Opm::EclipseStateConstPtr eclipseState,
     }
 
     well_collection_.setWellsPointer(w_);
-    well_collection_.applyGroupControls();
 
     setupGuideRates(wells, timeStep, well_data, well_names_to_index);
+
+    well_collection_.applyGroupControls();
 
     // Debug output.
 #define EXTRA_OUTPUT


### PR DESCRIPTION
With this fix guide rates for group control can be specified correctly using WRUPCON