### PR TITLE
Add member hydroCarbonState to the BlackoilState

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -377,6 +377,7 @@ list (APPEND PUBLIC_HEADER_FILES
         opm/core/utility/Event.hpp
         opm/core/utility/Event_impl.hpp
         opm/core/utility/Factory.hpp
+        opm/core/utility/initHydroCarbonState.hpp
         opm/core/utility/MonotCubicInterpolator.hpp
         opm/core/utility/NonuniformTableLinear.hpp
         opm/core/utility/NullStream.hpp

--- a/opm/core/simulator/BlackoilState.cpp
+++ b/opm/core/simulator/BlackoilState.cpp
@@ -21,10 +21,11 @@ BlackoilState::BlackoilState( size_t num_cells , size_t num_faces , size_t num_p
 }
 
 BlackoilState::BlackoilState( const BlackoilState& other )
-    : SimulationDataContainer(other)
+    : SimulationDataContainer(other),
+      hydrocarbonstate_(other.hydroCarbonState())
 {
     setBlackoilStateReferencePointers();
-    hydrocarbonstate_ = other.hydroCarbonState();
+
 }
 
 BlackoilState& BlackoilState::operator=( const BlackoilState& other )

--- a/opm/core/simulator/BlackoilState.cpp
+++ b/opm/core/simulator/BlackoilState.cpp
@@ -24,12 +24,14 @@ BlackoilState::BlackoilState( const BlackoilState& other )
     : SimulationDataContainer(other)
 {
     setBlackoilStateReferencePointers();
+    hydrocarbonstate_ = other.hydroCarbonState();
 }
 
 BlackoilState& BlackoilState::operator=( const BlackoilState& other )
 {
     SimulationDataContainer::operator=(other);
     setBlackoilStateReferencePointers();
+    hydrocarbonstate_ = other.hydroCarbonState();
     return *this;
 }
 

--- a/opm/core/simulator/BlackoilState.hpp
+++ b/opm/core/simulator/BlackoilState.hpp
@@ -62,16 +62,21 @@ namespace Opm
         std::vector<double>& surfacevol  () { return *surfacevol_ref_;  }
         std::vector<double>& gasoilratio () { return *gasoilratio_ref_; }
         std::vector<double>& rv ()          { return *rv_ref_;          }
+        std::vector<int>& hydroCarbonState() { return hydrocarbonstate_;  }
 
         const std::vector<double>& surfacevol  () const { return *surfacevol_ref_;  }
         const std::vector<double>& gasoilratio () const { return *gasoilratio_ref_; }
         const std::vector<double>& rv ()          const { return *rv_ref_;          }
+        const std::vector<int>& hydroCarbonState() const { return hydrocarbonstate_;  }
 
     private:
         void setBlackoilStateReferencePointers();
         std::vector<double>* surfacevol_ref_;
         std::vector<double>* gasoilratio_ref_;
         std::vector<double>* rv_ref_;
+
+        // A vector storing the hydro carbon state.
+        std::vector<int> hydrocarbonstate_;
 
 
     };

