### PR TITLE
added: downstream build support in the jenkins trigger

### DIFF
--- a/jenkins/build-opm-core.sh
+++ b/jenkins/build-opm-core.sh
@@ -38,17 +38,13 @@ function build_opm_core {
   build_module "-DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install" 0 $WORKSPACE/deps/opm-common
   popd
 
-  # Build opm-parser
-  clone_and_build_module opm-parser "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install" $OPM_PARSER_REVISION $WORKSPACE/serial
-
-  # Build opm-material
-  clone_and_build_module opm-material "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install" $OPM_MATERIAL_REVISION $WORKSPACE/serial
+  build_upstreams
 
   # Build opm-core
   pushd .
   mkdir serial/build-opm-core
   cd serial/build-opm-core
-  build_module "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install" 1 $WORKSPACE
+  build_module "-DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install -DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install" 1 $WORKSPACE
   test $? -eq 0 || exit 1
   popd
 }

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -2,10 +2,17 @@
 
 source `dirname $0`/build-opm-core.sh
 
+# Upstream revisions
+declare -a upstreams
+upstreams=(opm-parser
+           opm-material)
+
+declare -A upstreamRev
+upstreamRev[opm-parser]=master
+upstreamRev[opm-material]=master
+
 ERT_REVISION=master
 OPM_COMMON_REVISION=master
-OPM_PARSER_REVISION=master
-OPM_MATERIAL_REVISION=master
 
 build_opm_core
 test $? -eq 0 || exit 1


### PR DESCRIPTION
use 'jenkins build this with downstreams please'.

this will build all downstreams against the PR, and
execute their tests. PR's for upstream and downstream modules
can be specified.

the aggregated test results are attached to the job result on jenkins.

depends on https://github.com/OPM/opm-common/pull/111