### PR TITLE
fix incorrect derivative  of rock compressibility w.r.t. pressure

### DIFF
--- a/opm/core/props/rock/RockCompressibility.cpp
+++ b/opm/core/props/rock/RockCompressibility.cpp
@@ -101,7 +101,8 @@ namespace Opm
         if (p_.empty()) {
             // Approximating poro multiplier with a quadratic curve,
             // we must use its derivative.
-            return rock_comp_ + 2 * rock_comp_ * rock_comp_ * (pressure - pref_);
+            const double cpnorm = rock_comp_*(pressure - pref_);
+            return rock_comp_ + cpnorm*rock_comp_;
         } else {
             return Opm::linearInterpolationDerivative(p_, poromult_, pressure);
         }


### PR DESCRIPTION
this is a relatively minor SNAFU over which I stumbled when trying to compare the Jacobian matrices produced by ebos with the ones from flow. I only ran SPE1 and SPE9 on it but did not run Norne. (I did not notice any significant difference for those.)

since

f(x) = 1 + g(x) + 0.5*g(x)*g(x)

the derivative is

f'(x) = 0 - g'(x) + 2*0.5*g(x) * g'(x) = g'(x) + g(x)*g'(x)

note that the previous incorrect values do not affect the quality of
the obtained results (if the tolerance of the non-linear solver is
chosen to be small enough), but it may have deteriorated convergence
rates.