--- a/opm/core/simulator/BlackoilState.hpp
+++ b/opm/core/simulator/BlackoilState.hpp
@@ -30,11 +30,11 @@
 namespace Opm
 {
 
-enum HydroCarbonState {
-    GasOnly = 0,
-    GasAndOil = 1,
-    OilOnly = 2
-};
+    enum HydroCarbonState {
+        GasOnly = 0,
+        GasAndOil = 1,
+        OilOnly = 2
+    };
 
     /// Simulator state for a blackoil simulator.
     class BlackoilState : public SimulationDataContainer
@@ -68,12 +68,12 @@ enum HydroCarbonState {
         std::vector<double>& surfacevol  () { return *surfacevol_ref_;  }
         std::vector<double>& gasoilratio () { return *gasoilratio_ref_; }
         std::vector<double>& rv ()          { return *rv_ref_;          }
-        std::vector<int>& hydroCarbonState() { return hydrocarbonstate_;  }
+        std::vector<HydroCarbonState>& hydroCarbonState() { return hydrocarbonstate_;  }
 
         const std::vector<double>& surfacevol  () const { return *surfacevol_ref_;  }
         const std::vector<double>& gasoilratio () const { return *gasoilratio_ref_; }
         const std::vector<double>& rv ()          const { return *rv_ref_;          }
-        const std::vector<int>& hydroCarbonState() const { return hydrocarbonstate_;  }
+        const std::vector<HydroCarbonState>& hydroCarbonState() const { return hydrocarbonstate_;  }
 
     private:
         void setBlackoilStateReferencePointers();
@@ -82,7 +82,7 @@ enum HydroCarbonState {
         std::vector<double>* rv_ref_;
 
         // A vector storing the hydro carbon state.
-        std::vector<int> hydrocarbonstate_;
+        std::vector<HydroCarbonState> hydrocarbonstate_;
 
 
     };

--- a/opm/core/simulator/BlackoilState.hpp
+++ b/opm/core/simulator/BlackoilState.hpp
@@ -30,6 +30,12 @@
 namespace Opm
 {
 
+enum HydroCarbonState {
+    GasOnly = 0,
+    GasAndOil = 1,
+    OilOnly = 2
+};
+
     /// Simulator state for a blackoil simulator.
     class BlackoilState : public SimulationDataContainer
     {

--- a/opm/core/utility/initHydroCarbonState.hpp
+++ b/opm/core/utility/initHydroCarbonState.hpp
@@ -1,0 +1,42 @@
+#ifndef INITHYDROCARBONSTATE_HPP
+#define INITHYDROCARBONSTATE_HPP
+
+#include "opm/core/simulator/BlackoilState.hpp"
+
+namespace Opm
+{
+
+void initHydroCarbonState(BlackoilState& state, const PhaseUsage& pu, const int num_cells) {
+    enum { Oil = BlackoilPhases::Liquid, Gas = BlackoilPhases::Vapour, Water = BlackoilPhases::Aqua };
+    // hydrocarbonstate is only used when gas and oil is present
+    assert(pu.phase_used[Oil]);
+    if (!pu.phase_used[Gas]) {
+        return; // do nothing
+    }
+    std::vector<int>& hydroCarbonState = state.hydroCarbonState();
+    const int np = pu.num_phases;
+    hydroCarbonState.resize(num_cells);
+    std::fill(hydroCarbonState.begin(), hydroCarbonState.end(), HydroCarbonState::GasAndOil);
+
+    // set hydrocarbon state
+    const double epsilon = std::sqrt(std::numeric_limits<double>::epsilon());
+    const std::vector<double>& saturation = state.saturation();
+    for (int c = 0; c < num_cells; ++c) {
+        if (pu.phase_used[Water]) {
+            if ( saturation[c*np + pu.phase_pos[ Water ]] > (1.0 - epsilon)) {
+                continue; // cases (almost) filled with water is treated as GasAndOil case;
+            }
+        }
+        if ( saturation[c*np + pu.phase_pos[ Gas ]] == 0.0) {
+            hydroCarbonState[c] = HydroCarbonState::OilOnly;
+            continue;
+        }
+        if ( saturation[c*np + pu.phase_pos[ Oil ]] == 0.0) {
+            hydroCarbonState[c] = HydroCarbonState::GasOnly;
+        }
+    }
+}
+
+
+} // namespace Opm
+#endif // INITHYDROCARBONSTATE_HPP

--- a/opm/core/utility/initHydroCarbonState.hpp
+++ b/opm/core/utility/initHydroCarbonState.hpp
@@ -10,12 +10,14 @@ void initHydroCarbonState(BlackoilState& state, const PhaseUsage& pu, const int 
     enum { Oil = BlackoilPhases::Liquid, Gas = BlackoilPhases::Vapour, Water = BlackoilPhases::Aqua };
     // hydrocarbonstate is only used when gas and oil is present
     assert(pu.phase_used[Oil]);
-    if (!pu.phase_used[Gas]) {
-        return; // do nothing
-    }
-    std::vector<int>& hydroCarbonState = state.hydroCarbonState();
-    const int np = pu.num_phases;
+    std::vector<HydroCarbonState>& hydroCarbonState = state.hydroCarbonState();
     hydroCarbonState.resize(num_cells);
+    if (!pu.phase_used[Gas]) {
+        // hydroCarbonState should only be used when oil and gas is present. Return OilOnly to avoid potential trouble.
+        std::fill(hydroCarbonState.begin(), hydroCarbonState.end(), HydroCarbonState::OilOnly);
+        return;
+    }
+    const int np = pu.num_phases;
     std::fill(hydroCarbonState.begin(), hydroCarbonState.end(), HydroCarbonState::GasAndOil);
 
     // set hydrocarbon state


### PR DESCRIPTION
The hydroCarbonState is used to store the hydroCarbonState
  State 1: Gas only
  State 2: Gas and Oil
  State 3: Oil only
An empty vector is return at initialization as
no default values are provided by the blackoilstate.