### PR TITLE
Module renaming

### DIFF
--- a/opm/core/pressure/tpfa/TransTpfa_impl.hpp
+++ b/opm/core/pressure/tpfa/TransTpfa_impl.hpp
@@ -21,7 +21,7 @@ double faceArea(const Dune::CpGrid&, int);
 
 namespace
 {
-#ifdef HAVE_DUNE_CORNERPOINT
+#ifdef HAVE_OPM_GRID
 inline const double* multiplyFaceNormalWithArea(const Dune::CpGrid& grid, int face_index, const double* in)
 {
     int d=Opm::UgGridHelpers::dimensions(grid);
@@ -37,7 +37,7 @@ inline void maybeFreeFaceNormal(const Dune::CpGrid&, const double* array)
 {
     delete[] array;
 }
-#endif  // HAVE_DUNE_CORNERPOINT
+#endif  // HAVE_OPM_GRID
 
 inline const double* multiplyFaceNormalWithArea(const UnstructuredGrid&, int, const double* in)
 {


### PR DESCRIPTION
Rename HAVE_DUNE_CORNERPOINT -> HAVE_OPM_GRID. 

Note that this is a little strange since opm-core is upstream and not downstream
from opm-grid. However, when this file is used from opm-autodiff the macro is required.

Requires OPM/opm-common#104.
