### PR TITLE
Return -1 in WellState::numPhases if there are no wells.

### DIFF
--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -207,9 +207,17 @@ namespace Opm
         }
 
         /// The number of phases present.
+        /// \return the number of phases present or -1 if there are no wells
         int numPhases() const
         {
-            return wellRates().size() / numWells();
+            if( numWells() )
+            {
+                return wellRates().size() / numWells();
+            }
+            else
+            {
+                return -1;
+            }
         }
 
         virtual data::Wells report() const


### PR DESCRIPTION
This is an alternative to #1047. Closes OPM/opm-simulators#731