### PR TITLE
Remove warnings (by throwing), added copyright header

### DIFF
--- a/opm/core/wells/InjectionSpecification.cpp
+++ b/opm/core/wells/InjectionSpecification.cpp
@@ -1,5 +1,6 @@
 /*
-  Copyright 2016  The Open Porous Media project.
+  Copyright 2012  Sintef.
+  Copyright 2016  Statoil.
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -18,6 +19,8 @@
 
 #include <stdexcept>
 #include "config.h"
+
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/core/wells/InjectionSpecification.hpp>
 
 namespace Opm
@@ -51,7 +54,7 @@ namespace Opm
         case ControlMode::GRUP: return "GRUP";
         case ControlMode::FLD : return "FLD" ;
         }
-        throw new std::domain_error("Unknown control mode");
+        OPM_THROW(std::domain_error, "Unknown control mode " << mode << " encountered in injection specification");
     }
 
 
@@ -63,7 +66,7 @@ namespace Opm
         case InjectorType::OIL  : return "OIL"  ;
         case InjectorType::GAS  : return "GAS"  ;
         }
-        throw new std::domain_error("Unknown injector type");
+        OPM_THROW(std::domain_error, "Unknown injector type " << type << " encountered in injection specification");
     }
 
 
@@ -74,6 +77,6 @@ namespace Opm
         case GuideRateType::RAT     : return "RAT"     ;
         case GuideRateType::NONE_GRT: return "NONE_GRT";
         }
-        throw new std::domain_error("Unknown guide rate type");
+        OPM_THROW(std::domain_error, "Unknown guide rate type " << type << " encountered in injection specification");
     }
 } // namespace Opm

--- a/opm/core/wells/InjectionSpecification.cpp
+++ b/opm/core/wells/InjectionSpecification.cpp
@@ -1,3 +1,22 @@
+/*
+  Copyright 2016  The Open Porous Media project.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify it under the terms
+  of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+
+  OPM is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdexcept>
 #include "config.h"
 #include <opm/core/wells/InjectionSpecification.hpp>
 
@@ -32,6 +51,7 @@ namespace Opm
         case ControlMode::GRUP: return "GRUP";
         case ControlMode::FLD : return "FLD" ;
         }
+        throw new std::domain_error("Unknown control mode");
     }
 
 
@@ -43,6 +63,7 @@ namespace Opm
         case InjectorType::OIL  : return "OIL"  ;
         case InjectorType::GAS  : return "GAS"  ;
         }
+        throw new std::domain_error("Unknown injector type");
     }
 
 
@@ -53,5 +74,6 @@ namespace Opm
         case GuideRateType::RAT     : return "RAT"     ;
         case GuideRateType::NONE_GRT: return "NONE_GRT";
         }
+        throw new std::domain_error("Unknown guide rate type");
     }
 } // namespace Opm

--- a/opm/core/wells/ProductionSpecification.cpp
+++ b/opm/core/wells/ProductionSpecification.cpp
@@ -1,5 +1,6 @@
 /*
-  Copyright 2016  The Open Porous Media project.
+  Copyright 2012  Sintef.
+  Copyright 2016  Statoil.
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -18,6 +19,8 @@
 
 #include <stdexcept>
 #include "config.h"
+
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/core/wells/ProductionSpecification.hpp>
 
 namespace Opm
@@ -56,7 +59,7 @@ namespace Opm
         case ControlMode::GRUP: return "GRUP";
         case ControlMode::FLD : return "FLD" ;
         }
-        throw new std::domain_error("Unknown control mode");
+        OPM_THROW(std::domain_error, "Unknown control mode " << mode << " encountered in production specification");
     }
 
 
@@ -68,7 +71,7 @@ namespace Opm
         case Procedure::RATE  : return "RATE"  ;
         case Procedure::WELL  : return "WELL"  ;
         }
-        throw new std::domain_error("Unknown procedure");
+        OPM_THROW(std::domain_error, "Unknown procedure " << type << " encountered in production specification");
     }
 
 
@@ -81,7 +84,7 @@ namespace Opm
         case GuideRateType::WATER   : return "WATER"   ;
         case GuideRateType::NONE_GRT: return "NONE_GRT";
         }
-        throw new std::domain_error("Unknown guide rate type");
+        OPM_THROW(std::domain_error, "Unknown guide rate type " << type << " encountered in production specification");
     }
 
 

--- a/opm/core/wells/ProductionSpecification.cpp
+++ b/opm/core/wells/ProductionSpecification.cpp
@@ -1,3 +1,22 @@
+/*
+  Copyright 2016  The Open Porous Media project.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify it under the terms
+  of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+
+  OPM is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdexcept>
 #include "config.h"
 #include <opm/core/wells/ProductionSpecification.hpp>
 
@@ -37,6 +56,7 @@ namespace Opm
         case ControlMode::GRUP: return "GRUP";
         case ControlMode::FLD : return "FLD" ;
         }
+        throw new std::domain_error("Unknown control mode");
     }
 
 
@@ -48,6 +68,7 @@ namespace Opm
         case Procedure::RATE  : return "RATE"  ;
         case Procedure::WELL  : return "WELL"  ;
         }
+        throw new std::domain_error("Unknown procedure");
     }
 
 
@@ -60,6 +81,7 @@ namespace Opm
         case GuideRateType::WATER   : return "WATER"   ;
         case GuideRateType::NONE_GRT: return "NONE_GRT";
         }
+        throw new std::domain_error("Unknown guide rate type");
     }
 
 


### PR DESCRIPTION
Added six `throw`s (that will never be reached), thereby removing warnings

* OPM-core had 6 warnings (control reaches end of non-void function [-Wreturn-type])
* Removed warnings by adding `throw std::domain_error` that will never be reached
* Added copyright headers for `InjectionSpecification.cpp` and `ProductionSpecification.cpp`
