### PR TITLE
Unify output messages format.

### DIFF
--- a/examples/diagnose_relperm.cpp
+++ b/examples/diagnose_relperm.cpp
@@ -92,6 +92,9 @@ try
     std::string logFile = baseName + ".SATFUNCLOG";
     std::shared_ptr<EclipsePRTLog> prtLog = std::make_shared<EclipsePRTLog>(logFile, Log::DefaultMessageTypes);
     OpmLog::addBackend( "ECLIPSEPRTLOG" , prtLog );
+    std::shared_ptr<StreamLog> streamLog = std::make_shared<EclipsePRTLog>(std::cout, Log::DefaultMessageTypes);
+    OpmLog::addBackend( "STREAMLOG" , streamLog );
+    streamLog->setMessageLimiter(std::make_shared<MessageLimiter>(10));
     Opm::time::StopWatch timer;
     timer.start();
     RelpermDiagnostics diagnostic;

--- a/examples/diagnose_relperm.cpp
+++ b/examples/diagnose_relperm.cpp
@@ -92,16 +92,13 @@ try
     std::string logFile = baseName + ".SATFUNCLOG";
     std::shared_ptr<EclipsePRTLog> prtLog = std::make_shared<EclipsePRTLog>(logFile, Log::DefaultMessageTypes);
     OpmLog::addBackend( "ECLIPSEPRTLOG" , prtLog );
+    prtLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(true, false));
     std::shared_ptr<StreamLog> streamLog = std::make_shared<EclipsePRTLog>(std::cout, Log::DefaultMessageTypes);
     OpmLog::addBackend( "STREAMLOG" , streamLog );
     streamLog->setMessageLimiter(std::make_shared<MessageLimiter>(10));
-    Opm::time::StopWatch timer;
-    timer.start();
+    streamLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(true, true));
     RelpermDiagnostics diagnostic;
     diagnostic.diagnosis(eclState, deck, grid);
