### PR TITLE
 Using getInputGrid API from Parser

### DIFF
--- a/examples/compute_initial_state.cpp
+++ b/examples/compute_initial_state.cpp
@@ -90,7 +90,7 @@ try
     Opm::DeckConstPtr deck = parser->parseFile(deck_filename , parseContext);
     Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
     const double grav = param.getDefault("gravity", unit::gravity);
-    GridManager gm(deck);
+    GridManager gm(eclipseState->getInputGrid());
     const UnstructuredGrid& grid = *gm.c_grid();
     BlackoilPropertiesFromDeck props(deck, eclipseState, grid, param);
     warnIfUnusedParams(param);

--- a/examples/compute_tof.cpp
+++ b/examples/compute_tof.cpp
@@ -177,7 +177,7 @@ try
     EclipseStateConstPtr eclipseState = std::make_shared<EclipseState>(deck , parseContext);
 
     // Grid init
-    GridManager grid_manager(deck);
+    GridManager grid_manager(eclipseState->getInputGrid());
     const UnstructuredGrid& grid = *grid_manager.c_grid();
     // Rock and fluid init
     IncompPropertiesSinglePhase props(deck, eclipseState, grid);

--- a/examples/diagnose_relperm.cpp
+++ b/examples/diagnose_relperm.cpp
@@ -78,7 +78,7 @@ try
     Opm::DeckConstPtr deck(parser->parseFile(eclipseFilename, parseContext));
     eclState.reset(new EclipseState(deck, parseContext));
 
-    GridManager gm(deck);
+    GridManager gm(eclState->getInputGrid());
     const UnstructuredGrid& grid = *gm.c_grid();
     using boost::filesystem::path; 
     path fpath(eclipseFilename);

--- a/examples/wells_example.cpp
+++ b/examples/wells_example.cpp
@@ -42,7 +42,7 @@ try
     std::cout << "Done!" << std::endl;
 
     // Setup grid
-    GridManager grid(deck);
+    GridManager grid(eclipseState->getInputGrid());
 
     // Define rock and fluid properties
     IncompPropertiesFromDeck incomp_properties(deck, eclipseState, *grid.c_grid());

--- a/opm/core/grid/GridManager.cpp
+++ b/opm/core/grid/GridManager.cpp
@@ -45,14 +45,6 @@ namespace Opm
     }
 
 
-    GridManager::GridManager(Opm::DeckConstPtr deck)
-        : ug_(0)
-    {
-        auto eclipseGrid = std::make_shared<const Opm::EclipseGrid>(deck);
-        initFromEclipseGrid(eclipseGrid, std::vector<double>());
-    }
-
-
     GridManager::GridManager(Opm::EclipseGridConstPtr eclipseGrid,
                              const std::vector<double>& poreVolumes)
         : ug_(0)

