### PR TITLE
Fix incomplete type error for std::ofstream in examples

### DIFF
--- a/examples/compute_initial_state.cpp
+++ b/examples/compute_initial_state.cpp
@@ -36,6 +36,8 @@
 
 #include <boost/filesystem.hpp>
 
+#include <fstream>
+
 namespace
 {
     void warnIfUnusedParams(const Opm::parameter::ParameterGroup& param)

--- a/examples/compute_tof.cpp
+++ b/examples/compute_tof.cpp
@@ -54,7 +54,7 @@
 #include <iostream>
 #include <vector>
 #include <numeric>
-
+#include <fstream>
 
 namespace
 {

--- a/examples/compute_tof_from_files.cpp
+++ b/examples/compute_tof_from_files.cpp
@@ -54,7 +54,7 @@
 #include <vector>
 #include <numeric>
 #include <iterator>
-
+#include <fstream>
 
 namespace
 {


### PR DESCRIPTION
On my system I got
```c++
error: variable ‘std::ofstream file’ has initializer but incomplete type
         std::ofstream file(fname.str().c_str());
```
This is fixed with this commit by including fstream. Previously, this include might have happened implicitely.