-    timer.stop();
-    double tt = timer.secsSinceStart();
-    std::cout << "relperm diagnostics: " << tt << " seconds." << std::endl;
 }
 catch (const std::exception &e) {
     std::cerr << "Program threw an exception: " << e.what() << "\n";

--- a/opm/core/props/satfunc/RelpermDiagnostics.cpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics.cpp
@@ -107,14 +107,14 @@ namespace Opm{
         bool family2 = ((!swfnTables.empty() && !sgfnTables.empty()) || !sgwfnTables.empty()) && (!sof3Tables.empty() || !sof2Tables.empty());
 
         if (family1 && family2) {
-            const std::string msg = "-- Error:   Saturation families should not be mixed.\n Use either SGOF and SWOF or SGFN, SWFN and SOF3.";
+            const std::string msg = "Error:   Saturation families should not be mixed.\n Use either SGOF and SWOF or SGFN, SWFN and SOF3.";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
 
         if (!family1 && !family2) {
-            const std::string msg = "-- Error,   Saturations function must be specified using either \n \
+            const std::string msg = "Error,   Saturations function must be specified using either \n \
                              family 1 or family 2 keywords \n \
                              Use either SGOF and SWOF or SGFN, SWFN and SOF3.";
             messages_.push_back(msg);
@@ -217,7 +217,7 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
-            const std::string msg = "-- Error:   In SWOF table SATNUM = "+ regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "Error:   In SWOF table SATNUM = "+ regionIdx + ", saturation should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -225,13 +225,13 @@ namespace Opm{
         //TODO check endpoint sw.back() == 1. - Sor.
         //Check krw column.
         if (krw.front() != 0.0) {
-            const std::string msg = "-- Error:   In SWOF table SATNUM = " + regionIdx + ", first value of krw should be 0.";
+            const std::string msg = "Error:   In SWOF table SATNUM = " + regionIdx + ", first value of krw should be 0.";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (krw.front() < 0.0 || krw.back() > 1.0) {
-            const std::string msg = "-- Error:   In SWOF table SATNUM = " + regionIdx + ", krw should be in range [0,1].";
+            const std::string msg = "Error:   In SWOF table SATNUM = " + regionIdx + ", krw should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -239,7 +239,7 @@ namespace Opm{
 
         ///Check krow column.
         if (krow.front() > 1.0 || krow.back() < 0.0) {
-            const std::string msg = "-- Error:   In SWOF table SATNUM = "+ regionIdx + ", krow should be in range [0, 1].";
+            const std::string msg = "Error:   In SWOF table SATNUM = "+ regionIdx + ", krow should be in range [0, 1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -260,13 +260,13 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check sw column.
         if (sg.front() < 0.0 || sg.back() > 1.0) {
-            const std::string msg = "-- Error:   In SGOF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (sg.front() != 0.0) {
-            const std::string msg = "-- Error:   In SGOF table SATNUM = " + regionIdx + ", first value of sg should be 0.";
+            const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", first value of sg should be 0.";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -274,13 +274,13 @@ namespace Opm{
         //TODO check endpoint sw.back() == 1. - Sor.
         //Check krw column.
         if (krg.front() != 0.0) {
-            const std::string msg = "-- Error:   In SGOF table SATNUM = " + regionIdx + ", first value of krg should be 0.";
+            const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", first value of krg should be 0.";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (krg.front() < 0.0 || krg.back() > 1.0) {
-            const std::string msg = "-- Error:   In SGOF table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
+            const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -288,7 +288,7 @@ namespace Opm{
 
         //Check krow column.
         if (krog.front() > 1.0 || krog.back() < 0.0) {
-            const std::string msg = "-- Error:   In SGOF table SATNUM = " + regionIdx + ", krog should be in range [0, 1].";
+            const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", krog should be in range [0, 1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -306,33 +306,33 @@ namespace Opm{
         //Check sl column.
         //TODO first value means sl = swco + sor
         if (sl.front() < 0.0 || sl.back() > 1.0) {
-            const std::string msg = "-- Error:   In SLGOF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (sl.back() != 1.0) {
-            const std::string msg = "-- Error:   In SLGOF table SATNUM = " + regionIdx + ", last value of sl should be 1.";
+            const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", last value of sl should be 1.";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
 
         if (krg.front() > 1.0 || krg.back() < 0) {
-            const std::string msg = "-- Error:   In SLGOF table SATNUM = " + regionIdx + ", krg shoule be in range [0, 1].";
+            const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", krg shoule be in range [0, 1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (krg.back() != 0.0) {
-            const std::string msg = "-- Error:   In SLGOF table SATNUM = " + regionIdx + ", last value of krg hould be 0.";
+            const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", last value of krg hould be 0.";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
 
         if (krog.front() < 0.0 || krog.back() > 1.0) {
-            const std::string msg = "-- Error:   In SLGOF table SATNUM = " + regionIdx + ", krog shoule be in range [0, 1].";
+            const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", krog shoule be in range [0, 1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -351,7 +351,7 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
-            const std::string msg = "-- Error:   In SWFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "Error:   In SWFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -359,14 +359,14 @@ namespace Opm{
         
         //Check krw column.
         if (krw.front() < 0.0 || krw.back() > 1.0) {
-            const std::string msg = "-- Error:   In SWFN table SATNUM = " + regionIdx + ", krw should be in range [0,1].";
+            const std::string msg = "Error:   In SWFN table SATNUM = " + regionIdx + ", krw should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
 
         if (krw.front() != 0.0) {
-            const std::string msg = "-- Error:   In SWFN table SATNUM = " + regionIdx + ", first value of krw should be 0.";
+            const std::string msg = "Error:   In SWFN table SATNUM = " + regionIdx + ", first value of krw should be 0.";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -385,7 +385,7 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check sg column.
         if (sg.front() < 0.0 || sg.back() > 1.0) {
-            const std::string msg = "-- Error:   In SGFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "Error:   In SGFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -393,13 +393,13 @@ namespace Opm{
         
         //Check krg column.
         if (krg.front() < 0.0 || krg.back() > 1.0) {
-            const std::string msg = "-- Error:   In SGFN table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
+            const std::string msg = "Error:   In SGFN table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (krg.front() != 0.0) {
-            const std::string msg = "-- Error:   In SGFN table SATNUM = " + regionIdx + ", first value of krg should be 0.";
+            const std::string msg = "Error:   In SGFN table SATNUM = " + regionIdx + ", first value of krg should be 0.";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -420,7 +420,7 @@ namespace Opm{
         //Check so column.
         //TODO: The max so = 1 - Swco
         if (so.front() < 0.0 || so.back() > 1.0) {
-            const std::string msg = "-- Error:   In SOF3 table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -428,13 +428,13 @@ namespace Opm{
 
         //Check krow column.
         if (krow.front() < 0.0 || krow.back() > 1.0) {
-            const std::string msg = "-- Error:   In SOF3 table SATNUM = " + regionIdx + ", krow should be in range [0,1].";
+            const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", krow should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (krow.front() != 0.0) {
-            const std::string msg = "-- Error:   In SOF3 table SATNUM = " + regionIdx + ", first value of krow should be 0.";
+            const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", first value of krow should be 0.";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -442,21 +442,21 @@ namespace Opm{
 
         //Check krog column.
         if (krog.front() < 0.0 || krog.back() > 1.0) {
-            const std::string msg = "-- Error:   In SOF3 table SATNUM = " + regionIdx + ", krog should be in range [0,1].";
+            const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", krog should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
 
         if (krog.front() != 0.0) {
-            const std::string msg = "-- Error:   In SOF3 table SATNUM = " + regionIdx + ", first value of krog should be 0.";
+            const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", first value of krog should be 0.";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
     
         if (krog.back() != krow.back()) {
-            const std::string msg = "-- Error:   In SOF3 table SATNUM = " + regionIdx + ", max value of krog and krow should be the same.";
+            const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", max value of krog and krow should be the same.";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -476,7 +476,7 @@ namespace Opm{
         //Check so column.
         //TODO: The max so = 1 - Swco
         if (so.front() < 0.0 || so.back() > 1.0) {
-            const std::string msg = "-- Error:   In SOF2 table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "Error:   In SOF2 table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -484,13 +484,13 @@ namespace Opm{
 
         //Check krow column.
         if (kro.front() < 0.0 || kro.back() > 1.0) {
-            const std::string msg = "-- Error:   In SOF2 table SATNUM = " + regionIdx + ", krow should be in range [0,1].";
+            const std::string msg = "Error:   In SOF2 table SATNUM = " + regionIdx + ", krow should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (kro.front() != 0.0) {
-            const std::string msg = "-- Error:   In SOF2 table SATNUM = " + regionIdx + ", first value of krow should be 0.";
+            const std::string msg = "Error:   In SOF2 table SATNUM = " + regionIdx + ", first value of krow should be 0.";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -510,7 +510,7 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check sg column.
         if (sg.front() < 0.0 || sg.back() > 1.0) {
-            const std::string msg = "-- Error:   In SGWFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -518,13 +518,13 @@ namespace Opm{
 
         //Check krg column.
         if (krg.front() < 0.0 || krg.back() > 1.0) {
-            const std::string msg = "-- Error:   In SGWFN table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
+            const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (krg.front() != 0.0) {
-            const std::string msg = "-- Error:   In SGWFN table SATNUM = " + regionIdx + ", first value of krg should be 0.";
+            const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", first value of krg should be 0.";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -533,13 +533,13 @@ namespace Opm{
         //Check krgw column.
         //TODO check saturation sw = 1. - sg
         if (krgw.front() > 1.0 || krgw.back() < 0.0) {
-            const std::string msg = "-- Error:   In SGWFN table SATNUM = " + regionIdx + ", krgw should be in range [0,1].";
+            const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", krgw should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (krgw.back() != 0.0) {
-            const std::string msg = "-- Error:   In SGWFN table SATNUM = " + regionIdx + ", last value of krgw should be 0.";
+            const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", last value of krgw should be 0.";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -556,7 +556,7 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
-            const std::string msg = "-- Error:   In SGCWMIS table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "Error:   In SGCWMIS table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -564,7 +564,7 @@ namespace Opm{
 
         //Check critical gas column.
         if (sgc.front() < 0.0 || sgc.back() > 1.0) {
-            const std::string msg = "-- Error:   In SGCWMIS table SATNUM = " + regionIdx + ", critical gas saturation should be in range [0,1].";
+            const std::string msg = "Error:   In SGCWMIS table SATNUM = " + regionIdx + ", critical gas saturation should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -583,7 +583,7 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
-            const std::string msg = "-- Error:   In SORWMIS table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "Error:   In SORWMIS table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -591,7 +591,7 @@ namespace Opm{
 
         //Check critical oil column.
         if (sor.front() < 0.0 || sor.back() > 1.0) {
-            const std::string msg = "-- Error:   In SORWMIS table SATNUM = " + regionIdx + ", critical oil saturation should be in range [0,1].";
+            const std::string msg = "Error:   In SORWMIS table SATNUM = " + regionIdx + ", critical oil saturation should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -610,7 +610,7 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check phase fraction column.
         if (frac.front() < 0.0 || frac.back() > 1.0) {
-            const std::string msg = "-- Error:   In SSFN table SATNUM = " + regionIdx + ", phase fraction should be in range [0,1].";
+            const std::string msg = "Error:   In SSFN table SATNUM = " + regionIdx + ", phase fraction should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -618,7 +618,7 @@ namespace Opm{
 
         //Check gas relperm multiplier column.
         if (krgm.front() < 0.0 || krgm.back() > 1.0) {
-            const std::string msg = "-- Error:   In SSFN table SATNUM = " + regionIdx + ", gas relative permeability multiplier should be in range [0,1].";
+            const std::string msg = "Error:   In SSFN table SATNUM = " + regionIdx + ", gas relative permeability multiplier should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -626,7 +626,7 @@ namespace Opm{
 
         //Check solvent relperm multiplier column.
         if (krsm.front() < 0.0 || krsm.back() > 1.0) {
-            const std::string msg = "-- Error:   In SSFN table SATNUM = " + regionIdx + ", solvent relative permeability multiplier should be in range [0,1].";
+            const std::string msg = "Error:   In SSFN table SATNUM = " + regionIdx + ", solvent relative permeability multiplier should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -647,7 +647,7 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check phase fraction column.
         if (frac.front() < 0.0 || frac.back() > 1.0) {
-            const std::string msg = "-- Error:   In MISC table SATNUM = " + regionIdx + ", phase fraction should be in range [0,1].";
+            const std::string msg = "Error:   In MISC table SATNUM = " + regionIdx + ", phase fraction should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -655,7 +655,7 @@ namespace Opm{
 
         //Check miscibility column.
         if (misc.front() < 0.0 || misc.back() > 1.0) {
-            const std::string msg = "-- Error:   In MISC table SATNUM = " + regionIdx + ", miscibility should be in range [0,1].";
+            const std::string msg = "Error:   In MISC table SATNUM = " + regionIdx + ", miscibility should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -676,7 +676,7 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check phase fraction column.
         if (frac.front() < 0.0 || frac.back() > 1.0) {
-            const std::string msg = "-- Error:   In MSFN table SATNUM = " + regionIdx + ", total gas fraction should be in range [0,1].";
+            const std::string msg = "Error:   In MSFN table SATNUM = " + regionIdx + ", total gas fraction should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -684,7 +684,7 @@ namespace Opm{
 
         //Check gas_solvent relperm multiplier column.
         if (krgsm.front() < 0.0 || krgsm.back() > 1.0) {
-            const std::string msg = "-- Error:   In MSFN table SATNUM = " + regionIdx + ", gas+solvent relative permeability multiplier should be in range [0,1].";
+            const std::string msg = "Error:   In MSFN table SATNUM = " + regionIdx + ", gas+solvent relative permeability multiplier should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -692,7 +692,7 @@ namespace Opm{
 
         //Check oil relperm multiplier column.
         if (krom.front() > 1.0 || krom.back() < 0.0) {
-            const std::string msg = "-- Error:   In MSFN table SATNUM = " + regionIdx + ", oil relative permeability multiplier should be in range [0,1].";
+            const std::string msg = "Error:   In MSFN table SATNUM = " + regionIdx + ", oil relative permeability multiplier should be in range [0,1].";
             messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
@@ -722,13 +722,13 @@ namespace Opm{
              const std::string regionIdx = std::to_string(satnumIdx + 1);
              ///Consistency check.
              if (unscaledEpsInfo_[satnumIdx].Sgu > (1. - unscaledEpsInfo_[satnumIdx].Swl)) {
-                const std::string msg = "-- Warning: In saturation table SATNUM = " + regionIdx + ", Sgmax should not exceed 1-Swco.";
+                const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sgmax should not exceed 1-Swco.";
                 messages_.push_back(msg);
                 OpmLog::warning(msg);
                 counter_.warning += 1;
              }
              if (unscaledEpsInfo_[satnumIdx].Sgl > (1. - unscaledEpsInfo_[satnumIdx].Swu)) {
-                const std::string msg = "-- Warning: In saturation table SATNUM = " + regionIdx + ", Sgco should not exceed 1-Swmax.";
+                const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sgco should not exceed 1-Swmax.";
                 messages_.push_back(msg);
                 OpmLog::warning(msg);
                 counter_.warning += 1;
@@ -762,7 +762,7 @@ namespace Opm{
                      krog_value = table.evaluate("KROG" , Sou);
                  }
                  if (krow_value != krog_value) {
-                     const std::string msg = "-- Warning: In saturation table SATNUM = " + regionIdx + ", Krow(Somax) should be equal to Krog(Somax).";
+                     const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Krow(Somax) should be equal to Krog(Somax).";
                      messages_.push_back(msg);
                      OpmLog::warning(msg);
                      counter_.warning += 1;
@@ -771,13 +771,13 @@ namespace Opm{
              //Krw(Sw=0)=Krg(Sg=0)=Krow(So=0)=Krog(So=0)=0.
              //Mobile fluid requirements
             if (((unscaledEpsInfo_[satnumIdx].Sowcr + unscaledEpsInfo_[satnumIdx].Swcr)-1) >= 0) {
-                const std::string msg = "-- Warning: In saturation table SATNUM = " + regionIdx + ", Sowcr + Swcr should be less than 1.";
+                const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sowcr + Swcr should be less than 1.";
                 messages_.push_back(msg);
                 OpmLog::warning(msg);
                 counter_.warning += 1;
             }
             if (((unscaledEpsInfo_[satnumIdx].Sogcr + unscaledEpsInfo_[satnumIdx].Sgcr + unscaledEpsInfo_[satnumIdx].Swl) - 1 ) > 0) {
-                const std::string msg = "-- Warning: In saturation table SATNUM = " + regionIdx + ", Sogcr + Sgcr + Swco should be less than 1.";
+                const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sogcr + Sgcr + Swco should be less than 1.";
                 messages_.push_back(msg);
                 OpmLog::warning(msg);
                 counter_.warning += 1;

--- a/opm/core/props/satfunc/RelpermDiagnostics.cpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics.cpp
@@ -24,19 +24,6 @@
 
 namespace Opm{
 
-
-    RelpermDiagnostics::Counter::Counter()
-        :error(0)
-        ,warning(0)
-        ,problem(0)
-        ,bug(0)
-    {
-    }
-
-
-
-
-
     void RelpermDiagnostics::phaseCheck_(DeckConstPtr deck)
     {
         bool hasWater = deck->hasKeyword("WATER");
@@ -46,31 +33,26 @@ namespace Opm{
             
         if (hasWater && hasGas && !hasOil && !hasSolvent) {
             const std::string msg = "System:  Water-Gas system.";
-            std::cout << msg << std::endl;
             OpmLog::info(msg);
             fluidSystem_ = FluidSystem::WaterGas;
         }
         if (hasWater && hasOil && !hasGas && !hasSolvent) { 
             const std::string msg = "System:  Oil-Water system.";
-            std::cout << msg << std::endl;
             OpmLog::info(msg);
             fluidSystem_ = FluidSystem::OilWater; 
         }
         if (hasOil && hasGas && !hasWater && !hasSolvent) { 
             const std::string msg = "System:  Oil-Gas system.";
-            std::cout << msg << std::endl;
             OpmLog::info(msg);
             fluidSystem_ = FluidSystem::OilGas; 
         }
         if (hasOil && hasWater && hasGas && !hasSolvent) {
             const std::string msg = "System:  Black-oil system.";
-            std::cout << msg << std::endl;
             OpmLog::info(msg);
             fluidSystem_ = FluidSystem::BlackOil;
         }
         if (hasSolvent) {
             const std::string msg = "System:  Solvent model.";
-            std::cout << msg << std::endl;
             OpmLog::info(msg);
             fluidSystem_ = FluidSystem::Solvent;
         }
@@ -99,7 +81,6 @@ namespace Opm{
         if (family1 && family2) {
             const std::string msg = "Error:   Saturation families should not be mixed.\n Use either SGOF and SWOF or SGFN, SWFN and SOF3.";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         if (!family1 && !family2) {
@@ -107,19 +88,16 @@ namespace Opm{
                              family 1 or family 2 keywords \n \
                              Use either SGOF and SWOF or SGFN, SWFN and SOF3.";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         if (family1 && !family2) {
             satFamily_ = SaturationFunctionFamily::FamilyI;
             const std::string msg = "Relative permeability input format: Saturation Family I.";
-            std::cout << msg << std::endl;
             OpmLog::info(msg);
         } 
         if (!family1 && family2) {
             satFamily_ = SaturationFunctionFamily::FamilyII;
             const std::string msg = "Relative permeability input format: Saturation Family II.";
-            std::cout << msg << std::endl;
             OpmLog::info(msg);
         }
     }
@@ -207,26 +185,22 @@ namespace Opm{
         if (sw.front() < 0.0 || sw.back() > 1.0) {
             const std::string msg = "Error:   In SWOF table SATNUM = "+ regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         //TODO check endpoint sw.back() == 1. - Sor.
         //Check krw column.
         if (krw.front() != 0.0) {
             const std::string msg = "Error:   In SWOF table SATNUM = " + regionIdx + ", first value of krw should be 0.";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         if (krw.front() < 0.0 || krw.back() > 1.0) {
             const std::string msg = "Error:   In SWOF table SATNUM = " + regionIdx + ", krw should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         ///Check krow column.
         if (krow.front() > 1.0 || krow.back() < 0.0) {
             const std::string msg = "Error:   In SWOF table SATNUM = "+ regionIdx + ", krow should be in range [0, 1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         ///TODO check if run with gas.
     }
@@ -246,31 +220,26 @@ namespace Opm{
         if (sg.front() < 0.0 || sg.back() > 1.0) {
             const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         if (sg.front() != 0.0) {
             const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", first value of sg should be 0.";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         //TODO check endpoint sw.back() == 1. - Sor.
         //Check krw column.
         if (krg.front() != 0.0) {
             const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", first value of krg should be 0.";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         if (krg.front() < 0.0 || krg.back() > 1.0) {
             const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         //Check krow column.
         if (krog.front() > 1.0 || krog.back() < 0.0) {
             const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", krog should be in range [0, 1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         //TODO check if run with water.
     }
@@ -287,29 +256,24 @@ namespace Opm{
         if (sl.front() < 0.0 || sl.back() > 1.0) {
             const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         if (sl.back() != 1.0) {
             const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", last value of sl should be 1.";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         if (krg.front() > 1.0 || krg.back() < 0) {
             const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", krg shoule be in range [0, 1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         if (krg.back() != 0.0) {
             const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", last value of krg hould be 0.";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         if (krog.front() < 0.0 || krog.back() > 1.0) {
             const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", krog shoule be in range [0, 1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
     }
 
@@ -327,20 +291,17 @@ namespace Opm{
         if (sw.front() < 0.0 || sw.back() > 1.0) {
             const std::string msg = "Error:   In SWFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         
         //Check krw column.
         if (krw.front() < 0.0 || krw.back() > 1.0) {
             const std::string msg = "Error:   In SWFN table SATNUM = " + regionIdx + ", krw should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         if (krw.front() != 0.0) {
             const std::string msg = "Error:   In SWFN table SATNUM = " + regionIdx + ", first value of krw should be 0.";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
     }
 
@@ -358,19 +319,16 @@ namespace Opm{
         if (sg.front() < 0.0 || sg.back() > 1.0) {
             const std::string msg = "Error:   In SGFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         
         //Check krg column.
         if (krg.front() < 0.0 || krg.back() > 1.0) {
             const std::string msg = "Error:   In SGFN table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         if (krg.front() != 0.0) {
             const std::string msg = "Error:   In SGFN table SATNUM = " + regionIdx + ", first value of krg should be 0.";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
     }
 
@@ -390,38 +348,32 @@ namespace Opm{
         if (so.front() < 0.0 || so.back() > 1.0) {
             const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         //Check krow column.
         if (krow.front() < 0.0 || krow.back() > 1.0) {
             const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", krow should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         if (krow.front() != 0.0) {
             const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", first value of krow should be 0.";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         //Check krog column.
         if (krog.front() < 0.0 || krog.back() > 1.0) {
             const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", krog should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         if (krog.front() != 0.0) {
             const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", first value of krog should be 0.";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
     
         if (krog.back() != krow.back()) {
             const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", max value of krog and krow should be the same.";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
     }
 
@@ -440,19 +392,16 @@ namespace Opm{
         if (so.front() < 0.0 || so.back() > 1.0) {
             const std::string msg = "Error:   In SOF2 table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         //Check krow column.
         if (kro.front() < 0.0 || kro.back() > 1.0) {
             const std::string msg = "Error:   In SOF2 table SATNUM = " + regionIdx + ", krow should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         if (kro.front() != 0.0) {
             const std::string msg = "Error:   In SOF2 table SATNUM = " + regionIdx + ", first value of krow should be 0.";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
     }
 
@@ -471,19 +420,16 @@ namespace Opm{
         if (sg.front() < 0.0 || sg.back() > 1.0) {
             const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         //Check krg column.
         if (krg.front() < 0.0 || krg.back() > 1.0) {
             const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         if (krg.front() != 0.0) {
             const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", first value of krg should be 0.";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         //Check krgw column.
@@ -491,12 +437,10 @@ namespace Opm{
         if (krgw.front() > 1.0 || krgw.back() < 0.0) {
             const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", krgw should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
         if (krgw.back() != 0.0) {
             const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", last value of krgw should be 0.";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
     }
 
@@ -512,14 +456,12 @@ namespace Opm{
         if (sw.front() < 0.0 || sw.back() > 1.0) {
             const std::string msg = "Error:   In SGCWMIS table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         //Check critical gas column.
         if (sgc.front() < 0.0 || sgc.back() > 1.0) {
             const std::string msg = "Error:   In SGCWMIS table SATNUM = " + regionIdx + ", critical gas saturation should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
     }
 
@@ -537,14 +479,12 @@ namespace Opm{
         if (sw.front() < 0.0 || sw.back() > 1.0) {
             const std::string msg = "Error:   In SORWMIS table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         //Check critical oil column.
         if (sor.front() < 0.0 || sor.back() > 1.0) {
             const std::string msg = "Error:   In SORWMIS table SATNUM = " + regionIdx + ", critical oil saturation should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
     }
 
@@ -562,21 +502,18 @@ namespace Opm{
         if (frac.front() < 0.0 || frac.back() > 1.0) {
             const std::string msg = "Error:   In SSFN table SATNUM = " + regionIdx + ", phase fraction should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         //Check gas relperm multiplier column.
         if (krgm.front() < 0.0 || krgm.back() > 1.0) {
             const std::string msg = "Error:   In SSFN table SATNUM = " + regionIdx + ", gas relative permeability multiplier should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         //Check solvent relperm multiplier column.
         if (krsm.front() < 0.0 || krsm.back() > 1.0) {
             const std::string msg = "Error:   In SSFN table SATNUM = " + regionIdx + ", solvent relative permeability multiplier should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
     }
 
@@ -596,14 +533,12 @@ namespace Opm{
         if (frac.front() < 0.0 || frac.back() > 1.0) {
             const std::string msg = "Error:   In MISC table SATNUM = " + regionIdx + ", phase fraction should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         //Check miscibility column.
         if (misc.front() < 0.0 || misc.back() > 1.0) {
             const std::string msg = "Error:   In MISC table SATNUM = " + regionIdx + ", miscibility should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
     }
 
@@ -623,21 +558,18 @@ namespace Opm{
         if (frac.front() < 0.0 || frac.back() > 1.0) {
             const std::string msg = "Error:   In MSFN table SATNUM = " + regionIdx + ", total gas fraction should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         //Check gas_solvent relperm multiplier column.
         if (krgsm.front() < 0.0 || krgsm.back() > 1.0) {
             const std::string msg = "Error:   In MSFN table SATNUM = " + regionIdx + ", gas+solvent relative permeability multiplier should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
 
         //Check oil relperm multiplier column.
         if (krom.front() > 1.0 || krom.back() < 0.0) {
             const std::string msg = "Error:   In MSFN table SATNUM = " + regionIdx + ", oil relative permeability multiplier should be in range [0,1].";
             OpmLog::error(msg);
-            counter_.error += 1;
         }
     }
 
@@ -666,12 +598,10 @@ namespace Opm{
              if (unscaledEpsInfo_[satnumIdx].Sgu > (1. - unscaledEpsInfo_[satnumIdx].Swl)) {
                 const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sgmax should not exceed 1-Swco.";
                 OpmLog::warning(msg);
-                counter_.warning += 1;
              }
              if (unscaledEpsInfo_[satnumIdx].Sgl > (1. - unscaledEpsInfo_[satnumIdx].Swu)) {
                 const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sgco should not exceed 1-Swmax.";
                 OpmLog::warning(msg);
-                counter_.warning += 1;
              }
 
              //Krow(Sou) == Krog(Sou) for three-phase
@@ -704,7 +634,6 @@ namespace Opm{
                  if (krow_value != krog_value) {
                      const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Krow(Somax) should be equal to Krog(Somax).";
                      OpmLog::warning(msg);
-                     counter_.warning += 1;
                  }
              }
              //Krw(Sw=0)=Krg(Sg=0)=Krow(So=0)=Krog(So=0)=0.
@@ -712,12 +641,10 @@ namespace Opm{
             if (((unscaledEpsInfo_[satnumIdx].Sowcr + unscaledEpsInfo_[satnumIdx].Swcr)-1) >= 0) {
                 const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sowcr + Swcr should be less than 1.";
                 OpmLog::warning(msg);
-                counter_.warning += 1;
             }
             if (((unscaledEpsInfo_[satnumIdx].Sogcr + unscaledEpsInfo_[satnumIdx].Sgcr + unscaledEpsInfo_[satnumIdx].Swl) - 1 ) > 0) {
                 const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sogcr + Sgcr + Swco should be less than 1.";
                 OpmLog::warning(msg);
-                counter_.warning += 1;
             }
         }
     }

--- a/opm/core/props/satfunc/RelpermDiagnostics.cpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics.cpp
@@ -79,12 +79,12 @@ namespace Opm{
         bool family2 = ((!swfnTables.empty() && !sgfnTables.empty()) || !sgwfnTables.empty()) && (!sof3Tables.empty() || !sof2Tables.empty());
 
         if (family1 && family2) {
-            const std::string msg = "Error:   Saturation families should not be mixed.\n Use either SGOF and SWOF or SGFN, SWFN and SOF3.";
+            const std::string msg = "Saturation families should not be mixed.\n Use either SGOF and SWOF or SGFN, SWFN and SOF3.";
             OpmLog::error(msg);
         }
 
         if (!family1 && !family2) {
-            const std::string msg = "Error,   Saturations function must be specified using either \n \
+            const std::string msg = "Saturations function must be specified using either \n \
                              family 1 or family 2 keywords \n \
                              Use either SGOF and SWOF or SGFN, SWFN and SOF3.";
             OpmLog::error(msg);
@@ -110,7 +110,6 @@ namespace Opm{
     {
         const int numSatRegions = deck->getKeyword("TABDIMS").getRecord(0).getItem("NTSFUN").get< int >(0);
         const std::string msg = "Number of saturation regions: " + std::to_string(numSatRegions) + "\n";
-        std::cout << msg << std::endl;
         OpmLog::info(msg);
         const auto& tableManager = eclState->getTableManager();
         const TableContainer& swofTables    = tableManager.getSwofTables();
@@ -183,23 +182,23 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
-            const std::string msg = "Error:   In SWOF table SATNUM = "+ regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "In SWOF table SATNUM = "+ regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
         }
         //TODO check endpoint sw.back() == 1. - Sor.
         //Check krw column.
         if (krw.front() != 0.0) {
-            const std::string msg = "Error:   In SWOF table SATNUM = " + regionIdx + ", first value of krw should be 0.";
+            const std::string msg = "In SWOF table SATNUM = " + regionIdx + ", first value of krw should be 0.";
             OpmLog::error(msg);
         }
         if (krw.front() < 0.0 || krw.back() > 1.0) {
-            const std::string msg = "Error:   In SWOF table SATNUM = " + regionIdx + ", krw should be in range [0,1].";
+            const std::string msg = "In SWOF table SATNUM = " + regionIdx + ", krw should be in range [0,1].";
             OpmLog::error(msg);
         }
 
         ///Check krow column.
         if (krow.front() > 1.0 || krow.back() < 0.0) {
-            const std::string msg = "Error:   In SWOF table SATNUM = "+ regionIdx + ", krow should be in range [0, 1].";
+            const std::string msg = "In SWOF table SATNUM = "+ regionIdx + ", krow should be in range [0, 1].";
             OpmLog::error(msg);
         }
         ///TODO check if run with gas.
@@ -218,27 +217,27 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check sw column.
         if (sg.front() < 0.0 || sg.back() > 1.0) {
-            const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "In SGOF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
         }
         if (sg.front() != 0.0) {
-            const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", first value of sg should be 0.";
+            const std::string msg = "In SGOF table SATNUM = " + regionIdx + ", first value of sg should be 0.";
             OpmLog::error(msg);
         }
         //TODO check endpoint sw.back() == 1. - Sor.
         //Check krw column.
         if (krg.front() != 0.0) {
-            const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", first value of krg should be 0.";
+            const std::string msg = "In SGOF table SATNUM = " + regionIdx + ", first value of krg should be 0.";
             OpmLog::error(msg);
         }
         if (krg.front() < 0.0 || krg.back() > 1.0) {
-            const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
+            const std::string msg = "In SGOF table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
             OpmLog::error(msg);
         }
 
         //Check krow column.
         if (krog.front() > 1.0 || krog.back() < 0.0) {
-            const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", krog should be in range [0, 1].";
+            const std::string msg = "In SGOF table SATNUM = " + regionIdx + ", krog should be in range [0, 1].";
             OpmLog::error(msg);
         }
         //TODO check if run with water.
@@ -254,25 +253,25 @@ namespace Opm{
         //Check sl column.
         //TODO first value means sl = swco + sor
         if (sl.front() < 0.0 || sl.back() > 1.0) {
-            const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "In SLGOF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
         }
         if (sl.back() != 1.0) {
-            const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", last value of sl should be 1.";
+            const std::string msg = "In SLGOF table SATNUM = " + regionIdx + ", last value of sl should be 1.";
             OpmLog::error(msg);
         }
 
         if (krg.front() > 1.0 || krg.back() < 0) {
-            const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", krg shoule be in range [0, 1].";
+            const std::string msg = "In SLGOF table SATNUM = " + regionIdx + ", krg shoule be in range [0, 1].";
             OpmLog::error(msg);
         }
         if (krg.back() != 0.0) {
-            const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", last value of krg hould be 0.";
+            const std::string msg = "In SLGOF table SATNUM = " + regionIdx + ", last value of krg hould be 0.";
             OpmLog::error(msg);
         }
 
         if (krog.front() < 0.0 || krog.back() > 1.0) {
-            const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", krog shoule be in range [0, 1].";
+            const std::string msg = "In SLGOF table SATNUM = " + regionIdx + ", krog shoule be in range [0, 1].";
             OpmLog::error(msg);
         }
     }
@@ -289,18 +288,18 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
-            const std::string msg = "Error:   In SWFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "In SWFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
         }
         
         //Check krw column.
         if (krw.front() < 0.0 || krw.back() > 1.0) {
-            const std::string msg = "Error:   In SWFN table SATNUM = " + regionIdx + ", krw should be in range [0,1].";
+            const std::string msg = "In SWFN table SATNUM = " + regionIdx + ", krw should be in range [0,1].";
             OpmLog::error(msg);
         }
 
         if (krw.front() != 0.0) {
-            const std::string msg = "Error:   In SWFN table SATNUM = " + regionIdx + ", first value of krw should be 0.";
+            const std::string msg = "In SWFN table SATNUM = " + regionIdx + ", first value of krw should be 0.";
             OpmLog::error(msg);
         }
     }
@@ -346,33 +345,33 @@ namespace Opm{
         //Check so column.
         //TODO: The max so = 1 - Swco
         if (so.front() < 0.0 || so.back() > 1.0) {
-            const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "In SOF3 table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
         }
 
         //Check krow column.
         if (krow.front() < 0.0 || krow.back() > 1.0) {
-            const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", krow should be in range [0,1].";
+            const std::string msg = "In SOF3 table SATNUM = " + regionIdx + ", krow should be in range [0,1].";
             OpmLog::error(msg);
         }
         if (krow.front() != 0.0) {
-            const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", first value of krow should be 0.";
+            const std::string msg = "In SOF3 table SATNUM = " + regionIdx + ", first value of krow should be 0.";
             OpmLog::error(msg);
         }
 
         //Check krog column.
         if (krog.front() < 0.0 || krog.back() > 1.0) {
-            const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", krog should be in range [0,1].";
+            const std::string msg = "In SOF3 table SATNUM = " + regionIdx + ", krog should be in range [0,1].";
             OpmLog::error(msg);
         }
 
         if (krog.front() != 0.0) {
-            const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", first value of krog should be 0.";
+            const std::string msg = "In SOF3 table SATNUM = " + regionIdx + ", first value of krog should be 0.";
             OpmLog::error(msg);
         }
     
         if (krog.back() != krow.back()) {
-            const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", max value of krog and krow should be the same.";
+            const std::string msg = "In SOF3 table SATNUM = " + regionIdx + ", max value of krog and krow should be the same.";
             OpmLog::error(msg);
         }
     }
@@ -390,17 +389,17 @@ namespace Opm{
         //Check so column.
         //TODO: The max so = 1 - Swco
         if (so.front() < 0.0 || so.back() > 1.0) {
-            const std::string msg = "Error:   In SOF2 table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "In SOF2 table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
         }
 
         //Check krow column.
         if (kro.front() < 0.0 || kro.back() > 1.0) {
-            const std::string msg = "Error:   In SOF2 table SATNUM = " + regionIdx + ", krow should be in range [0,1].";
+            const std::string msg = "In SOF2 table SATNUM = " + regionIdx + ", krow should be in range [0,1].";
             OpmLog::error(msg);
         }
         if (kro.front() != 0.0) {
-            const std::string msg = "Error:   In SOF2 table SATNUM = " + regionIdx + ", first value of krow should be 0.";
+            const std::string msg = "In SOF2 table SATNUM = " + regionIdx + ", first value of krow should be 0.";
             OpmLog::error(msg);
         }
     }
@@ -418,28 +417,28 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check sg column.
         if (sg.front() < 0.0 || sg.back() > 1.0) {
-            const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "In SGWFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
         }
 
         //Check krg column.
         if (krg.front() < 0.0 || krg.back() > 1.0) {
-            const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
+            const std::string msg = "In SGWFN table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
             OpmLog::error(msg);
         }
         if (krg.front() != 0.0) {
-            const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", first value of krg should be 0.";
+            const std::string msg = "In SGWFN table SATNUM = " + regionIdx + ", first value of krg should be 0.";
             OpmLog::error(msg);
         }
 
         //Check krgw column.
         //TODO check saturation sw = 1. - sg
         if (krgw.front() > 1.0 || krgw.back() < 0.0) {
-            const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", krgw should be in range [0,1].";
+            const std::string msg = "In SGWFN table SATNUM = " + regionIdx + ", krgw should be in range [0,1].";
             OpmLog::error(msg);
         }
         if (krgw.back() != 0.0) {
-            const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", last value of krgw should be 0.";
+            const std::string msg = "In SGWFN table SATNUM = " + regionIdx + ", last value of krgw should be 0.";
             OpmLog::error(msg);
         }
     }
@@ -454,13 +453,13 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
-            const std::string msg = "Error:   In SGCWMIS table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "In SGCWMIS table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
         }
 
         //Check critical gas column.
         if (sgc.front() < 0.0 || sgc.back() > 1.0) {
-            const std::string msg = "Error:   In SGCWMIS table SATNUM = " + regionIdx + ", critical gas saturation should be in range [0,1].";
+            const std::string msg = "In SGCWMIS table SATNUM = " + regionIdx + ", critical gas saturation should be in range [0,1].";
             OpmLog::error(msg);
         }
     }
@@ -477,13 +476,13 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
-            const std::string msg = "Error:   In SORWMIS table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
+            const std::string msg = "In SORWMIS table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
             OpmLog::error(msg);
         }
 
         //Check critical oil column.
         if (sor.front() < 0.0 || sor.back() > 1.0) {
-            const std::string msg = "Error:   In SORWMIS table SATNUM = " + regionIdx + ", critical oil saturation should be in range [0,1].";
+            const std::string msg = "In SORWMIS table SATNUM = " + regionIdx + ", critical oil saturation should be in range [0,1].";
             OpmLog::error(msg);
         }
     }
@@ -500,19 +499,19 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check phase fraction column.
         if (frac.front() < 0.0 || frac.back() > 1.0) {
-            const std::string msg = "Error:   In SSFN table SATNUM = " + regionIdx + ", phase fraction should be in range [0,1].";
+            const std::string msg = "In SSFN table SATNUM = " + regionIdx + ", phase fraction should be in range [0,1].";
             OpmLog::error(msg);
         }
 
         //Check gas relperm multiplier column.
         if (krgm.front() < 0.0 || krgm.back() > 1.0) {
-            const std::string msg = "Error:   In SSFN table SATNUM = " + regionIdx + ", gas relative permeability multiplier should be in range [0,1].";
+            const std::string msg = "In SSFN table SATNUM = " + regionIdx + ", gas relative permeability multiplier should be in range [0,1].";
             OpmLog::error(msg);
         }
 
         //Check solvent relperm multiplier column.
         if (krsm.front() < 0.0 || krsm.back() > 1.0) {
-            const std::string msg = "Error:   In SSFN table SATNUM = " + regionIdx + ", solvent relative permeability multiplier should be in range [0,1].";
+            const std::string msg = "In SSFN table SATNUM = " + regionIdx + ", solvent relative permeability multiplier should be in range [0,1].";
             OpmLog::error(msg);
         }
     }
@@ -531,13 +530,13 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check phase fraction column.
         if (frac.front() < 0.0 || frac.back() > 1.0) {
-            const std::string msg = "Error:   In MISC table SATNUM = " + regionIdx + ", phase fraction should be in range [0,1].";
+            const std::string msg = "In MISC table SATNUM = " + regionIdx + ", phase fraction should be in range [0,1].";
             OpmLog::error(msg);
         }
 
         //Check miscibility column.
         if (misc.front() < 0.0 || misc.back() > 1.0) {
-            const std::string msg = "Error:   In MISC table SATNUM = " + regionIdx + ", miscibility should be in range [0,1].";
+            const std::string msg = "In MISC table SATNUM = " + regionIdx + ", miscibility should be in range [0,1].";
             OpmLog::error(msg);
         }
     }
@@ -556,19 +555,19 @@ namespace Opm{
         const std::string regionIdx = std::to_string(satnumIdx);
         //Check phase fraction column.
         if (frac.front() < 0.0 || frac.back() > 1.0) {
-            const std::string msg = "Error:   In MSFN table SATNUM = " + regionIdx + ", total gas fraction should be in range [0,1].";
+            const std::string msg = "In MSFN table SATNUM = " + regionIdx + ", total gas fraction should be in range [0,1].";
             OpmLog::error(msg);
         }
 
         //Check gas_solvent relperm multiplier column.
         if (krgsm.front() < 0.0 || krgsm.back() > 1.0) {
-            const std::string msg = "Error:   In MSFN table SATNUM = " + regionIdx + ", gas+solvent relative permeability multiplier should be in range [0,1].";
+            const std::string msg = "In MSFN table SATNUM = " + regionIdx + ", gas+solvent relative permeability multiplier should be in range [0,1].";
             OpmLog::error(msg);
         }
 
         //Check oil relperm multiplier column.
         if (krom.front() > 1.0 || krom.back() < 0.0) {
-            const std::string msg = "Error:   In MSFN table SATNUM = " + regionIdx + ", oil relative permeability multiplier should be in range [0,1].";
+            const std::string msg = "In MSFN table SATNUM = " + regionIdx + ", oil relative permeability multiplier should be in range [0,1].";
             OpmLog::error(msg);
         }
     }
@@ -596,11 +595,11 @@ namespace Opm{
              const std::string regionIdx = std::to_string(satnumIdx + 1);
              ///Consistency check.
              if (unscaledEpsInfo_[satnumIdx].Sgu > (1. - unscaledEpsInfo_[satnumIdx].Swl)) {
-                const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sgmax should not exceed 1-Swco.";
+                const std::string msg = "In saturation table SATNUM = " + regionIdx + ", Sgmax should not exceed 1-Swco.";
                 OpmLog::warning(msg);
              }
              if (unscaledEpsInfo_[satnumIdx].Sgl > (1. - unscaledEpsInfo_[satnumIdx].Swu)) {
-                const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sgco should not exceed 1-Swmax.";
+                const std::string msg = "In saturation table SATNUM = " + regionIdx + ", Sgco should not exceed 1-Swmax.";
                 OpmLog::warning(msg);
              }
 
@@ -632,18 +631,18 @@ namespace Opm{
                      krog_value = table.evaluate("KROG" , Sou);
                  }
                  if (krow_value != krog_value) {
-                     const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Krow(Somax) should be equal to Krog(Somax).";
+                     const std::string msg = "In saturation table SATNUM = " + regionIdx + ", Krow(Somax) should be equal to Krog(Somax).";
                      OpmLog::warning(msg);
                  }
              }
              //Krw(Sw=0)=Krg(Sg=0)=Krow(So=0)=Krog(So=0)=0.
              //Mobile fluid requirements
             if (((unscaledEpsInfo_[satnumIdx].Sowcr + unscaledEpsInfo_[satnumIdx].Swcr)-1) >= 0) {
-                const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sowcr + Swcr should be less than 1.";
+                const std::string msg = "In saturation table SATNUM = " + regionIdx + ", Sowcr + Swcr should be less than 1.";
                 OpmLog::warning(msg);
             }
             if (((unscaledEpsInfo_[satnumIdx].Sogcr + unscaledEpsInfo_[satnumIdx].Sgcr + unscaledEpsInfo_[satnumIdx].Swl) - 1 ) > 0) {
-                const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sogcr + Sgcr + Swco should be less than 1.";
+                const std::string msg = "In saturation table SATNUM = " + regionIdx + ", Sogcr + Sgcr + Swco should be less than 1.";
                 OpmLog::warning(msg);
             }
         }

--- a/opm/core/props/satfunc/RelpermDiagnostics.cpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics.cpp
@@ -37,16 +37,6 @@ namespace Opm{
 
 
 
-
-    std::vector<std::string>
-    RelpermDiagnostics::getMessages() const
-    {
-        return messages_;
-    }
-
-
-
-
     void RelpermDiagnostics::phaseCheck_(DeckConstPtr deck)
     {
         bool hasWater = deck->hasKeyword("WATER");
@@ -108,7 +98,6 @@ namespace Opm{
 
         if (family1 && family2) {
             const std::string msg = "Error:   Saturation families should not be mixed.\n Use either SGOF and SWOF or SGFN, SWFN and SOF3.";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -117,7 +106,6 @@ namespace Opm{
             const std::string msg = "Error,   Saturations function must be specified using either \n \
                              family 1 or family 2 keywords \n \
                              Use either SGOF and SWOF or SGFN, SWFN and SOF3.";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -218,7 +206,6 @@ namespace Opm{
         //Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
             const std::string msg = "Error:   In SWOF table SATNUM = "+ regionIdx + ", saturation should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -226,13 +213,11 @@ namespace Opm{
         //Check krw column.
         if (krw.front() != 0.0) {
             const std::string msg = "Error:   In SWOF table SATNUM = " + regionIdx + ", first value of krw should be 0.";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (krw.front() < 0.0 || krw.back() > 1.0) {
             const std::string msg = "Error:   In SWOF table SATNUM = " + regionIdx + ", krw should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -240,7 +225,6 @@ namespace Opm{
         ///Check krow column.
         if (krow.front() > 1.0 || krow.back() < 0.0) {
             const std::string msg = "Error:   In SWOF table SATNUM = "+ regionIdx + ", krow should be in range [0, 1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -261,13 +245,11 @@ namespace Opm{
         //Check sw column.
         if (sg.front() < 0.0 || sg.back() > 1.0) {
             const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (sg.front() != 0.0) {
             const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", first value of sg should be 0.";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -275,13 +257,11 @@ namespace Opm{
         //Check krw column.
         if (krg.front() != 0.0) {
             const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", first value of krg should be 0.";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (krg.front() < 0.0 || krg.back() > 1.0) {
             const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -289,7 +269,6 @@ namespace Opm{
         //Check krow column.
         if (krog.front() > 1.0 || krog.back() < 0.0) {
             const std::string msg = "Error:   In SGOF table SATNUM = " + regionIdx + ", krog should be in range [0, 1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -307,33 +286,28 @@ namespace Opm{
         //TODO first value means sl = swco + sor
         if (sl.front() < 0.0 || sl.back() > 1.0) {
             const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (sl.back() != 1.0) {
             const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", last value of sl should be 1.";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
 
         if (krg.front() > 1.0 || krg.back() < 0) {
             const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", krg shoule be in range [0, 1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (krg.back() != 0.0) {
             const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", last value of krg hould be 0.";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
 
         if (krog.front() < 0.0 || krog.back() > 1.0) {
             const std::string msg = "Error:   In SLGOF table SATNUM = " + regionIdx + ", krog shoule be in range [0, 1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -352,7 +326,6 @@ namespace Opm{
         //Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
             const std::string msg = "Error:   In SWFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -360,14 +333,12 @@ namespace Opm{
         //Check krw column.
         if (krw.front() < 0.0 || krw.back() > 1.0) {
             const std::string msg = "Error:   In SWFN table SATNUM = " + regionIdx + ", krw should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
 
         if (krw.front() != 0.0) {
             const std::string msg = "Error:   In SWFN table SATNUM = " + regionIdx + ", first value of krw should be 0.";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -386,7 +357,6 @@ namespace Opm{
         //Check sg column.
         if (sg.front() < 0.0 || sg.back() > 1.0) {
             const std::string msg = "Error:   In SGFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -394,13 +364,11 @@ namespace Opm{
         //Check krg column.
         if (krg.front() < 0.0 || krg.back() > 1.0) {
             const std::string msg = "Error:   In SGFN table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (krg.front() != 0.0) {
             const std::string msg = "Error:   In SGFN table SATNUM = " + regionIdx + ", first value of krg should be 0.";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -421,7 +389,6 @@ namespace Opm{
         //TODO: The max so = 1 - Swco
         if (so.front() < 0.0 || so.back() > 1.0) {
             const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -429,13 +396,11 @@ namespace Opm{
         //Check krow column.
         if (krow.front() < 0.0 || krow.back() > 1.0) {
             const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", krow should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (krow.front() != 0.0) {
             const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", first value of krow should be 0.";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -443,21 +408,18 @@ namespace Opm{
         //Check krog column.
         if (krog.front() < 0.0 || krog.back() > 1.0) {
             const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", krog should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
 
         if (krog.front() != 0.0) {
             const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", first value of krog should be 0.";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
     
         if (krog.back() != krow.back()) {
             const std::string msg = "Error:   In SOF3 table SATNUM = " + regionIdx + ", max value of krog and krow should be the same.";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -477,7 +439,6 @@ namespace Opm{
         //TODO: The max so = 1 - Swco
         if (so.front() < 0.0 || so.back() > 1.0) {
             const std::string msg = "Error:   In SOF2 table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -485,13 +446,11 @@ namespace Opm{
         //Check krow column.
         if (kro.front() < 0.0 || kro.back() > 1.0) {
             const std::string msg = "Error:   In SOF2 table SATNUM = " + regionIdx + ", krow should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (kro.front() != 0.0) {
             const std::string msg = "Error:   In SOF2 table SATNUM = " + regionIdx + ", first value of krow should be 0.";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -511,7 +470,6 @@ namespace Opm{
         //Check sg column.
         if (sg.front() < 0.0 || sg.back() > 1.0) {
             const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -519,13 +477,11 @@ namespace Opm{
         //Check krg column.
         if (krg.front() < 0.0 || krg.back() > 1.0) {
             const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (krg.front() != 0.0) {
             const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", first value of krg should be 0.";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -534,13 +490,11 @@ namespace Opm{
         //TODO check saturation sw = 1. - sg
         if (krgw.front() > 1.0 || krgw.back() < 0.0) {
             const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", krgw should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
         if (krgw.back() != 0.0) {
             const std::string msg = "Error:   In SGWFN table SATNUM = " + regionIdx + ", last value of krgw should be 0.";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -557,7 +511,6 @@ namespace Opm{
         //Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
             const std::string msg = "Error:   In SGCWMIS table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -565,7 +518,6 @@ namespace Opm{
         //Check critical gas column.
         if (sgc.front() < 0.0 || sgc.back() > 1.0) {
             const std::string msg = "Error:   In SGCWMIS table SATNUM = " + regionIdx + ", critical gas saturation should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -584,7 +536,6 @@ namespace Opm{
         //Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
             const std::string msg = "Error:   In SORWMIS table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -592,7 +543,6 @@ namespace Opm{
         //Check critical oil column.
         if (sor.front() < 0.0 || sor.back() > 1.0) {
             const std::string msg = "Error:   In SORWMIS table SATNUM = " + regionIdx + ", critical oil saturation should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -611,7 +561,6 @@ namespace Opm{
         //Check phase fraction column.
         if (frac.front() < 0.0 || frac.back() > 1.0) {
             const std::string msg = "Error:   In SSFN table SATNUM = " + regionIdx + ", phase fraction should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -619,7 +568,6 @@ namespace Opm{
         //Check gas relperm multiplier column.
         if (krgm.front() < 0.0 || krgm.back() > 1.0) {
             const std::string msg = "Error:   In SSFN table SATNUM = " + regionIdx + ", gas relative permeability multiplier should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -627,7 +575,6 @@ namespace Opm{
         //Check solvent relperm multiplier column.
         if (krsm.front() < 0.0 || krsm.back() > 1.0) {
             const std::string msg = "Error:   In SSFN table SATNUM = " + regionIdx + ", solvent relative permeability multiplier should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -648,7 +595,6 @@ namespace Opm{
         //Check phase fraction column.
         if (frac.front() < 0.0 || frac.back() > 1.0) {
             const std::string msg = "Error:   In MISC table SATNUM = " + regionIdx + ", phase fraction should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -656,7 +602,6 @@ namespace Opm{
         //Check miscibility column.
         if (misc.front() < 0.0 || misc.back() > 1.0) {
             const std::string msg = "Error:   In MISC table SATNUM = " + regionIdx + ", miscibility should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -677,7 +622,6 @@ namespace Opm{
         //Check phase fraction column.
         if (frac.front() < 0.0 || frac.back() > 1.0) {
             const std::string msg = "Error:   In MSFN table SATNUM = " + regionIdx + ", total gas fraction should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -685,7 +629,6 @@ namespace Opm{
         //Check gas_solvent relperm multiplier column.
         if (krgsm.front() < 0.0 || krgsm.back() > 1.0) {
             const std::string msg = "Error:   In MSFN table SATNUM = " + regionIdx + ", gas+solvent relative permeability multiplier should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -693,7 +636,6 @@ namespace Opm{
         //Check oil relperm multiplier column.
         if (krom.front() > 1.0 || krom.back() < 0.0) {
             const std::string msg = "Error:   In MSFN table SATNUM = " + regionIdx + ", oil relative permeability multiplier should be in range [0,1].";
-            messages_.push_back(msg);
             OpmLog::error(msg);
             counter_.error += 1;
         }
@@ -723,13 +665,11 @@ namespace Opm{
              ///Consistency check.
              if (unscaledEpsInfo_[satnumIdx].Sgu > (1. - unscaledEpsInfo_[satnumIdx].Swl)) {
                 const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sgmax should not exceed 1-Swco.";
-                messages_.push_back(msg);
                 OpmLog::warning(msg);
                 counter_.warning += 1;
              }
              if (unscaledEpsInfo_[satnumIdx].Sgl > (1. - unscaledEpsInfo_[satnumIdx].Swu)) {
                 const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sgco should not exceed 1-Swmax.";
-                messages_.push_back(msg);
                 OpmLog::warning(msg);
                 counter_.warning += 1;
              }
@@ -763,7 +703,6 @@ namespace Opm{
                  }
                  if (krow_value != krog_value) {
                      const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Krow(Somax) should be equal to Krog(Somax).";
-                     messages_.push_back(msg);
                      OpmLog::warning(msg);
                      counter_.warning += 1;
                  }
@@ -772,13 +711,11 @@ namespace Opm{
              //Mobile fluid requirements
             if (((unscaledEpsInfo_[satnumIdx].Sowcr + unscaledEpsInfo_[satnumIdx].Swcr)-1) >= 0) {
                 const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sowcr + Swcr should be less than 1.";
-                messages_.push_back(msg);
                 OpmLog::warning(msg);
                 counter_.warning += 1;
             }
             if (((unscaledEpsInfo_[satnumIdx].Sogcr + unscaledEpsInfo_[satnumIdx].Sgcr + unscaledEpsInfo_[satnumIdx].Swl) - 1 ) > 0) {
                 const std::string msg = "Warning: In saturation table SATNUM = " + regionIdx + ", Sogcr + Sgcr + Swco should be less than 1.";
-                messages_.push_back(msg);
                 OpmLog::warning(msg);
                 counter_.warning += 1;
             }

--- a/opm/core/props/satfunc/RelpermDiagnostics.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics.hpp
@@ -62,8 +62,6 @@ namespace Opm {
                        DeckConstPtr deck,
                        const GridT& grid);
 
-        std::vector<std::string> getMessages() const;
-
     private:
         enum FluidSystem {
             OilWater,
@@ -96,9 +94,6 @@ namespace Opm {
         std::vector<Opm::EclEpsScalingPointsInfo<double> > unscaledEpsInfo_;
         std::vector<Opm::EclEpsScalingPointsInfo<double> > scaledEpsInfo_;
 
-        std::vector<std::string> messages_;
-        ///Store scaled information.
-        std::vector<std::string> scaled_messages_;
 
         ///Check the phase that used.
         void phaseCheck_(DeckConstPtr deck);

--- a/opm/core/props/satfunc/RelpermDiagnostics.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics.hpp
@@ -81,16 +81,6 @@ namespace Opm {
   
         SaturationFunctionFamily satFamily_;
 
-        struct Counter {
-            Counter();
-            int error;
-            int warning;
-            int problem;
-            int bug;
-        };
-
-        Counter counter_;
-        
         std::vector<Opm::EclEpsScalingPointsInfo<double> > unscaledEpsInfo_;
         std::vector<Opm::EclEpsScalingPointsInfo<double> > scaledEpsInfo_;
 

--- a/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
@@ -72,14 +72,12 @@ namespace Opm {
             if (scaledEpsInfo_[c].Sgu > (1.0 - scaledEpsInfo_[c].Swl)) {
                 const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGU exceed 1.0 - SWL";
                 OpmLog::warning(tag, msg);
-                counter_.warning += 1;
             }
             
             // SGL <= 1.0 - SWU
             if (scaledEpsInfo_[c].Sgl > (1.0 - scaledEpsInfo_[c].Swu)) {
                 const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGL exceed 1.0 - SWU";
                 OpmLog::warning(tag, msg);
-                counter_.warning += 1;
             }
 
             if (deck->hasKeyword("SCALECRS") && fluidSystem_ == FluidSystem::BlackOil) {
@@ -87,13 +85,11 @@ namespace Opm {
                 if ((scaledEpsInfo_[c].Sowcr + scaledEpsInfo_[c].Swcr) >= 1.0) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR + SWCR exceed 1.0";
                     OpmLog::warning(tag, msg);
-                    counter_.warning += 1;
                 }
 
                 if ((scaledEpsInfo_[c].Sogcr + scaledEpsInfo_[c].Sgcr + scaledEpsInfo_[c].Swl) >= 1.0) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOGCR + SGCR + SWL exceed 1.0";
                     OpmLog::warning(tag, msg);
-                    counter_.warning += 1;
                 }
             }
             ///Following rules come from NEXUS.
@@ -101,19 +97,16 @@ namespace Opm {
                 if (scaledEpsInfo_[c].Swl > scaledEpsInfo_[c].Swcr) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SWL > SWCR";
                     OpmLog::warning(tag, msg);
-                    counter_.warning += 1;
                 }
 
                 if (scaledEpsInfo_[c].Swcr > scaledEpsInfo_[c].Sowcr) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SWCR > SOWCR";
                     OpmLog::warning(tag, msg);
-                    counter_.warning += 1;
                 }
             
                 if (scaledEpsInfo_[c].Sowcr > scaledEpsInfo_[c].Swu) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR > SWU";
                     OpmLog::warning(tag, msg);
-                    counter_.warning += 1;
                 }
             }
 
@@ -121,7 +114,6 @@ namespace Opm {
                 if (scaledEpsInfo_[c].Sgl > scaledEpsInfo_[c].Sgcr) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGL > SGCR";
                     OpmLog::warning(tag, msg);
-                    counter_.warning += 1;
                 }
             }
 
@@ -129,13 +121,11 @@ namespace Opm {
                 if (scaledEpsInfo_[c].Sgcr > scaledEpsInfo_[c].Sogcr) {
                     const std::string msg = "-- Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGCR > SOGCR";
                     OpmLog::warning(tag, msg);
-                    counter_.warning += 1;
                 }
 
                 if (scaledEpsInfo_[c].Sogcr > scaledEpsInfo_[c].Sgu) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOGCR > SGU";
                     OpmLog::warning(tag, msg);
-                    counter_.warning += 1;
                 }
             }
         } 

--- a/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
@@ -83,7 +83,8 @@ namespace Opm {
         EclEpsGridProperties epsGridProperties;
         epsGridProperties.initFromDeck(deck, eclState, /*imbibition=*/false);       
         const auto& satnum = eclState->get3DProperties().getIntGridProperty("SATNUM");
-
+        
+        const std::string tag = "Scaled endpoints";
         for (int c = 0; c < nc; ++c) {
             const int cartIdx = compressedToCartesianIdx[c];
             const std::string satnumIdx = std::to_string(satnum.iget(cartIdx));
@@ -100,7 +101,7 @@ namespace Opm {
             if (scaledEpsInfo_[c].Sgu > (1.0 - scaledEpsInfo_[c].Swl)) {
                 const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGU exceed 1.0 - SWL";
                 scaled_messages_.push_back(msg);
-                OpmLog::warning(msg);
+                OpmLog::warning(tag, msg);
                 counter_.warning += 1;
             }
             
@@ -108,7 +109,7 @@ namespace Opm {
             if (scaledEpsInfo_[c].Sgl > (1.0 - scaledEpsInfo_[c].Swu)) {
                 const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGL exceed 1.0 - SWU";
                 scaled_messages_.push_back(msg);
-                OpmLog::warning(msg);
+                OpmLog::warning(tag, msg);
                 counter_.warning += 1;
             }
 
@@ -117,14 +118,14 @@ namespace Opm {
                 if ((scaledEpsInfo_[c].Sowcr + scaledEpsInfo_[c].Swcr) >= 1.0) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR + SWCR exceed 1.0";
                     scaled_messages_.push_back(msg);
-                    OpmLog::warning(msg);
+                    OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }
 
                 if ((scaledEpsInfo_[c].Sogcr + scaledEpsInfo_[c].Sgcr + scaledEpsInfo_[c].Swl) >= 1.0) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOGCR + SGCR + SWL exceed 1.0";
                     scaled_messages_.push_back(msg);
-                    OpmLog::warning(msg);
+                    OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }
             }
@@ -133,21 +134,21 @@ namespace Opm {
                 if (scaledEpsInfo_[c].Swl > scaledEpsInfo_[c].Swcr) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SWL > SWCR";
                     scaled_messages_.push_back(msg);
-                    OpmLog::warning(msg);
+                    OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }
 
                 if (scaledEpsInfo_[c].Swcr > scaledEpsInfo_[c].Sowcr) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SWCR > SOWCR";
                     scaled_messages_.push_back(msg);
-                    OpmLog::warning(msg);
+                    OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }
             
                 if (scaledEpsInfo_[c].Sowcr > scaledEpsInfo_[c].Swu) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR > SWU";
                     scaled_messages_.push_back(msg);
-                    OpmLog::warning(msg);
+                    OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }
             }
@@ -156,7 +157,7 @@ namespace Opm {
                 if (scaledEpsInfo_[c].Sgl > scaledEpsInfo_[c].Sgcr) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGL > SGCR";
                     scaled_messages_.push_back(msg);
-                    OpmLog::warning(msg);
+                    OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }
             }
@@ -165,14 +166,14 @@ namespace Opm {
                 if (scaledEpsInfo_[c].Sgcr > scaledEpsInfo_[c].Sogcr) {
                     const std::string msg = "-- Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGCR > SOGCR";
                     scaled_messages_.push_back(msg);
-                    OpmLog::warning(msg);
+                    OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }
 
                 if (scaledEpsInfo_[c].Sogcr > scaledEpsInfo_[c].Sgu) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOGCR > SGU";
                     scaled_messages_.push_back(msg);
-                    OpmLog::warning(msg);
+                    OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }
             }

--- a/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
@@ -39,35 +39,6 @@ namespace Opm {
         tableCheck_(eclState, deck);
         unscaledEndPointsCheck_(deck, eclState);
         scaledEndPointsCheck_(deck, eclState, grid);
-        if (!messages_.empty()) {
-            std::sort(messages_.begin(), messages_.end());
-            auto it = std::unique(messages_.begin(), messages_.end());
-            messages_.erase(it, messages_.end());
-            std::cout << std::endl;
-            for (const auto& x : messages_) {
-                std::cout << x << std::endl;
-            }
-        }
-        int limits = 0;
-        if (!scaled_messages_.empty()) {
-            std::cout << std::endl;
-            for (const auto& x : scaled_messages_) {
-                if (limits < 10) {
-                    std::cout << x << std::endl;
-                    limits++;
-                } else {
-                    std::cout << "\nMore inconsistencies exist. Check saturation function input and .SATFUNCLOG file!" << std::endl;
-                    break;
-                }
-            }
-        }
-
-        const std::string summary_msg = "\n\nError summary:" + 
-            std::string("\nWarnings          " + std::to_string(counter_.warning)) +
-            std::string("\nProblems          " + std::to_string(counter_.problem)) +
-            std::string("\nErrors            " + std::to_string(counter_.error)) + 
-            std::string("\nBugs              " + std::to_string(counter_.bug))+ "\n";
-        std::cout << summary_msg << std::endl;
     }
 
     template <class GridT>
@@ -100,7 +71,6 @@ namespace Opm {
             // SGU <= 1.0 - SWL
             if (scaledEpsInfo_[c].Sgu > (1.0 - scaledEpsInfo_[c].Swl)) {
                 const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGU exceed 1.0 - SWL";
-                scaled_messages_.push_back(msg);
                 OpmLog::warning(tag, msg);
                 counter_.warning += 1;
             }
@@ -108,7 +78,6 @@ namespace Opm {
             // SGL <= 1.0 - SWU
             if (scaledEpsInfo_[c].Sgl > (1.0 - scaledEpsInfo_[c].Swu)) {
                 const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGL exceed 1.0 - SWU";
-                scaled_messages_.push_back(msg);
                 OpmLog::warning(tag, msg);
                 counter_.warning += 1;
             }
@@ -117,14 +86,12 @@ namespace Opm {
                 // Mobilility check.
                 if ((scaledEpsInfo_[c].Sowcr + scaledEpsInfo_[c].Swcr) >= 1.0) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR + SWCR exceed 1.0";
-                    scaled_messages_.push_back(msg);
                     OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }
 
                 if ((scaledEpsInfo_[c].Sogcr + scaledEpsInfo_[c].Sgcr + scaledEpsInfo_[c].Swl) >= 1.0) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOGCR + SGCR + SWL exceed 1.0";
-                    scaled_messages_.push_back(msg);
                     OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }
@@ -133,21 +100,18 @@ namespace Opm {
             if (fluidSystem_ != FluidSystem::WaterGas) {
                 if (scaledEpsInfo_[c].Swl > scaledEpsInfo_[c].Swcr) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SWL > SWCR";
-                    scaled_messages_.push_back(msg);
                     OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }
 
                 if (scaledEpsInfo_[c].Swcr > scaledEpsInfo_[c].Sowcr) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SWCR > SOWCR";
-                    scaled_messages_.push_back(msg);
                     OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }
             
                 if (scaledEpsInfo_[c].Sowcr > scaledEpsInfo_[c].Swu) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR > SWU";
-                    scaled_messages_.push_back(msg);
                     OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }
@@ -156,7 +120,6 @@ namespace Opm {
             if (fluidSystem_ != FluidSystem::OilWater) {
                 if (scaledEpsInfo_[c].Sgl > scaledEpsInfo_[c].Sgcr) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGL > SGCR";
-                    scaled_messages_.push_back(msg);
                     OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }
@@ -165,14 +128,12 @@ namespace Opm {
             if (fluidSystem_ != FluidSystem::BlackOil) {
                 if (scaledEpsInfo_[c].Sgcr > scaledEpsInfo_[c].Sogcr) {
                     const std::string msg = "-- Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGCR > SOGCR";
-                    scaled_messages_.push_back(msg);
                     OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }
 
                 if (scaledEpsInfo_[c].Sogcr > scaledEpsInfo_[c].Sgu) {
                     const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOGCR > SGU";
-                    scaled_messages_.push_back(msg);
                     OpmLog::warning(tag, msg);
                     counter_.warning += 1;
                 }

--- a/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
@@ -33,7 +33,7 @@ namespace Opm {
                                        Opm::DeckConstPtr deck,
                                        const GridT& grid)
     {
-        std::cout << "\n\n***************Saturation Functions Diagnostics***************\n\n";
+        OpmLog::info("***************Saturation Functions Diagnostics***************");
         phaseCheck_(deck);
         satFamilyCheck_(eclState);
         tableCheck_(eclState, deck);
@@ -70,61 +70,61 @@ namespace Opm {
 
             // SGU <= 1.0 - SWL
             if (scaledEpsInfo_[c].Sgu > (1.0 - scaledEpsInfo_[c].Swl)) {
-                const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGU exceed 1.0 - SWL";
+                const std::string msg = "For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGU exceed 1.0 - SWL";
                 OpmLog::warning(tag, msg);
             }
             
             // SGL <= 1.0 - SWU
             if (scaledEpsInfo_[c].Sgl > (1.0 - scaledEpsInfo_[c].Swu)) {
-                const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGL exceed 1.0 - SWU";
+                const std::string msg = "For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGL exceed 1.0 - SWU";
                 OpmLog::warning(tag, msg);
             }
 
             if (deck->hasKeyword("SCALECRS") && fluidSystem_ == FluidSystem::BlackOil) {
                 // Mobilility check.
                 if ((scaledEpsInfo_[c].Sowcr + scaledEpsInfo_[c].Swcr) >= 1.0) {
-                    const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR + SWCR exceed 1.0";
+                    const std::string msg = "For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR + SWCR exceed 1.0";
                     OpmLog::warning(tag, msg);
                 }
 
                 if ((scaledEpsInfo_[c].Sogcr + scaledEpsInfo_[c].Sgcr + scaledEpsInfo_[c].Swl) >= 1.0) {
-                    const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOGCR + SGCR + SWL exceed 1.0";
+                    const std::string msg = "For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOGCR + SGCR + SWL exceed 1.0";
                     OpmLog::warning(tag, msg);
                 }
             }
             ///Following rules come from NEXUS.
             if (fluidSystem_ != FluidSystem::WaterGas) {
                 if (scaledEpsInfo_[c].Swl > scaledEpsInfo_[c].Swcr) {
-                    const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SWL > SWCR";
+                    const std::string msg = "For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SWL > SWCR";
                     OpmLog::warning(tag, msg);
                 }
 
                 if (scaledEpsInfo_[c].Swcr > scaledEpsInfo_[c].Sowcr) {
-                    const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SWCR > SOWCR";
+                    const std::string msg = "For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SWCR > SOWCR";
                     OpmLog::warning(tag, msg);
                 }
             
                 if (scaledEpsInfo_[c].Sowcr > scaledEpsInfo_[c].Swu) {
-                    const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR > SWU";
+                    const std::string msg = "For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR > SWU";
                     OpmLog::warning(tag, msg);
                 }
             }
 
             if (fluidSystem_ != FluidSystem::OilWater) {
                 if (scaledEpsInfo_[c].Sgl > scaledEpsInfo_[c].Sgcr) {
-                    const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGL > SGCR";
+                    const std::string msg = "For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGL > SGCR";
                     OpmLog::warning(tag, msg);
                 }
             }
 
             if (fluidSystem_ != FluidSystem::BlackOil) {
                 if (scaledEpsInfo_[c].Sgcr > scaledEpsInfo_[c].Sogcr) {
-                    const std::string msg = "-- Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGCR > SOGCR";
+                    const std::string msg = "For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGCR > SOGCR";
                     OpmLog::warning(tag, msg);
                 }
 
                 if (scaledEpsInfo_[c].Sogcr > scaledEpsInfo_[c].Sgu) {
-                    const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOGCR > SGU";
+                    const std::string msg = "For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOGCR > SGU";
                     OpmLog::warning(tag, msg);
                 }
             }

--- a/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
@@ -56,7 +56,7 @@ namespace Opm {
                     std::cout << x << std::endl;
                     limits++;
                 } else {
-                    std::cout << "\nMore inconsistencies exist. Check saturation function input and LOGFILE!" << std::endl;
+                    std::cout << "\nMore inconsistencies exist. Check saturation function input and .SATFUNCLOG file!" << std::endl;
                     break;
                 }
             }
@@ -98,7 +98,7 @@ namespace Opm {
 
             // SGU <= 1.0 - SWL
             if (scaledEpsInfo_[c].Sgu > (1.0 - scaledEpsInfo_[c].Swl)) {
-                const std::string msg = "-- Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGU exceed 1.0 - SWL";
+                const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGU exceed 1.0 - SWL";
                 scaled_messages_.push_back(msg);
                 OpmLog::warning(msg);
                 counter_.warning += 1;
@@ -106,7 +106,7 @@ namespace Opm {
             
             // SGL <= 1.0 - SWU
             if (scaledEpsInfo_[c].Sgl > (1.0 - scaledEpsInfo_[c].Swu)) {
-                const std::string msg = "-- Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGL exceed 1.0 - SWU";
+                const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGL exceed 1.0 - SWU";
                 scaled_messages_.push_back(msg);
                 OpmLog::warning(msg);
                 counter_.warning += 1;
@@ -115,14 +115,14 @@ namespace Opm {
             if (deck->hasKeyword("SCALECRS") && fluidSystem_ == FluidSystem::BlackOil) {
                 // Mobilility check.
                 if ((scaledEpsInfo_[c].Sowcr + scaledEpsInfo_[c].Swcr) >= 1.0) {
-                    const std::string msg = "-- Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR + SWCR exceed 1.0";
+                    const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR + SWCR exceed 1.0";
                     scaled_messages_.push_back(msg);
                     OpmLog::warning(msg);
                     counter_.warning += 1;
                 }
 
                 if ((scaledEpsInfo_[c].Sogcr + scaledEpsInfo_[c].Sgcr + scaledEpsInfo_[c].Swl) >= 1.0) {
-                    const std::string msg = "-- Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOGCR + SGCR + SWL exceed 1.0";
+                    const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOGCR + SGCR + SWL exceed 1.0";
                     scaled_messages_.push_back(msg);
                     OpmLog::warning(msg);
                     counter_.warning += 1;
@@ -131,21 +131,21 @@ namespace Opm {
             ///Following rules come from NEXUS.
             if (fluidSystem_ != FluidSystem::WaterGas) {
                 if (scaledEpsInfo_[c].Swl > scaledEpsInfo_[c].Swcr) {
-                    const std::string msg = "-- Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SWL > SWCR";
+                    const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SWL > SWCR";
                     scaled_messages_.push_back(msg);
                     OpmLog::warning(msg);
                     counter_.warning += 1;
                 }
 
                 if (scaledEpsInfo_[c].Swcr > scaledEpsInfo_[c].Sowcr) {
-                    const std::string msg = "-- Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SWCR > SOWCR";
+                    const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SWCR > SOWCR";
                     scaled_messages_.push_back(msg);
                     OpmLog::warning(msg);
                     counter_.warning += 1;
                 }
             
                 if (scaledEpsInfo_[c].Sowcr > scaledEpsInfo_[c].Swu) {
-                    const std::string msg = "-- Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR > SWU";
+                    const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR > SWU";
                     scaled_messages_.push_back(msg);
                     OpmLog::warning(msg);
                     counter_.warning += 1;
@@ -154,7 +154,7 @@ namespace Opm {
 
             if (fluidSystem_ != FluidSystem::OilWater) {
                 if (scaledEpsInfo_[c].Sgl > scaledEpsInfo_[c].Sgcr) {
-                    const std::string msg = "-- Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGL > SGCR";
+                    const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGL > SGCR";
                     scaled_messages_.push_back(msg);
                     OpmLog::warning(msg);
                     counter_.warning += 1;
@@ -170,7 +170,7 @@ namespace Opm {
                 }
 
                 if (scaledEpsInfo_[c].Sogcr > scaledEpsInfo_[c].Sgu) {
-                    const std::string msg = "-- Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOGCR > SGU";
+                    const std::string msg = "Warning: For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOGCR > SGU";
                     scaled_messages_.push_back(msg);
                     OpmLog::warning(msg);
                     counter_.warning += 1;

--- a/tests/test_relpermdiagnostics.cpp
+++ b/tests/test_relpermdiagnostics.cpp
@@ -34,7 +34,7 @@
 #include <boost/test/floating_point_comparison.hpp>
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 #include <opm/common/OpmLog/OpmLog.hpp>
-#include <opm/common/OpmLog/EclipsePRTLog.hpp>
+#include <opm/common/OpmLog/CounterLog.hpp>
 
 #include <opm/core/grid.h>
 #include <opm/core/grid/cart_grid.h>
@@ -58,16 +58,12 @@ BOOST_AUTO_TEST_CASE(diagnosis)
                              });
     Opm::DeckConstPtr deck(parser->parseFile("../tests/relpermDiagnostics.DATA", parseContext));
     eclState.reset(new EclipseState(deck, parseContext));
-
     GridManager gm(eclState->getInputGrid());
     const UnstructuredGrid& grid = *gm.c_grid();
-    std::string logFile = "LOGFILE.txt";
-    std::shared_ptr<EclipsePRTLog> prtLog = std::make_shared<EclipsePRTLog>(logFile, Log::DefaultMessageTypes);
-    OpmLog::addBackend( "ECLIPSEPRTLOG" , prtLog );
+    std::shared_ptr<CounterLog> counterLog = std::make_shared<CounterLog>(Log::DefaultMessageTypes);
+    OpmLog::addBackend( "COUNTERLOG" , counterLog );
     RelpermDiagnostics diagnostics;
     diagnostics.diagnosis(eclState, deck, grid);
-    auto msg = diagnostics.getMessages();
-    BOOST_CHECK(!msg.empty());
-    BOOST_CHECK_EQUAL(msg.size(), 1);
+    BOOST_CHECK_EQUAL(1, counterLog->numMessages(Log::MessageType::Warning));
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
With https://github.com/OPM/opm-common/pull/115, the diagnostics messages will not output prefix twice.