### PR TITLE
Add operator== and operator!= to PhasePresence.

### DIFF
--- a/opm/core/props/BlackoilPhases.hpp
+++ b/opm/core/props/BlackoilPhases.hpp
@@ -60,6 +60,9 @@ namespace Opm
         void setFreeOil  () { insert(BlackoilPhases::Liquid); }
         void setFreeGas  () { insert(BlackoilPhases::Vapour); }
 
+        bool operator==(const PhasePresence& other) { return present_ == other.present_; }
+        bool operator!=(const PhasePresence& other) { return !this->operator==(other); }
+
     private:
         unsigned char present_;
 

--- a/opm/core/props/BlackoilPhases.hpp
+++ b/opm/core/props/BlackoilPhases.hpp
@@ -60,8 +60,8 @@ namespace Opm
         void setFreeOil  () { insert(BlackoilPhases::Liquid); }
         void setFreeGas  () { insert(BlackoilPhases::Vapour); }
 
-        bool operator==(const PhasePresence& other) { return present_ == other.present_; }
-        bool operator!=(const PhasePresence& other) { return !this->operator==(other); }
+        bool operator==(const PhasePresence& other) const { return present_ == other.present_; }
+        bool operator!=(const PhasePresence& other) const { return !this->operator==(other); }
 
     private:
         unsigned char present_;


### PR DESCRIPTION
This makes it simpler to write code debugging or inspecting changed phase configurations.