--- a/opm/core/grid/GridManager.hpp
+++ b/opm/core/grid/GridManager.hpp
@@ -41,9 +41,6 @@ namespace Opm
     class GridManager
     {
     public:
-        /// Construct a 3d corner-point grid or tensor grid from a deck.
-        explicit GridManager(Opm::DeckConstPtr deck);
-
         /// Construct a grid from an EclipseState::EclipseGrid instance.
         explicit GridManager(Opm::EclipseGridConstPtr eclipseGrid);
 

--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -390,7 +390,7 @@ WellsManager::init(const Opm::EclipseStateConstPtr eclipseState,
     DoubleArray ntg_glob(eclipseState, "NTG", 1.0);
     NTGArray    ntg(ntg_glob, global_cell);
 
-    EclipseGridConstPtr eclGrid = eclipseState->getEclipseGrid();
+    EclipseGridConstPtr eclGrid = eclipseState->getInputGrid();
 
     // use cell thickness (dz) from eclGrid
     // dz overwrites values calculated by WellDetails::getCubeDim

--- a/tests/test_EclipseWriteRFTHandler.cpp
+++ b/tests/test_EclipseWriteRFTHandler.cpp
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(test_EclipseWriterRFTHandler)
     std::shared_ptr<Opm::SimulatorTimer> simulatorTimer = std::make_shared<Opm::SimulatorTimer>();
     simulatorTimer->init(eclipseState->getSchedule()->getTimeMap());
 
-    std::shared_ptr<Opm::GridManager>  ourFineGridManagerPtr = std::make_shared<Opm::GridManager>(eclipseState->getEclipseGrid());
+    std::shared_ptr<Opm::GridManager>  ourFineGridManagerPtr = std::make_shared<Opm::GridManager>(eclipseState->getInputGrid());
     const UnstructuredGrid &ourFinerUnstructuredGrid = *ourFineGridManagerPtr->c_grid();
     const int* compressedToCartesianCellIdx = Opm::UgGridHelpers::globalCell(ourFinerUnstructuredGrid);
 

--- a/tests/test_EclipseWriter.cpp
+++ b/tests/test_EclipseWriter.cpp
@@ -69,7 +69,7 @@ void createEclipseWriter(const char *deckString)
 
     eclipseState.reset(new Opm::EclipseState(deck , parseContext));
 
-    auto eclGrid = eclipseState->getEclipseGrid();
+    auto eclGrid = eclipseState->getInputGrid();
     BOOST_CHECK(eclGrid->getNX() == 3);
     BOOST_CHECK(eclGrid->getNY() == 3);
     BOOST_CHECK(eclGrid->getNZ() == 3);
@@ -212,7 +212,7 @@ void checkEgridFile()
     // use ERT directly to inspect the EGRID file produced by EclipseWriter
     auto egridFile = fortio_open_reader("FOO.EGRID", /*isFormated=*/0, ECL_ENDIAN_FLIP);
 
-    auto eclGrid = eclipseState->getEclipseGrid();
+    auto eclGrid = eclipseState->getInputGrid();
 
     ecl_kw_type *eclKeyword;
     // yes, that's an assignment!

--- a/tests/test_blackoilstate.cpp
+++ b/tests/test_blackoilstate.cpp
@@ -28,6 +28,13 @@ using namespace Opm;
 using namespace std;
 
 
+// ACTNUM 1 998*2 3
+std::vector<int> get_testBlackoilStateActnum() {
+    std::vector<int> actnum(10 * 10 * 10, 2);
+    actnum.front() = 1;
+    actnum.back() = 3;
+    return actnum;
+}
 
 BOOST_AUTO_TEST_CASE(EqualsDifferentDeckReturnFalse) {
 
@@ -35,12 +42,20 @@ BOOST_AUTO_TEST_CASE(EqualsDifferentDeckReturnFalse) {
     const string filename1 = "testBlackoilState1.DATA";
     const string filename2 = "testBlackoilState2.DATA";
     Opm::ParserPtr parser(new Opm::Parser());
-    Opm::DeckConstPtr deck1(parser->parseFile(filename1, parseContext));
-    Opm::DeckConstPtr deck2(parser->parseFile(filename2, parseContext));
 
-    GridManager gridManager1(deck1);
+    Opm::DeckConstPtr deck1(parser->parseFile(filename1, parseContext));
+    auto eg1 = std::make_shared<Opm::EclipseGrid>(deck1);
+    std::vector<int> actnum = get_testBlackoilStateActnum();
+    eg1->resetACTNUM(actnum.data());
+
+
+    Opm::DeckConstPtr deck2(parser->parseFile(filename2, parseContext));
+    auto eg2 = std::make_shared<Opm::EclipseGrid>(deck2);
+
+    GridManager gridManager1(eg1);
     const UnstructuredGrid& grid1 = *gridManager1.c_grid();
-    GridManager gridManager2(deck2);
+
+    GridManager gridManager2(eg2);
     const UnstructuredGrid& grid2 = *gridManager2.c_grid();
 
     BlackoilState state1( UgGridHelpers::numCells( grid1 ) , UgGridHelpers::numFaces( grid1 ) , 3);
@@ -58,8 +73,11 @@ BOOST_AUTO_TEST_CASE(EqualsNumericalDifferenceReturnFalse) {
     Opm::ParseContext parseContext;
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck(parser->parseFile(filename , parseContext));
+    auto eg = std::make_shared<Opm::EclipseGrid>(deck);
+    std::vector<int> actnum = get_testBlackoilStateActnum();
+    eg->resetACTNUM(actnum.data());
 
-    GridManager gridManager(deck);
+    GridManager gridManager(eg);
     const UnstructuredGrid& grid = *gridManager.c_grid();
 
     BlackoilState state1( UgGridHelpers::numCells( grid ) , UgGridHelpers::numFaces( grid ) , 3);

--- a/tests/test_column_extract.cpp
+++ b/tests/test_column_extract.cpp
@@ -134,7 +134,12 @@ BOOST_AUTO_TEST_CASE(DisjointColumn)
     Opm::ParseContext parseContext;
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck(parser->parseString(grdecl , parseContext));
-    Opm::GridManager manager(deck);
+    Opm::EclipseGridPtr ep = std::make_shared<Opm::EclipseGrid>(deck);
+    std::vector<int> actnum;
+    for (size_t i = 1; i <= (3 * 3 * 3); i++)
+        actnum.push_back(i != 14); // ACTNUM 13*1 0 13* 1
+    ep->resetACTNUM(actnum.data());
+    Opm::GridManager manager(ep);
 
     VVI columns;
     Opm::extractColumn(*manager.c_grid(), columns);

--- a/tests/test_compressedpropertyaccess.cpp
+++ b/tests/test_compressedpropertyaccess.cpp
@@ -60,7 +60,7 @@ struct TestFixture : public Setup
 {
     TestFixture()
         : Setup ()
-        , grid  (deck)
+        , grid  (ecl->getInputGrid())
         , reltol(1.0e-10)
     {
     }

--- a/tests/test_pinchprocessor.cpp
+++ b/tests/test_pinchprocessor.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(Processing)
     Opm::DeckConstPtr deck = parser->parseFile(filename, parseContext);
     std::shared_ptr<EclipseState> eclstate (new Opm::EclipseState(deck, parseContext));
     const auto& porv = eclstate->get3DProperties().getDoubleGridProperty("PORV").getData();
-    EclipseGridConstPtr eclgrid = eclstate->getEclipseGrid();
+    EclipseGridConstPtr eclgrid = eclstate->getInputGrid();
 
     BOOST_CHECK_EQUAL(eclgrid->getMinpvMode(), MinpvMode::EclSTD);
 

--- a/tests/test_relpermdiagnostics.cpp
+++ b/tests/test_relpermdiagnostics.cpp
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(diagnosis)
     Opm::DeckConstPtr deck(parser->parseFile("../tests/relpermDiagnostics.DATA", parseContext));
     eclState.reset(new EclipseState(deck, parseContext));
 
-    GridManager gm(deck);
+    GridManager gm(eclState->getInputGrid());
     const UnstructuredGrid& grid = *gm.c_grid();
     std::string logFile = "LOGFILE.txt";
     std::shared_ptr<EclipsePRTLog> prtLog = std::make_shared<EclipsePRTLog>(logFile, Log::DefaultMessageTypes);

--- a/tests/test_stoppedwells.cpp
+++ b/tests/test_stoppedwells.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(TestStoppedWells)
     Opm::DeckConstPtr deck(parser->parseFile(filename , parseContext));
 
     Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
-    Opm::GridManager gridManager(deck);
+    Opm::GridManager gridManager(eclipseState->getInputGrid());
 
     double target_surfacerate_inj;
     double target_surfacerate_prod;

--- a/tests/test_ug.cpp
+++ b/tests/test_ug.cpp
@@ -22,12 +22,13 @@
 #include <opm/core/grid/cornerpoint_grid.h>  /* compute_geometry */
 #include <opm/core/grid/GridManager.hpp>  /* compute_geometry */
 #include <opm/core/grid/cpgpreprocess/preprocess.h>
-#include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 using namespace std;
 
@@ -54,14 +55,18 @@ BOOST_AUTO_TEST_CASE(Equal) {
         "\n";
     
     Opm::ParserPtr parser(new Opm::Parser() );
+
     Opm::DeckConstPtr deck1 = parser->parseFile( filename1 , parseContext);
+    Opm::EclipseState es1(deck1, parseContext);
+
     Opm::DeckConstPtr deck2 = parser->parseString( deck2Data , parseContext);
+    Opm::EclipseState es2(deck2, parseContext);
     
     BOOST_CHECK( deck1->hasKeyword("ZCORN") );
     BOOST_CHECK( deck1->hasKeyword("COORD") );
     
-    Opm::GridManager grid1(deck1);
-    Opm::GridManager grid2(deck2);
+    Opm::GridManager grid1(es1.getInputGrid());
+    Opm::GridManager grid2(es2.getInputGrid());
     
     const UnstructuredGrid* cgrid1 = grid1.c_grid();
     const UnstructuredGrid* cgrid2 = grid2.c_grid();
@@ -75,15 +80,16 @@ BOOST_AUTO_TEST_CASE(Equal) {
 
 
 
+// TODO This method might be obsolete after using EclipseState to generate grid
 BOOST_AUTO_TEST_CASE(EqualEclipseGrid) {
     const std::string filename = "CORNERPOINT_ACTNUM.DATA";
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck = parser->parseFile( filename , parseContext);
+    Opm::EclipseState es(deck, parseContext);
+    auto grid = es.getInputGrid();
 
-    std::shared_ptr<const Opm::EclipseGrid> grid(new Opm::EclipseGrid(deck));
-
-    Opm::GridManager gridM(grid);
+    Opm::GridManager gridM(es.getInputGrid());
     const UnstructuredGrid* cgrid1 = gridM.c_grid();
     struct UnstructuredGrid * cgrid2;
     {
@@ -150,21 +156,19 @@ BOOST_AUTO_TEST_CASE(TOPS_Fully_Specified) {
         "EDIT\n"
         "\n";
 
-    Opm::ParserPtr parser(new Opm::Parser() );
+    Opm::ParserPtr parser(new Opm::Parser());
     Opm::ParseContext parseContext;
-    Opm::DeckConstPtr deck1 = parser->parseString( deck1Data , parseContext);
-    Opm::DeckConstPtr deck2 = parser->parseString( deck2Data , parseContext);
+    Opm::DeckConstPtr deck1 = parser->parseString(deck1Data, parseContext);
+    Opm::DeckConstPtr deck2 = parser->parseString(deck2Data, parseContext);
 
-    std::shared_ptr<const Opm::EclipseGrid> grid1(new Opm::EclipseGrid(deck1));
-    std::shared_ptr<const Opm::EclipseGrid> grid2(new Opm::EclipseGrid(deck2));
+    Opm::EclipseState es1(deck1, parseContext);
+    Opm::EclipseState es2(deck2, parseContext);
 
-    Opm::GridManager gridM1(grid1);
-    Opm::GridManager gridM2(grid2);
+    Opm::GridManager gridM1(es1.getInputGrid());
+    Opm::GridManager gridM2(es2.getInputGrid());
 
     const UnstructuredGrid* cgrid1 = gridM1.c_grid();
     const UnstructuredGrid* cgrid2 = gridM2.c_grid();
 
-    BOOST_CHECK( grid_equal( cgrid1 , cgrid2 ));
+    BOOST_CHECK(grid_equal(cgrid1, cgrid2));
 }
-
-

--- a/tests/test_wellsmanager.cpp
+++ b/tests/test_wellsmanager.cpp
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(New_Constructor_Works) {
     Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
 
     Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
-    Opm::GridManager gridManager(deck);
+    Opm::GridManager gridManager(eclipseState->getInputGrid());
 
     {
         Opm::WellsManager wellsManager(eclipseState, 0, *gridManager.c_grid(), NULL);
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE(WellsEqual) {
     Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
 
     Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
-    Opm::GridManager gridManager(deck);
+    Opm::GridManager gridManager(eclipseState->getInputGrid());
 
     Opm::WellsManager wellsManager0(eclipseState, 0, *gridManager.c_grid(), NULL);
     Opm::WellsManager wellsManager1(eclipseState, 1, *gridManager.c_grid(), NULL);
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(ControlsEqual) {
     Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
 
     Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
-    Opm::GridManager gridManager(deck);
+    Opm::GridManager gridManager(eclipseState->getInputGrid());
 
     Opm::WellsManager wellsManager0(eclipseState, 0, *gridManager.c_grid(), NULL);
     Opm::WellsManager wellsManager1(eclipseState, 1, *gridManager.c_grid(), NULL);
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE(WellShutOK) {
     Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
 
     Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
-    Opm::GridManager gridManager(deck);
+    Opm::GridManager gridManager(eclipseState->getInputGrid());
 
     Opm::WellsManager wellsManager2(eclipseState, 2, *gridManager.c_grid(), NULL);
 
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(WellSTOPOK) {
     Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
 
     Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
-    Opm::GridManager gridManager(deck);
+    Opm::GridManager gridManager(eclipseState->getInputGrid());
 
     Opm::WellsManager wellsManager(eclipseState, 0, *gridManager.c_grid(), NULL);
 

--- a/tests/test_wellsmanager.cpp
+++ b/tests/test_wellsmanager.cpp
@@ -29,273 +29,255 @@
 #include <boost/test/unit_test.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-        #include <opm/parser/eclipse/Parser/ParseContext.hpp>
-        #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 
-        #include <opm/core/wells/WellsManager.hpp>
-        #include <opm/core/wells.h>
-        #include <opm/core/well_controls.h>
+#include <opm/core/wells/WellsManager.hpp>
+#include <opm/core/wells.h>
+#include <opm/core/well_controls.h>
 
-        #include <opm/core/grid/GridManager.hpp>
+#include <opm/core/grid/GridManager.hpp>
 
+void wells_static_check(const Wells* wells) {
+    BOOST_CHECK_EQUAL(2, wells->number_of_wells);
+    BOOST_CHECK_EQUAL(3, wells->number_of_phases);
 
-        void wells_static_check(const Wells* wells) {
-            BOOST_CHECK_EQUAL(2 , wells->number_of_wells);
-            BOOST_CHECK_EQUAL(3 , wells->number_of_phases);
+    BOOST_CHECK_EQUAL("INJ1", wells->name[0]);
+    BOOST_CHECK_EQUAL("PROD1", wells->name[1]);
 
-            BOOST_CHECK_EQUAL("INJ1" , wells->name[0]);
-            BOOST_CHECK_EQUAL("PROD1" , wells->name[1]);
+    /* The mapping from well number into the wells->WI and wells->well_cells arrays. */
+    BOOST_CHECK_EQUAL(0, wells->well_connpos[0]);
+    BOOST_CHECK_EQUAL(1, wells->well_connpos[1]);
+    BOOST_CHECK_EQUAL(2, wells->well_connpos[2]);
 
-            /* The mapping from well number into the wells->WI and wells->well_cells arrays. */
-            BOOST_CHECK_EQUAL(0 , wells->well_connpos[0]);
-            BOOST_CHECK_EQUAL(1 , wells->well_connpos[1]);
-            BOOST_CHECK_EQUAL(2 , wells->well_connpos[2]);
+    /* Connection factor */
+    BOOST_CHECK_CLOSE(1.2279166666666664e-12, wells->WI[0], 0.001);
+    BOOST_CHECK_CLOSE(1.2279166666666664e-12, wells->WI[1], 0.001);
 
-            /* Connection factor */
-            BOOST_CHECK_CLOSE(1.2279166666666664e-12 , wells->WI[0] , 0.001);
-            BOOST_CHECK_CLOSE(1.2279166666666664e-12 , wells->WI[1] , 0.001);
+    /* Completed cells */
+    BOOST_CHECK_EQUAL(0, wells->well_cells[0]);
+    BOOST_CHECK_EQUAL(9 + 2 * 10 + 2 * 10 * 10, wells->well_cells[1]);
+}
 
-            /* Completed cells */
-            BOOST_CHECK_EQUAL(0 , wells->well_cells[0]);
-            BOOST_CHECK_EQUAL(9 + 2*10 + 2*10*10 , wells->well_cells[1]);
+/*
+ The number of controls is determined by looking at which elements
+ have been given explicit - non-default - values in the WCONxxxx
+ keyword. Is that at all interesting?
+ */
+
+void check_controls_epoch0(struct WellControls ** ctrls) {
+    // The injector
+    {
+        const struct WellControls * ctrls0 = ctrls[0];
+        BOOST_CHECK_EQUAL(3, well_controls_get_num(ctrls0));   // The number of controls for the injector == 3??
+
+        BOOST_CHECK_EQUAL(SURFACE_RATE, well_controls_iget_type(ctrls0, 0));
+        BOOST_CHECK_EQUAL(RESERVOIR_RATE, well_controls_iget_type(ctrls0, 1));
+        BOOST_CHECK_EQUAL(BHP, well_controls_iget_type(ctrls0, 2));
+
+        // The different targets
+        BOOST_CHECK_EQUAL(100.0 / 86400, well_controls_iget_target(ctrls0, 0));
+        BOOST_CHECK_EQUAL(200.0 / 86400, well_controls_iget_target(ctrls0, 1));
+        BOOST_CHECK_EQUAL(400 * 100000, well_controls_iget_target(ctrls0, 2));
+
+        // Which control is active
+        BOOST_CHECK_EQUAL(0, well_controls_get_current(ctrls0));
+
+        // The phase distribution in the active target
+        {
+            const double * distr = well_controls_iget_distr(ctrls0, 0);
+            BOOST_CHECK_EQUAL(0, distr[0]);  // Water
+            BOOST_CHECK_EQUAL(0, distr[1]);  // Oil
+            BOOST_CHECK_EQUAL(1, distr[2]);  // Gas
         }
+    }
 
+    // The producer
+    {
+        const struct WellControls * ctrls1 = ctrls[1];
+        BOOST_CHECK_EQUAL(2, well_controls_get_num(ctrls1));   // The number of controls for the producer == 2??
+        BOOST_CHECK_EQUAL(SURFACE_RATE, well_controls_iget_type(ctrls1, 0));
+        BOOST_CHECK_EQUAL(BHP, well_controls_iget_type(ctrls1, 1));
 
-        /*
-           The number of controls is determined by looking at which elements
-           have been given explicit - non-default - values in the WCONxxxx
-           keyword. Is that at all interesting?
-        */
+        // The different targets
+        BOOST_CHECK_EQUAL(-20000.0 / 86400, well_controls_iget_target(ctrls1, 0));
+        BOOST_CHECK_EQUAL(1000 * 100000, well_controls_iget_target(ctrls1, 1));
 
+        // Which control is active
+        BOOST_CHECK_EQUAL(0, well_controls_get_current(ctrls1));
 
-        void check_controls_epoch0( struct WellControls ** ctrls) {
-            // The injector
-            {
-                const struct WellControls * ctrls0 = ctrls[0];
-                BOOST_CHECK_EQUAL( 3 , well_controls_get_num(ctrls0));   // The number of controls for the injector == 3??
-
-                BOOST_CHECK_EQUAL( SURFACE_RATE   , well_controls_iget_type(ctrls0 , 0) );
-                BOOST_CHECK_EQUAL( RESERVOIR_RATE , well_controls_iget_type(ctrls0 , 1) );
-                BOOST_CHECK_EQUAL( BHP            , well_controls_iget_type(ctrls0 , 2) );
-
-                // The different targets
-                BOOST_CHECK_EQUAL( 100.0 / 86400 , well_controls_iget_target(ctrls0,0));
-                BOOST_CHECK_EQUAL( 200.0 / 86400 , well_controls_iget_target(ctrls0,1));
-                BOOST_CHECK_EQUAL( 400 * 100000  , well_controls_iget_target(ctrls0,2));
-
-                // Which control is active
-                BOOST_CHECK_EQUAL( 0 , well_controls_get_current(ctrls0) );
-
-                // The phase distribution in the active target
-                {
-                     const double * distr = well_controls_iget_distr( ctrls0 , 0 );
-                     BOOST_CHECK_EQUAL( 0 , distr[0] );  // Water
-                     BOOST_CHECK_EQUAL( 0 , distr[1] );  // Oil
-                     BOOST_CHECK_EQUAL( 1 , distr[2] );  // Gas
-                }
-            }
-
-            // The producer
-            {
-                const struct WellControls * ctrls1 = ctrls[1];
-                BOOST_CHECK_EQUAL( 2 , well_controls_get_num( ctrls1 ));   // The number of controls for the producer == 2??
-                BOOST_CHECK_EQUAL( SURFACE_RATE   , well_controls_iget_type(ctrls1 , 0) );
-                BOOST_CHECK_EQUAL( BHP            , well_controls_iget_type(ctrls1 , 1) );
-
-                // The different targets
-                BOOST_CHECK_EQUAL( -20000.0 / 86400 , well_controls_iget_target(ctrls1,0));
-                BOOST_CHECK_EQUAL(  1000 * 100000   , well_controls_iget_target(ctrls1,1));
-
-                // Which control is active
-                BOOST_CHECK_EQUAL( 0 , well_controls_get_current(ctrls1));
-
-                // The phase distribution in the active target
-               {
-                    const double * distr = well_controls_iget_distr( ctrls1 , 0 );
-                    BOOST_CHECK_EQUAL( 0 , distr[0] );  // Water
-                    BOOST_CHECK_EQUAL( 1 , distr[1] );  // Oil
-                    BOOST_CHECK_EQUAL( 0 , distr[2] );  // Gas
-                }
-            }
+        // The phase distribution in the active target
+        {
+            const double * distr = well_controls_iget_distr(ctrls1, 0);
+            BOOST_CHECK_EQUAL(0, distr[0]);  // Water
+            BOOST_CHECK_EQUAL(1, distr[1]);  // Oil
+            BOOST_CHECK_EQUAL(0, distr[2]);  // Gas
         }
+    }
+}
 
+void check_controls_epoch1(struct WellControls ** ctrls) {
+    // The injector
+    {
+        const struct WellControls * ctrls0 = ctrls[0];
+        BOOST_CHECK_EQUAL(3, well_controls_get_num(ctrls0));   // The number of controls for the injector == 3??
 
+        BOOST_CHECK_EQUAL(SURFACE_RATE, well_controls_iget_type(ctrls0, 0));
+        BOOST_CHECK_EQUAL(RESERVOIR_RATE, well_controls_iget_type(ctrls0, 1));
+        BOOST_CHECK_EQUAL(BHP, well_controls_iget_type(ctrls0, 2));
 
+        // The different targets
+        BOOST_CHECK_CLOSE(10.0 / 86400, well_controls_iget_target(ctrls0, 0), 0.001);
+        BOOST_CHECK_CLOSE(20.0 / 86400, well_controls_iget_target(ctrls0, 1), 0.001);
+        BOOST_CHECK_CLOSE(40 * 100000, well_controls_iget_target(ctrls0, 2), 0.001);
 
-        void check_controls_epoch1( struct WellControls ** ctrls) {
-            // The injector
-            {
-                const struct WellControls * ctrls0 = ctrls[0];
-                BOOST_CHECK_EQUAL( 3 , well_controls_get_num(ctrls0));   // The number of controls for the injector == 3??
+        // Which control is active
+        BOOST_CHECK_EQUAL(1, well_controls_get_current(ctrls0));
 
-                BOOST_CHECK_EQUAL( SURFACE_RATE   , well_controls_iget_type(ctrls0 , 0 ));
-                BOOST_CHECK_EQUAL( RESERVOIR_RATE , well_controls_iget_type(ctrls0 , 1 ));
-                BOOST_CHECK_EQUAL( BHP            , well_controls_iget_type(ctrls0 , 2 ));
-
-                // The different targets
-                BOOST_CHECK_CLOSE( 10.0 / 86400 , well_controls_iget_target(ctrls0 , 0) , 0.001);
-                BOOST_CHECK_CLOSE( 20.0 / 86400 , well_controls_iget_target(ctrls0 , 1) , 0.001);
-                BOOST_CHECK_CLOSE( 40 * 100000  , well_controls_iget_target(ctrls0 , 2) , 0.001);
-
-                // Which control is active
-                BOOST_CHECK_EQUAL( 1 , well_controls_get_current(ctrls0));
-
-                {
-                    const double * distr = well_controls_iget_distr( ctrls0 , 1 );
-                    BOOST_CHECK_EQUAL( 1 , distr[0] );  // Water
-                    BOOST_CHECK_EQUAL( 0 , distr[1] );  // Oil
-                    BOOST_CHECK_EQUAL( 0 , distr[2] );  // Gas
-                }
-            }
-
-            // The producer
-            {
-                const struct WellControls * ctrls1 = ctrls[1];
-                BOOST_CHECK_EQUAL( 3 , well_controls_get_num(ctrls1));   // The number of controls for the producer - now 3.
-                BOOST_CHECK_EQUAL( SURFACE_RATE   , well_controls_iget_type(ctrls1 , 0) );
-                BOOST_CHECK_EQUAL( RESERVOIR_RATE , well_controls_iget_type(ctrls1 , 1) );
-                BOOST_CHECK_EQUAL( BHP            , well_controls_iget_type(ctrls1 , 2) );
-
-                // The different targets
-                BOOST_CHECK_CLOSE( -999.0 / 86400 , well_controls_iget_target(ctrls1 , 0), 0.001);
-                BOOST_CHECK_CLOSE( -123.0 / 86400 , well_controls_iget_target(ctrls1 , 1), 0.001);
-                BOOST_CHECK_CLOSE(  100 * 100000  , well_controls_iget_target(ctrls1 , 2), 0.001);
-
-                // Which control is active
-                BOOST_CHECK_EQUAL( 1 , well_controls_get_current(ctrls1) );
-
-                {
-                    const double * distr = well_controls_iget_distr( ctrls1 , 1 );
-                    BOOST_CHECK_EQUAL( 1 , distr[0] );  // Water
-                    BOOST_CHECK_EQUAL( 1 , distr[1] );  // Oil
-                    BOOST_CHECK_EQUAL( 1 , distr[2] );  // Gas
-                }
-            }
+        {
+            const double * distr = well_controls_iget_distr(ctrls0, 1);
+            BOOST_CHECK_EQUAL(1, distr[0]);  // Water
+            BOOST_CHECK_EQUAL(0, distr[1]);  // Oil
+            BOOST_CHECK_EQUAL(0, distr[2]);  // Gas
         }
+    }
 
+    // The producer
+    {
+        const struct WellControls * ctrls1 = ctrls[1];
+        BOOST_CHECK_EQUAL(3, well_controls_get_num(ctrls1));   // The number of controls for the producer - now 3.
+        BOOST_CHECK_EQUAL(SURFACE_RATE, well_controls_iget_type(ctrls1, 0));
+        BOOST_CHECK_EQUAL(RESERVOIR_RATE, well_controls_iget_type(ctrls1, 1));
+        BOOST_CHECK_EQUAL(BHP, well_controls_iget_type(ctrls1, 2));
 
-        void check_controls_epoch3( struct WellControls ** ctrls) {
-            // The new producer
-            const struct WellControls * ctrls1 = ctrls[1];
-            // Note: controls include default (1 atm) BHP control.
-            BOOST_CHECK_EQUAL( 6 , well_controls_get_num(ctrls1));
+        // The different targets
+        BOOST_CHECK_CLOSE(-999.0 / 86400, well_controls_iget_target(ctrls1, 0), 0.001);
+        BOOST_CHECK_CLOSE(-123.0 / 86400, well_controls_iget_target(ctrls1, 1), 0.001);
+        BOOST_CHECK_CLOSE(100 * 100000, well_controls_iget_target(ctrls1, 2), 0.001);
+
+        // Which control is active
+        BOOST_CHECK_EQUAL(1, well_controls_get_current(ctrls1));
+
+        {
+            const double * distr = well_controls_iget_distr(ctrls1, 1);
+            BOOST_CHECK_EQUAL(1, distr[0]);  // Water
+            BOOST_CHECK_EQUAL(1, distr[1]);  // Oil
+            BOOST_CHECK_EQUAL(1, distr[2]);  // Gas
         }
+    }
+}
 
+void check_controls_epoch3(struct WellControls ** ctrls) {
+    // The new producer
+    const struct WellControls * ctrls1 = ctrls[1];
+    // Note: controls include default (1 atm) BHP control.
+    BOOST_CHECK_EQUAL(6, well_controls_get_num(ctrls1));
+}
 
+BOOST_AUTO_TEST_CASE(New_Constructor_Works) {
 
+    const std::string filename = "wells_manager_data.data";
+    Opm::ParserPtr parser(new Opm::Parser());
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
 
-        BOOST_AUTO_TEST_CASE(New_Constructor_Works) {
-
-            const std::string filename = "wells_manager_data.data";
-            Opm::ParserPtr parser(new Opm::Parser());
-            Opm::ParseContext parseContext;
-            Opm::DeckConstPtr deck(parser->parseFile(filename , parseContext));
-
-            Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
-            Opm::GridManager gridManager(deck);
-
-            {
-                Opm::WellsManager wellsManager(eclipseState, 0, *gridManager.c_grid(), NULL);
-                wells_static_check( wellsManager.c_wells() );
-                check_controls_epoch0( wellsManager.c_wells()->ctrls );
-            }
-
-            {
-                Opm::WellsManager wellsManager(eclipseState, 1, *gridManager.c_grid(), NULL);
-                wells_static_check( wellsManager.c_wells() );
-                check_controls_epoch1( wellsManager.c_wells()->ctrls );
-            }
-
-
-            {
-                Opm::WellsManager wellsManager(eclipseState, 3, *gridManager.c_grid(), NULL);
-                const Wells* wells = wellsManager.c_wells();
-
-                // There is 3 wells in total in the deck at the 3rd schedule step.
-                // PROD1 is shut and should therefore not be counted.
-                // The new well is therefore the secound well.
-                BOOST_CHECK_EQUAL(2 , wells->number_of_wells);
-                BOOST_CHECK_EQUAL( wells->name[0] , "INJ1");
-                BOOST_CHECK_EQUAL( wells->name[1] , "NEW");
-
-                check_controls_epoch3( wellsManager.c_wells()->ctrls );
-            }
-
-        }
-
-
-
-        BOOST_AUTO_TEST_CASE(WellsEqual) {
-            const std::string filename = "wells_manager_data.data";
-            Opm::ParserPtr parser(new Opm::Parser());
-            Opm::ParseContext parseContext;
-            Opm::DeckConstPtr deck(parser->parseFile(filename , parseContext));
-
-            Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
-            Opm::GridManager gridManager(deck);
-
-            Opm::WellsManager wellsManager0(eclipseState , 0 , *gridManager.c_grid(), NULL);
-            Opm::WellsManager wellsManager1(eclipseState , 1 , *gridManager.c_grid(), NULL);
-
-            BOOST_CHECK(  wells_equal( wellsManager0.c_wells() , wellsManager0.c_wells(),false) );
-            BOOST_CHECK( !wells_equal( wellsManager0.c_wells() , wellsManager1.c_wells(),false) );
-        }
-
-
-        BOOST_AUTO_TEST_CASE(ControlsEqual) {
-            const std::string filename = "wells_manager_data.data";
-            Opm::ParseContext parseContext;
-            Opm::ParserPtr parser(new Opm::Parser());
-            Opm::DeckConstPtr deck(parser->parseFile(filename , parseContext));
-
-            Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
-            Opm::GridManager gridManager(deck);
-
-            Opm::WellsManager wellsManager0(eclipseState , 0 , *gridManager.c_grid(), NULL);
-            Opm::WellsManager wellsManager1(eclipseState , 1 , *gridManager.c_grid(), NULL);
-
-            BOOST_CHECK(  well_controls_equal( wellsManager0.c_wells()->ctrls[0] , wellsManager0.c_wells()->ctrls[0] , false));
-            BOOST_CHECK(  well_controls_equal( wellsManager0.c_wells()->ctrls[1] , wellsManager0.c_wells()->ctrls[1] , false));
-            BOOST_CHECK(  well_controls_equal( wellsManager1.c_wells()->ctrls[0] , wellsManager1.c_wells()->ctrls[0] , false));
-            BOOST_CHECK(  well_controls_equal( wellsManager1.c_wells()->ctrls[1] , wellsManager1.c_wells()->ctrls[1] , false));
-
-            BOOST_CHECK(  !well_controls_equal( wellsManager0.c_wells()->ctrls[0] , wellsManager0.c_wells()->ctrls[1] , false));
-            BOOST_CHECK(  !well_controls_equal( wellsManager0.c_wells()->ctrls[1] , wellsManager0.c_wells()->ctrls[0] , false));
-            BOOST_CHECK(  !well_controls_equal( wellsManager1.c_wells()->ctrls[0] , wellsManager0.c_wells()->ctrls[0] , false));
-            BOOST_CHECK(  !well_controls_equal( wellsManager1.c_wells()->ctrls[1] , wellsManager0.c_wells()->ctrls[1] , false));
-        }
-
-
-
-        BOOST_AUTO_TEST_CASE(WellShutOK) {
-            const std::string filename = "wells_manager_data.data";
-            Opm::ParserPtr parser(new Opm::Parser());
-            Opm::ParseContext parseContext;
-            Opm::DeckConstPtr deck(parser->parseFile(filename , parseContext));
-
-            Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
-            Opm::GridManager gridManager(deck);
-
-            Opm::WellsManager wellsManager2(eclipseState , 2 , *gridManager.c_grid(), NULL);
-
-            // Shut wells are not added to the deck. i.e number of wells should be 2-1
-            BOOST_CHECK( wellsManager2.c_wells()->number_of_wells == 1);
-
-            //BOOST_CHECK_NO_THROW( Opm::WellsManager wellsManager2(eclipseState , 2 , *gridManager.c_grid(), NULL));
-        }
-
-
-
-        BOOST_AUTO_TEST_CASE(WellSTOPOK) {
-            const std::string filename = "wells_manager_data_wellSTOP.data";
-            Opm::ParserPtr parser(new Opm::Parser());
-            Opm::ParseContext parseContext;
-            Opm::DeckConstPtr deck(parser->parseFile(filename , parseContext));
-
-            Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
     Opm::GridManager gridManager(deck);
 
-    Opm::WellsManager wellsManager(eclipseState , 0 , *gridManager.c_grid(), NULL);
+    {
+        Opm::WellsManager wellsManager(eclipseState, 0, *gridManager.c_grid(), NULL);
+        wells_static_check(wellsManager.c_wells());
+        check_controls_epoch0(wellsManager.c_wells()->ctrls);
+    }
+
+    {
+        Opm::WellsManager wellsManager(eclipseState, 1, *gridManager.c_grid(), NULL);
+        wells_static_check(wellsManager.c_wells());
+        check_controls_epoch1(wellsManager.c_wells()->ctrls);
+    }
+
+    {
+        Opm::WellsManager wellsManager(eclipseState, 3, *gridManager.c_grid(), NULL);
+        const Wells* wells = wellsManager.c_wells();
+
+        // There is 3 wells in total in the deck at the 3rd schedule step.
+        // PROD1 is shut and should therefore not be counted.
+        // The new well is therefore the secound well.
+        BOOST_CHECK_EQUAL(2, wells->number_of_wells);
+        BOOST_CHECK_EQUAL(wells->name[0], "INJ1");
+        BOOST_CHECK_EQUAL(wells->name[1], "NEW");
+
+        check_controls_epoch3(wellsManager.c_wells()->ctrls);
+    }
+
+}
+
+BOOST_AUTO_TEST_CASE(WellsEqual) {
+    const std::string filename = "wells_manager_data.data";
+    Opm::ParserPtr parser(new Opm::Parser());
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
+
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
+    Opm::GridManager gridManager(deck);
+
+    Opm::WellsManager wellsManager0(eclipseState, 0, *gridManager.c_grid(), NULL);
+    Opm::WellsManager wellsManager1(eclipseState, 1, *gridManager.c_grid(), NULL);
+
+    BOOST_CHECK(wells_equal( wellsManager0.c_wells() , wellsManager0.c_wells(),false));
+    BOOST_CHECK(!wells_equal( wellsManager0.c_wells() , wellsManager1.c_wells(),false));
+}
+
+BOOST_AUTO_TEST_CASE(ControlsEqual) {
+    const std::string filename = "wells_manager_data.data";
+    Opm::ParseContext parseContext;
+    Opm::ParserPtr parser(new Opm::Parser());
+    Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
+
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
+    Opm::GridManager gridManager(deck);
+
+    Opm::WellsManager wellsManager0(eclipseState, 0, *gridManager.c_grid(), NULL);
+    Opm::WellsManager wellsManager1(eclipseState, 1, *gridManager.c_grid(), NULL);
+
+    BOOST_CHECK(well_controls_equal( wellsManager0.c_wells()->ctrls[0] , wellsManager0.c_wells()->ctrls[0] , false));
+    BOOST_CHECK(well_controls_equal( wellsManager0.c_wells()->ctrls[1] , wellsManager0.c_wells()->ctrls[1] , false));
+    BOOST_CHECK(well_controls_equal( wellsManager1.c_wells()->ctrls[0] , wellsManager1.c_wells()->ctrls[0] , false));
+    BOOST_CHECK(well_controls_equal( wellsManager1.c_wells()->ctrls[1] , wellsManager1.c_wells()->ctrls[1] , false));
+
+    BOOST_CHECK(!well_controls_equal( wellsManager0.c_wells()->ctrls[0] , wellsManager0.c_wells()->ctrls[1] , false));
+    BOOST_CHECK(!well_controls_equal( wellsManager0.c_wells()->ctrls[1] , wellsManager0.c_wells()->ctrls[0] , false));
+    BOOST_CHECK(!well_controls_equal( wellsManager1.c_wells()->ctrls[0] , wellsManager0.c_wells()->ctrls[0] , false));
+    BOOST_CHECK(!well_controls_equal( wellsManager1.c_wells()->ctrls[1] , wellsManager0.c_wells()->ctrls[1] , false));
+}
+
+BOOST_AUTO_TEST_CASE(WellShutOK) {
+    const std::string filename = "wells_manager_data.data";
+    Opm::ParserPtr parser(new Opm::Parser());
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
+
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
+    Opm::GridManager gridManager(deck);
+
+    Opm::WellsManager wellsManager2(eclipseState, 2, *gridManager.c_grid(), NULL);
+
+    // Shut wells are not added to the deck. i.e number of wells should be 2-1
+    BOOST_CHECK(wellsManager2.c_wells()->number_of_wells == 1);
+
+    //BOOST_CHECK_NO_THROW( Opm::WellsManager wellsManager2(eclipseState , 2 , *gridManager.c_grid(), NULL));
+}
+
+BOOST_AUTO_TEST_CASE(WellSTOPOK) {
+    const std::string filename = "wells_manager_data_wellSTOP.data";
+    Opm::ParserPtr parser(new Opm::Parser());
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
+
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
+    Opm::GridManager gridManager(deck);
+
+    Opm::WellsManager wellsManager(eclipseState, 0, *gridManager.c_grid(), NULL);
 
     const Wells* wells = wellsManager.c_wells();
     const struct WellControls* ctrls0 = wells->ctrls[0];

--- a/tests/test_writeReadRestartFile.cpp
+++ b/tests/test_writeReadRestartFile.cpp
@@ -208,7 +208,7 @@ Opm::EclipseWriterPtr createEclipseWriter(Opm::DeckConstPtr deck,
   Opm::EclipseWriterPtr eclWriter(new Opm::EclipseWriter(params,
                                                          eclipseState,
                                                          phaseUsage,
-                                                         eclipseState->getEclipseGrid()->getCartesianSize(),
+                                                         eclipseState->getInputGrid()->getCartesianSize(),
                                                          0));
   return eclWriter;
 }
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE(EclipseReadWriteWellStateData)
     Opm::GridManager gridManager(deck);
     Opm::WellsManager wellsManager(eclipseState, 1, *gridManager.c_grid(), NULL);
     const Wells* wells = wellsManager.c_wells();
-    std::shared_ptr<Opm::BlackoilState> blackoilState = createBlackOilState(eclipseState->getEclipseGrid(), phaseUsage);
+    std::shared_ptr<Opm::BlackoilState> blackoilState = createBlackOilState(eclipseState->getInputGrid(), phaseUsage);
     wellState->init(wells, *blackoilState);
 
     //Set test data for pressure
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(EclipseReadWriteWellStateData)
     wellStateRestored->init(wells, *blackoilState);
 
     //Read and verify OPM XWEL data, and solution data: pressure, temperature, saturation data, rs and rv
-    std::shared_ptr<Opm::BlackoilState> blackoilStateRestored = createBlackOilState(eclipseState->getEclipseGrid(), phaseUsage);
+    std::shared_ptr<Opm::BlackoilState> blackoilStateRestored = createBlackOilState(eclipseState->getInputGrid(), phaseUsage);
     Opm::init_from_restart_file(eclipseState, Opm::UgGridHelpers::numCells(*gridManager.c_grid()), phaseUsage, *blackoilStateRestored, *wellStateRestored);
     
     BOOST_CHECK_EQUAL_COLLECTIONS(wellState->bhp().begin(), wellState->bhp().end(), wellStateRestored->bhp().begin(), wellStateRestored->bhp().end());

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -156,7 +156,7 @@ Opm::EclipseWriterPtr createEclipseWriter(Opm::DeckConstPtr deck,
   Opm::EclipseWriterPtr eclWriter(new Opm::EclipseWriter(params,
                                                          eclipseState,
                                                          phaseUsage,
-                                                         eclipseState->getEclipseGrid()->getCartesianSize(),
+                                                         eclipseState->getInputGrid()->getCartesianSize(),
                                                          0));
   return eclWriter;
 }
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo)
     eclipseWriter->writeInit(*simTimer);
 
     std::shared_ptr<Opm::WellState> wellState(new Opm::WellState());
-    std::shared_ptr<Opm::BlackoilState> blackoilState = createBlackOilState(eclipseState->getEclipseGrid());
+    std::shared_ptr<Opm::BlackoilState> blackoilState = createBlackOilState(eclipseState->getInputGrid());
     wellState->init(0, *blackoilState);
 
     int countTimeStep = eclipseState->getSchedule()->getTimeMap()->numTimesteps();
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo)
       eclipseWriter->writeTimeStep(*simTimer, *blackoilState, *wellState, false);
     }
 
-    verifyWellState(eclipse_restart_filename, eclipseState->getEclipseGrid(), eclipseState->getSchedule());
+    verifyWellState(eclipse_restart_filename, eclipseState->getInputGrid(), eclipseState->getSchedule());
 
     test_work_area_free(test_area);
 }


### PR DESCRIPTION
This PR adds two fixes
* First, now we are using the new EclipseState.getInputGrid API in Parser
* Second, this PR fixes a bug introduced in ACTNUM PR OPM/opm-parser#768 (see issue #1001)
* Third, fixes arbitrary indentation in test file

See OPM/opm-parser#769