### PR TITLE
Avoid ambiguous calls to abs with unsigned integers.

### DIFF
--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -578,18 +578,32 @@ private:
 
     namespace detail
     {
-    /// \brief Computes the maximum of theabsolute values of two values.
-    template<typename T>
-    struct MaxAbsFunctor
-    {
-        typedef T result_type;
-
-        result_type operator()(const T& t1, const T& t2)
+        /// \brief Computes the maximum of the absolute values of two values.
+        template<typename T>
+        struct MaxAbsFunctor
         {
-            return std::max(std::abs(t1),std::abs(t2));
-        }
-    };
+            typedef T result_type;
+
+            result_type operator()(const T& t1, const T& t2)
+            {
+                return std::max(std::abs(t1),std::abs(t2));
+            }
+        };
+
+
+        /// \brief Specialization to avoid ambiguous abs() for unsigned integers.
+        template <>
+        struct MaxAbsFunctor<std::size_t>
+        {
+            typedef std::size_t result_type;
+
+            result_type operator()(const std::size_t& t1, const std::size_t& t2)
+            {
+                return std::max(t1, t2);
+            }
+        };
     }
+
     /// \brief Create a functor for computing a global L infinity norm
     ///
     /// To be used with ParallelISTLInformation::computeReduction.

--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -579,25 +579,26 @@ private:
     namespace detail
     {
         /// \brief Computes the maximum of the absolute values of two values.
-        template<typename T>
+        template<typename T, typename Enable = void>
         struct MaxAbsFunctor
         {
-            typedef T result_type;
-
-            result_type operator()(const T& t1, const T& t2)
+            using result_type = T;
+            result_type operator()(const T& t1,
+                                   const T& t2)
             {
-                return std::max(std::abs(t1),std::abs(t2));
+                return std::max(std::abs(t1), std::abs(t2));
             }
         };
 
-
-        /// \brief Specialization to avoid ambiguous abs() for unsigned integers.
-        template <>
-        struct MaxAbsFunctor<std::size_t>
+        // Specialization for unsigned integers. They need their own
+        // version since abs(x) is ambiguous (as well as somewhat
+        // meaningless).
+        template<typename T>
+        struct MaxAbsFunctor<T, typename std::enable_if<std::is_unsigned<T>::value>::type>
         {
-            typedef std::size_t result_type;
-
-            result_type operator()(const std::size_t& t1, const std::size_t& t2)
+            using result_type = T;
+            result_type operator()(const T& t1,
+                                   const T& t2)
             {
                 return std::max(t1, t2);
             }

--- a/tests/test_parallelistlinformation.cpp
+++ b/tests/test_parallelistlinformation.cpp
@@ -33,6 +33,7 @@
 #include <functional>
 #ifdef HAVE_DUNE_ISTL
 
+
 template<typename T>
 void runSumMaxMinTest(const T offset)
 {
@@ -60,7 +61,9 @@ void runSumMaxMinTest(const T offset)
     BOOST_CHECK(std::get<1>(values)==std::max(N+offset-1, std::get<1>(oldvalues)));
     BOOST_CHECK(std::get<2>(values)==std::min(offset, std::get<2>(oldvalues)));
     BOOST_CHECK(std::get<3>(values)==((end-1)*end*(2*end-1)-(start-1)*start*(2*start-1))/6+std::get<3>(oldvalues));
-    BOOST_CHECK(std::get<4>(values)==std::max(std::abs(offset),std::abs(N+offset-1)));
+    // Must avoid std::abs() directly to prevent ambiguity with unsigned integers.
+    Opm::Reduction::detail::MaxAbsFunctor<T> maxabsfunc;
+    BOOST_CHECK(std::get<4>(values)==maxabsfunc(offset, N+offset-1));
 }
 
 BOOST_AUTO_TEST_CASE(tupleReductionTestInt)


### PR DESCRIPTION
In #1026 a `MaxAbs` reduction was added. It causes ambiguous calls for me, when trying to instantiate `std::abs(x)` with x and unsigned integer type.

The suggested patch avoids this by adding a specialization for `std::size_t` in the reduction code, and by using the operator directly in the test.