### PR TITLE
Make wells_equal work for null wells.

### DIFF
--- a/opm/core/wells/wells.c
+++ b/opm/core/wells/wells.c
@@ -545,6 +545,12 @@ bool
 wells_equal(const struct Wells *W1, const struct Wells *W2 , bool verbose)
 /* ---------------------------------------------------------------------- */
 {
+    // Cater the case where W1 and W2 are the same (null) pointers.
+    if( W1 == W2 )
+    {
+        return true;
+    }
+
     bool are_equal = true;
     are_equal = (W1->number_of_wells == W2->number_of_wells);
     are_equal = are_equal && (W1->number_of_phases == W2->number_of_phases);

--- a/opm/core/wells/wells.c
+++ b/opm/core/wells/wells.c
@@ -550,7 +550,11 @@ wells_equal(const struct Wells *W1, const struct Wells *W2 , bool verbose)
     {
         return true;
     }
-
+    if( W1 == 0 || W2 == 0)
+    {
+        return false;
+    }
+    
     bool are_equal = true;
     are_equal = (W1->number_of_wells == W2->number_of_wells);
     are_equal = are_equal && (W1->number_of_phases == W2->number_of_phases);

--- a/opm/core/wells/wells.c
+++ b/opm/core/wells/wells.c
@@ -550,7 +550,7 @@ wells_equal(const struct Wells *W1, const struct Wells *W2 , bool verbose)
     {
         return true;
     }
-    if( W1 == 0 || W2 == 0)
+    if( W1 == NULL || W2 == NULL)
     {
         return false;
     }


### PR DESCRIPTION
This is needed to run test cases without wells with debugging on.
Without this commit we get a segmentation fault in an assert statement which compares to null well pointers.