### PR TITLE
Do not compute WellState::numPhases

### DIFF
--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -244,6 +244,7 @@ namespace Opm
             this->wellrates_ = rhs.wellrates_;
             this->perfrates_ = rhs.perfrates_;
             this->perfpress_ = rhs.perfpress_;
+            this->numPhases_ = rhs.numPhases_;
             this->wellMap_ = rhs.wellMap_;
             this->wells_.reset( clone_wells( rhs.wells_.get() ) );
 


### PR DESCRIPTION
but store it during initialization and reuse it afterwards. Previously it was computed by dividing
the size of the bhp_ array by the number of wells. This crashed if there were no wells present/active, e.g. when writing the report step.

Closes OPM/opm-simulators#731