### PR TITLE
Fix two phase equil initialization

### DIFF
--- a/opm/core/props/satfunc/SaturationPropsFromDeck.cpp
+++ b/opm/core/props/satfunc/SaturationPropsFromDeck.cpp
@@ -155,11 +155,12 @@ namespace Opm
                 // copy the values calculated using opm-material to the target arrays
                 for (int canonicalPhaseIdx = 0; canonicalPhaseIdx < BlackoilPhases::MaxNumPhases; ++canonicalPhaseIdx) {
                     // skip unused phases
-                    if ( ! phaseUsage_.phase_used[canonicalPhaseIdx])
+                    if ( ! phaseUsage_.phase_used[canonicalPhaseIdx]) {
                         continue;
+                    }
                     const int pcPhaseIdx = phaseUsage_.phase_pos[canonicalPhaseIdx];
 
-                    double sign = (canonicalPhaseIdx == BlackoilPhases::Aqua)? -1.0 : 1.0;
+                    const double sign = (canonicalPhaseIdx == BlackoilPhases::Aqua)? -1.0 : 1.0;
                     // in opm-material the wetting phase is the reference phase
                     // for two-phase problems i.e water for oil-water system,
                     // but for flow it is always oil. Add oil (liquid) capillary pressure value

--- a/opm/core/simulator/initStateEquil_impl.hpp
+++ b/opm/core/simulator/initStateEquil_impl.hpp
@@ -767,28 +767,34 @@ namespace Opm
                 double sat[BlackoilPhases::MaxNumPhases];
                 double threshold_sat = 1.0e-6;
 
-                sat[waterpos] = smax[waterpos];
-                sat[gaspos] = smax[gaspos];
-                sat[oilpos] = 1.0 - sat[waterpos] - sat[gaspos];
-                if (sw > smax[waterpos]-threshold_sat ) {
-                    sat[waterpos] = smax[waterpos];
-                    props.capPress(1, sat, &cell, pc, 0);                   
-                    phase_pressures[oilpos][local_index] = phase_pressures[waterpos][local_index] + pc[waterpos];
-                } else if (sg > smax[gaspos]-threshold_sat) {
-                    sat[gaspos] = smax[gaspos];
-                    props.capPress(1, sat, &cell, pc, 0);                   
-                    phase_pressures[oilpos][local_index] = phase_pressures[gaspos][local_index] - pc[gaspos];
-                }
-                if (sg < smin[gaspos]+threshold_sat) {
-                    sat[gaspos] = smin[gaspos];
-                    props.capPress(1, sat, &cell, pc, 0);
-                    phase_pressures[gaspos][local_index] = phase_pressures[oilpos][local_index] + pc[gaspos];
-                }
-                if (sw < smin[waterpos]+threshold_sat) {
-                    sat[waterpos] = smin[waterpos];
-                    props.capPress(1, sat, &cell, pc, 0);
-                    phase_pressures[waterpos][local_index] = phase_pressures[oilpos][local_index] - pc[waterpos];
-                }
+                sat[oilpos] = 1.0;
+                  if (water) {
+                      sat[waterpos] = smax[waterpos];
+                      sat[oilpos] -= sat[waterpos];
+                  }
+                  if (gas) {
+                      sat[gaspos] = smax[gaspos];
+                      sat[oilpos] -= sat[gaspos];
+                  }
+                  if (water && sw > smax[waterpos]-threshold_sat ) {
+                      sat[waterpos] = smax[waterpos];
+                      props.capPress(1, sat, &cell, pc, 0);
+                      phase_pressures[oilpos][local_index] = phase_pressures[waterpos][local_index] + pc[waterpos];
+                  } else if (gas && sg > smax[gaspos]-threshold_sat) {
+                      sat[gaspos] = smax[gaspos];
+                      props.capPress(1, sat, &cell, pc, 0);
+                      phase_pressures[oilpos][local_index] = phase_pressures[gaspos][local_index] - pc[gaspos];
+                  }
+                  if (gas && sg < smin[gaspos]+threshold_sat) {
+                      sat[gaspos] = smin[gaspos];
+                      props.capPress(1, sat, &cell, pc, 0);
+                      phase_pressures[gaspos][local_index] = phase_pressures[oilpos][local_index] + pc[gaspos];
+                  }
+                  if (water && sw < smin[waterpos]+threshold_sat) {
+                      sat[waterpos] = smin[waterpos];
+                      props.capPress(1, sat, &cell, pc, 0);
+                      phase_pressures[waterpos][local_index] = phase_pressures[oilpos][local_index] - pc[waterpos];
+                  }
             }
             return phase_saturations;
         }


### PR DESCRIPTION
- add guards against non-existing phase
- shift the capillary pressure values with the oil capillary pressure value to handle cases where oil is not the reference case in opm-material. i.e oil-water problems.   

Tested on the Brugge case. Tested that it does not effect norne, Model 2 and SPE9 initialization. 

Not tested on oil-gas problems.  