### PR TITLE
Two phase bugfixes

### DIFF
--- a/opm/core/props/BlackoilPropertiesFromDeck.cpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck.cpp
@@ -322,8 +322,8 @@ namespace Opm
             this->compute_R_(n, p, T, z, cells, &R_[0]);
         }
         const auto& pu = phaseUsage();
-        bool oil_and_gas = pu.phase_pos[BlackoilPhases::Liquid] &&
-            pu.phase_pos[BlackoilPhases::Vapour];
+        bool oil_and_gas = pu.phase_used[BlackoilPhases::Liquid] &&
+            pu.phase_used[BlackoilPhases::Vapour];
         const int o = pu.phase_pos[BlackoilPhases::Liquid];
         const int g = pu.phase_pos[BlackoilPhases::Vapour];
 

--- a/opm/core/props/phaseUsageFromDeck.hpp
+++ b/opm/core/props/phaseUsageFromDeck.hpp
@@ -94,7 +94,7 @@ namespace Opm
             }
             else {
                 //Set to ridiculous value on purpose: should never be used
-                pu.phase_pos[i] = -1;
+                pu.phase_pos[i] = 2000000000;
             }
         }
 

--- a/opm/core/props/phaseUsageFromDeck.hpp
+++ b/opm/core/props/phaseUsageFromDeck.hpp
@@ -88,8 +88,14 @@ namespace Opm
         }
         pu.num_phases = 0;
         for (int i = 0; i < BlackoilPhases::MaxNumPhases; ++i) {
-            pu.phase_pos[i] = pu.num_phases;
-            pu.num_phases += pu.phase_used[i];
+            if (pu.phase_used[i]) {
+                pu.phase_pos[i] = pu.num_phases;
+                pu.num_phases += 1;
+            }
+            else {
+                //Set to ridiculous value on purpose: should never be used
+                pu.phase_pos[i] = -1;
+            }
         }
 
         // Only 2 or 3 phase systems handled.

--- a/opm/core/simulator/initState_impl.hpp
+++ b/opm/core/simulator/initState_impl.hpp
@@ -800,10 +800,6 @@ namespace Opm
                                         const Props& props,
                                         State& state)
     {
-
-        //if (props.numPhases() != 3) {
-        //    OPM_THROW(std::runtime_error, "initBlackoilSurfvol() is only supported in three-phase simulations.");
-        //}
         const std::vector<double>& rs = state.gasoilratio();
         const std::vector<double>& rv = state.rv();
 
@@ -827,18 +823,6 @@ namespace Opm
 
         std::vector<double> capPressures(number_of_cells*np);
         props.capPress(number_of_cells,&state.saturation()[0],&allcells[0],&capPressures[0],NULL);
-
-        /*
-         * FIXME: This never used?
-        std::vector<double> Pw(number_of_cells);
-        std::vector<double> Pg(number_of_cells);
-
-        for (int c = 0; c < number_of_cells; ++c){
-            Pw[c] = state.pressure()[c] + capPressures[c*np + BlackoilPhases::Aqua];
-            Pg[c] = state.pressure()[c] + capPressures[c*np + BlackoilPhases::Vapour];
-        }
-        */
-
 
         double z_tmp;
 

--- a/opm/core/simulator/initState_impl.hpp
+++ b/opm/core/simulator/initState_impl.hpp
@@ -741,7 +741,7 @@ namespace Opm
     }
 
     /// Initialize surface volume from pressure and saturation by z = As.
-    /// Here  saturation is used as an intial guess for z in the
+    /// Here  saturation is used as an initial guess for z in the
     /// computation of A.
     template <class Props, class State>
     void initBlackoilSurfvol(const UnstructuredGrid& grid,
@@ -801,9 +801,9 @@ namespace Opm
                                         State& state)
     {
 
-        if (props.numPhases() != 3) {
-            OPM_THROW(std::runtime_error, "initBlackoilSurfvol() is only supported in three-phase simulations.");
-        }
+        //if (props.numPhases() != 3) {
+        //    OPM_THROW(std::runtime_error, "initBlackoilSurfvol() is only supported in three-phase simulations.");
+        //}
         const std::vector<double>& rs = state.gasoilratio();
         const std::vector<double>& rv = state.rv();
 
@@ -828,6 +828,8 @@ namespace Opm
         std::vector<double> capPressures(number_of_cells*np);
         props.capPress(number_of_cells,&state.saturation()[0],&allcells[0],&capPressures[0],NULL);
 
+        /*
+         * FIXME: This never used?
         std::vector<double> Pw(number_of_cells);
         std::vector<double> Pg(number_of_cells);
 
@@ -835,6 +837,7 @@ namespace Opm
             Pw[c] = state.pressure()[c] + capPressures[c*np + BlackoilPhases::Aqua];
             Pg[c] = state.pressure()[c] + capPressures[c*np + BlackoilPhases::Vapour];
         }
+        */
 
 
         double z_tmp;


### PR DESCRIPTION
This PR enables running a two phase test case with plausible results

This PR should have no side effects for running existing three phase simulations. See also the twin PR in opm-simulators which should be merged simultaneously with this one