### PR TITLE
Prevent dereferencing the end iterator.

### DIFF
--- a/opm/core/simulator/initStateEquil.hpp
+++ b/opm/core/simulator/initStateEquil.hpp
@@ -264,6 +264,11 @@ namespace Opm
                     if (deck->hasKeyword("DISGAS")) {                    
                         const TableContainer& rsvdTables = tables.getRsvdTables();
                         for (size_t i = 0; i < rec.size(); ++i) {
+                            if (eqlmap.cells(i).empty())
+                            {
+                                rs_func_.push_back(std::shared_ptr<Miscibility::RsVD>());
+                                continue;
+                            }
                             const int cell = *(eqlmap.cells(i).begin());                   
                             if (!rec[i].liveOilInitConstantRs()) {
                                 if (rsvdTables.size() <= 0 ) {
@@ -297,6 +302,11 @@ namespace Opm
                     if (deck->hasKeyword("VAPOIL")) {                    
                         const TableContainer& rvvdTables = tables.getRvvdTables();
                         for (size_t i = 0; i < rec.size(); ++i) {
+                            if (eqlmap.cells(i).empty())
+                            {
+                                rv_func_.push_back(std::shared_ptr<Miscibility::RvVD>());
+                                continue;
+                            }
                             const int cell = *(eqlmap.cells(i).begin());                   
                             if (!rec[i].wetGasInitConstantRv()) {
                                 if (rvvdTables.size() <= 0) { 
@@ -381,6 +391,10 @@ namespace Opm
                 {
                     for (const auto& r : reg.activeRegions()) {
                         const auto& cells = reg.cells(r);
+                        if (cells.empty())
+                        {
+                            continue;
+                        }
                         const int repcell = *cells.begin();
 
                         const RhoCalc calc(props, repcell);


### PR DESCRIPTION
This happened for empty regions and surfaced when compiling
with "-D_GLIBCXX_DEBUG  -DDEBUG -DGLIBCXX_FORCE_NEW".

This closes #1008, but I am not sure whether pushing nullpointers to rs_func_ and rv_func_ is a good idea.