### PR TITLE
Bugfix in setup guiderates

### DIFF
--- a/opm/core/wells/WellCollection.cpp
+++ b/opm/core/wells/WellCollection.cpp
@@ -61,6 +61,11 @@ namespace Opm
     }
 
     void WellCollection::addWell(WellConstPtr wellChild, size_t timeStep, const PhaseUsage& phaseUsage) {
+        if (wellChild->getStatus(timeStep) == WellCommon::SHUT) {
+            //SHUT wells are not added to the well collection
+            return;
+        }
+
         WellsGroupInterface* parent = findNode(wellChild->getGroupName(timeStep));
         if (!parent) {
             OPM_THROW(std::runtime_error, "Trying to add well " << wellChild->name() << " Step: " << boost::lexical_cast<std::string>(timeStep) << " to group named " << wellChild->getGroupName(timeStep) << ", but this group does not exist in the WellCollection.");

--- a/tests/wells_group.data
+++ b/tests/wells_group.data
@@ -34,6 +34,11 @@ WELSPECS
     'PROD1' 'G2'   10 10    8400 'OIL'  /
 /
 
+COMPDAT
+    'INJ1'   1  1 1  1 'OPEN' 1   10.6092   0.5  /
+    'PROD1'  10 1 1  1 'OPEN' 0   10.6092   0.5  /
+/
+
 TSTEP
   14.0 /
 
@@ -41,6 +46,11 @@ TSTEP
 WELSPECS
     'INJ2' 'G1'    1  1    8335 'GAS'  /
     'PROD2' 'G2'   10 10    8400 'OIL'  /
+/
+
+COMPDAT
+    'INJ2'   1  1 1  1 'OPEN' 1   10.6092   0.5  /
+    'PROD2'  10 1 1  1 'OPEN' 0   10.6092   0.5  /
 /
 
 GCONINJE


### PR DESCRIPTION
- Handle shut wells
- Use the groups control type to determine which phase to calculate
the guide rates from. i.e for a ORAT controlled group, calculate the
guide rates from the oil phase well potentials etc.