### PR TITLE
Check for HAVE_UMFPACK in LinearSolverFactory

### DIFF
--- a/opm/core/linalg/LinearSolverFactory.cpp
+++ b/opm/core/linalg/LinearSolverFactory.cpp
@@ -23,7 +23,7 @@
 
 #include <opm/core/linalg/LinearSolverFactory.hpp>
 
-#if HAVE_SUITESPARSE_UMFPACK_H
+#if HAVE_UMFPACK
 #include <opm/core/linalg/LinearSolverUmfpack.hpp>
 #endif
 
@@ -45,7 +45,7 @@ namespace Opm
 
     LinearSolverFactory::LinearSolverFactory()
     {
-#if HAVE_SUITESPARSE_UMFPACK_H
+#if HAVE_UMFPACK
         solver_.reset(new LinearSolverUmfpack);
 #elif HAVE_DUNE_ISTL
         solver_.reset(new LinearSolverIstl);
@@ -65,7 +65,7 @@ namespace Opm
             param.getDefault<std::string>("linsolver", "umfpack");
 
         if (ls == "umfpack") {
-#if HAVE_SUITESPARSE_UMFPACK_H
+#if HAVE_UMFPACK
             solver_.reset(new LinearSolverUmfpack);
 #endif
         }


### PR DESCRIPTION
Check for the right preprocessor define to enable umfpack support.
Matches the directive set in `config.h`

I'm not completely sure if this indicates that my system is broken or if it's something that got lost in a change some time ago, but the umfpack test would fail on recent checkouts.