### PR TITLE
TransMult and InitConfig are references

### DIFF
--- a/examples/compute_initial_state.cpp
+++ b/examples/compute_initial_state.cpp
@@ -90,7 +90,7 @@ try
     Opm::ParseContext parseContext;
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::DeckConstPtr deck = parser->parseFile(deck_filename , parseContext);
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck, parseContext));
     const double grav = param.getDefault("gravity", unit::gravity);
     GridManager gm(eclipseState->getInputGrid());
     const UnstructuredGrid& grid = *gm.c_grid();

--- a/examples/compute_tof.cpp
+++ b/examples/compute_tof.cpp
@@ -174,7 +174,7 @@ try
     Parser parser;
     ParseContext parseContext;
     DeckConstPtr deck = parser.parseFile(deck_filename , parseContext);
-    EclipseStateConstPtr eclipseState = std::make_shared<EclipseState>(deck , parseContext);
+    EclipseStateConstPtr eclipseState = std::make_shared<EclipseState>(*deck , parseContext);
 
     // Grid init
     GridManager grid_manager(eclipseState->getInputGrid());

--- a/examples/diagnose_relperm.cpp
+++ b/examples/diagnose_relperm.cpp
@@ -76,7 +76,7 @@ try
                               { ParseContext::INTERNAL_ERROR_UNINITIALIZED_THPRES, InputError::IGNORE}
                              });
     Opm::DeckConstPtr deck(parser->parseFile(eclipseFilename, parseContext));
-    eclState.reset(new EclipseState(deck, parseContext));
+    eclState.reset(new EclipseState(*deck, parseContext));
 
     GridManager gm(eclState->getInputGrid());
     const UnstructuredGrid& grid = *gm.c_grid();

--- a/examples/wells_example.cpp
+++ b/examples/wells_example.cpp
@@ -38,7 +38,7 @@ try
     ParseContext parseContext;
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck = parser->parseFile(file_name , parseContext);
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck , parseContext));
     std::cout << "Done!" << std::endl;
 
     // Setup grid

--- a/opm/core/simulator/initStateEquil.hpp
+++ b/opm/core/simulator/initStateEquil.hpp
@@ -200,7 +200,7 @@ namespace Opm
             std::vector<EquilRecord>
             getEquil(const Opm::EclipseState& state)
             {
-                const auto& init = *state.getInitConfig();
+                const auto& init = state.getInitConfig();
 
                 if( !init.hasEquil() ) {
                     OPM_THROW(std::domain_error, "Deck does not provide equilibration data.");

--- a/tests/test_blackoilstate.cpp
+++ b/tests/test_blackoilstate.cpp
@@ -37,20 +37,16 @@ std::vector<int> get_testBlackoilStateActnum() {
 }
 
 BOOST_AUTO_TEST_CASE(EqualsDifferentDeckReturnFalse) {
-
-    ParseContext parseContext;
     const string filename1 = "testBlackoilState1.DATA";
     const string filename2 = "testBlackoilState2.DATA";
-    Opm::ParserPtr parser(new Opm::Parser());
 
-    Opm::DeckConstPtr deck1(parser->parseFile(filename1, parseContext));
-    auto eg1 = std::make_shared<Opm::EclipseGrid>(deck1);
+    const auto es1 = Opm::Parser::parse(filename1);
+    auto eg1 = es1.getInputGridCopy();
     std::vector<int> actnum = get_testBlackoilStateActnum();
     eg1->resetACTNUM(actnum.data());
 
-
-    Opm::DeckConstPtr deck2(parser->parseFile(filename2, parseContext));
-    auto eg2 = std::make_shared<Opm::EclipseGrid>(deck2);
+    const auto es2 = Opm::Parser::parse(filename2);
+    auto eg2 = es2.getInputGrid();
 
     GridManager gridManager1(eg1);
     const UnstructuredGrid& grid1 = *gridManager1.c_grid();
@@ -61,7 +57,7 @@ BOOST_AUTO_TEST_CASE(EqualsDifferentDeckReturnFalse) {
     BlackoilState state1( UgGridHelpers::numCells( grid1 ) , UgGridHelpers::numFaces( grid1 ) , 3);
     BlackoilState state2( UgGridHelpers::numCells( grid2 ) , UgGridHelpers::numFaces( grid2 ) , 3);
 
-    BOOST_CHECK_EQUAL( false , state1.equal(state2) );
+    BOOST_CHECK( ! state1.equal(state2) );
 }
 
 
@@ -70,10 +66,10 @@ BOOST_AUTO_TEST_CASE(EqualsDifferentDeckReturnFalse) {
 BOOST_AUTO_TEST_CASE(EqualsNumericalDifferenceReturnFalse) {
 
     const string filename = "testBlackoilState1.DATA";
-    Opm::ParseContext parseContext;
-    Opm::ParserPtr parser(new Opm::Parser());
-    Opm::DeckConstPtr deck(parser->parseFile(filename , parseContext));
-    auto eg = std::make_shared<Opm::EclipseGrid>(deck);
+
+    const auto es = Opm::Parser::parse(filename);
+    auto eg = es.getInputGridCopy();
+
     std::vector<int> actnum = get_testBlackoilStateActnum();
     eg->resetACTNUM(actnum.data());
 
@@ -84,33 +80,33 @@ BOOST_AUTO_TEST_CASE(EqualsNumericalDifferenceReturnFalse) {
     BlackoilState state2( UgGridHelpers::numCells( grid ) , UgGridHelpers::numFaces( grid ) , 3);
 
 
-    BOOST_CHECK_EQUAL( true , state1.equal(state2) );
+    BOOST_CHECK( state1.equal(state2) );
     {
         std::vector<double>& p1 = state1.pressure();
         std::vector<double>& p2 = state2.pressure();
         p1[0] = p1[0] * 2 + 1;
 
-        BOOST_CHECK_EQUAL( false , state1.equal(state2) );
+        BOOST_CHECK( ! state1.equal(state2) );
         p1[0] = p2[0];
-        BOOST_CHECK_EQUAL( true , state1.equal(state2) );
+        BOOST_CHECK(   state1.equal(state2) );
     }
     {
         std::vector<double>& gor1 = state1.gasoilratio();
         std::vector<double>& gor2 = state2.gasoilratio();
         gor1[0] = gor1[0] * 2 + 1;
 
-        BOOST_CHECK_EQUAL( false , state1.equal(state2) );
+        BOOST_CHECK( ! state1.equal(state2) );
         gor1[0] = gor2[0];
-        BOOST_CHECK_EQUAL( true , state1.equal(state2) );
+        BOOST_CHECK(   state1.equal(state2) );
     }
     {
         std::vector<double>& p1 = state1.facepressure();
         std::vector<double>& p2 = state2.facepressure();
         p1[0] = p1[0] * 2 + 1;
 
-        BOOST_CHECK_EQUAL( false , state1.equal(state2) );
+        BOOST_CHECK( ! state1.equal(state2) );
         p1[0] = p2[0];
-        BOOST_CHECK_EQUAL( true , state1.equal(state2) );
+        BOOST_CHECK(   state1.equal(state2) );
     }
 
     {
@@ -119,9 +115,9 @@ BOOST_AUTO_TEST_CASE(EqualsNumericalDifferenceReturnFalse) {
         if (f1.size() > 0 ) {
             f1[0] = f1[0] * 2 + 1;
 
-            BOOST_CHECK_EQUAL( false , state1.equal(state2) );
+            BOOST_CHECK( ! state1.equal(state2) );
             f1[0] = f2[0];
-            BOOST_CHECK_EQUAL( true , state1.equal(state2) );
+            BOOST_CHECK(   state1.equal(state2) );
         }
     }
     {
@@ -130,9 +126,9 @@ BOOST_AUTO_TEST_CASE(EqualsNumericalDifferenceReturnFalse) {
         if (sv1.size() > 0) {
             sv1[0] = sv1[0] * 2 + 1;
 
-            BOOST_CHECK_EQUAL( false , state1.equal(state2) );
+            BOOST_CHECK( ! state1.equal(state2) );
             sv1[0] = sv2[0];
-            BOOST_CHECK_EQUAL( true , state1.equal(state2) );
+            BOOST_CHECK(   state1.equal(state2) );
         }
     }
     {
@@ -140,8 +136,8 @@ BOOST_AUTO_TEST_CASE(EqualsNumericalDifferenceReturnFalse) {
         std::vector<double>& sat2 = state2.saturation();
         sat1[0] = sat1[0] * 2 + 1;
 
-        BOOST_CHECK_EQUAL( false , state1.equal(state2) );
+        BOOST_CHECK( ! state1.equal(state2) );
         sat1[0] = sat2[0];
-        BOOST_CHECK_EQUAL( true , state1.equal(state2) );
+        BOOST_CHECK(   state1.equal(state2) );
     }
 }

--- a/tests/test_compressedpropertyaccess.cpp
+++ b/tests/test_compressedpropertyaccess.cpp
@@ -47,7 +47,7 @@ struct SetupSimple {
         Opm::ParseContext parseContext;
         Opm::ParserPtr parser(new Opm::Parser());
         deck = parser->parseFile("compressed_gridproperty.data" , parseContext);
-        ecl.reset(new Opm::EclipseState(deck , parseContext));
+        ecl.reset(new Opm::EclipseState(*deck , parseContext));
     }
 
     Opm::DeckConstPtr         deck;

--- a/tests/test_equil.cpp
+++ b/tests/test_equil.cpp
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE (DeckAllDead)
     Opm::ParseContext parseContext;
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::DeckConstPtr deck = parser->parseFile("deadfluids.DATA" , parseContext);
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck, parseContext));
     Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, *grid, false);
     Opm::EQUIL::DeckDependent::InitialStateComputer comp(props, deck, eclipseState, *grid, 10.0);
     const auto& pressures = comp.press();
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE (CapillaryInversion)
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck = parser->parseFile("capillary.DATA" , parseContext);
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck , parseContext));
     Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, false);
 
     // Test the capillary inversion for oil-water.
@@ -448,7 +448,7 @@ BOOST_AUTO_TEST_CASE (DeckWithCapillary)
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck = parser->parseFile("capillary.DATA" , parseContext);
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck , parseContext));
     Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, false);
 
     Opm::EQUIL::DeckDependent::InitialStateComputer comp(props, deck, eclipseState, grid, 10.0);
@@ -489,7 +489,7 @@ BOOST_AUTO_TEST_CASE (DeckWithCapillaryOverlap)
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck = parser->parseFile("capillary_overlap.DATA" , parseContext);
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck , parseContext));
     Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, false);
 
     Opm::EQUIL::DeckDependent::InitialStateComputer comp(props, deck, eclipseState, grid, 9.80665);
@@ -552,7 +552,7 @@ BOOST_AUTO_TEST_CASE (DeckWithLiveOil)
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck = parser->parseFile("equil_liveoil.DATA" , parseContext);
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck , parseContext));
     Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, false);
 
     Opm::EQUIL::DeckDependent::InitialStateComputer comp(props, deck, eclipseState, grid, 9.80665);
@@ -632,7 +632,7 @@ BOOST_AUTO_TEST_CASE (DeckWithLiveGas)
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck = parser->parseFile("equil_livegas.DATA" , parseContext);
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck , parseContext));
     Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, false);
 
     Opm::EQUIL::DeckDependent::InitialStateComputer comp(props, deck, eclipseState, grid, 9.80665);
@@ -715,7 +715,7 @@ BOOST_AUTO_TEST_CASE (DeckWithRSVDAndRVVD)
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck = parser->parseFile("equil_rsvd_and_rvvd.DATA", parseContext);
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck , parseContext));
     Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, false);
 
     Opm::EQUIL::DeckDependent::InitialStateComputer comp(props, deck, eclipseState, grid, 9.80665);

--- a/tests/test_norne_pvt.cpp
+++ b/tests/test_norne_pvt.cpp
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE( Test_Norne_PVT) {
     std::shared_ptr<const Deck> deck;
     deck = parser->parseFile("norne_pvt.data", parseContext);
 
-    Opm::EclipseStateConstPtr eclState(new EclipseState(deck, parseContext));
+    Opm::EclipseStateConstPtr eclState(new EclipseState(*deck, parseContext));
 
     verify_norne_oil_pvt_region1( deck, eclState );
     verify_norne_oil_pvt_region2( deck, eclState );

--- a/tests/test_pinchprocessor.cpp
+++ b/tests/test_pinchprocessor.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(Processing)
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::ParseContext parseContext({{ ParseContext::PARSE_RANDOM_SLASH , InputError::IGNORE }});
     Opm::DeckConstPtr deck = parser->parseFile(filename, parseContext);
-    std::shared_ptr<EclipseState> eclstate (new Opm::EclipseState(deck, parseContext));
+    std::shared_ptr<EclipseState> eclstate (new Opm::EclipseState(*deck, parseContext));
     const auto& porv = eclstate->get3DProperties().getDoubleGridProperty("PORV").getData();
     EclipseGridConstPtr eclgrid = eclstate->getInputGrid();
 
@@ -92,10 +92,10 @@ BOOST_AUTO_TEST_CASE(Processing)
     std::vector<double> htrans(Opm::UgGridHelpers::numCellFaces(grid));
     Grid* ug = const_cast<Grid*>(& grid);
     tpfa_htrans_compute(ug, rock.permeability(), htrans.data());
-    auto transMult = eclstate->getTransMult();
+    const auto& transMult = eclstate->getTransMult();
     std::vector<double> multz(nc, 0.0);
     for (int i = 0; i < nc; ++i) {
-        multz[i] = transMult->getMultiplier(global_cell[i], Opm::FaceDir::ZPlus);
+        multz[i] = transMult.getMultiplier(global_cell[i], Opm::FaceDir::ZPlus);
     }
     Opm::NNC nnc(deck, eclgrid);
     pinch.process(grid, htrans, actnum, multz, porv, nnc);

--- a/tests/test_relpermdiagnostics.cpp
+++ b/tests/test_relpermdiagnostics.cpp
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(diagnosis)
                               { ParseContext::PARSE_RANDOM_TEXT, InputError::IGNORE}
                              });
     Opm::DeckConstPtr deck(parser->parseFile("../tests/relpermDiagnostics.DATA", parseContext));
-    eclState.reset(new EclipseState(deck, parseContext));
+    eclState.reset(new EclipseState(*deck, parseContext));
     GridManager gm(eclState->getInputGrid());
     const UnstructuredGrid& grid = *gm.c_grid();
     std::shared_ptr<CounterLog> counterLog = std::make_shared<CounterLog>(Log::DefaultMessageTypes);

--- a/tests/test_satfunc.cpp
+++ b/tests/test_satfunc.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE (GwsegStandard)
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck = parser->parseFile("satfuncStandard.DATA", parseContext);
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck , parseContext));
     Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, param, false);
     
     const int np = 3;
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE (GwsegEPSBase)
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck = parser->parseFile("satfuncEPSBase.DATA" , parseContext);
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck , parseContext));
     Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, param, false);
     
     const int np = 3;
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_CASE (GwsegEPS_A)
     Opm::ParseContext parseContext;
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::DeckConstPtr deck = parser->parseFile("satfuncEPS_A.DATA" , parseContext);
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck , parseContext));
     Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, param, false);
     
     const int np = 3;
@@ -493,7 +493,7 @@ BOOST_AUTO_TEST_CASE (GwsegEPS_C)
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck = parser->parseFile("satfuncEPS_C.DATA", parseContext);
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck , parseContext));
     Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, param, false);
     
     const int np = 3;
@@ -596,7 +596,7 @@ BOOST_AUTO_TEST_CASE (GwsegEPS_D)
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck = parser->parseFile("satfuncEPS_D.DATA" , parseContext);
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck , parseContext));
     Opm::BlackoilPropertiesFromDeck props(deck, eclipseState, grid, param, false);
     
     const int np = 3;

--- a/tests/test_stoppedwells.cpp
+++ b/tests/test_stoppedwells.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(TestStoppedWells)
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck(parser->parseFile(filename , parseContext));
 
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck , parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck , parseContext));
     Opm::GridManager gridManager(eclipseState->getInputGrid());
 
     double target_surfacerate_inj;

--- a/tests/test_ug.cpp
+++ b/tests/test_ug.cpp
@@ -57,10 +57,10 @@ BOOST_AUTO_TEST_CASE(Equal) {
     Opm::ParserPtr parser(new Opm::Parser() );
 
     Opm::DeckConstPtr deck1 = parser->parseFile( filename1 , parseContext);
-    Opm::EclipseState es1(deck1, parseContext);
+    Opm::EclipseState es1(*deck1, parseContext);
 
     Opm::DeckConstPtr deck2 = parser->parseString( deck2Data , parseContext);
-    Opm::EclipseState es2(deck2, parseContext);
+    Opm::EclipseState es2(*deck2, parseContext);
     
     BOOST_CHECK( deck1->hasKeyword("ZCORN") );
     BOOST_CHECK( deck1->hasKeyword("COORD") );
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(EqualEclipseGrid) {
     Opm::ParserPtr parser(new Opm::Parser() );
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck = parser->parseFile( filename , parseContext);
-    Opm::EclipseState es(deck, parseContext);
+    Opm::EclipseState es(*deck, parseContext);
     auto grid = es.getInputGrid();
 
     Opm::GridManager gridM(es.getInputGrid());
@@ -161,8 +161,8 @@ BOOST_AUTO_TEST_CASE(TOPS_Fully_Specified) {
     Opm::DeckConstPtr deck1 = parser->parseString(deck1Data, parseContext);
     Opm::DeckConstPtr deck2 = parser->parseString(deck2Data, parseContext);
 
-    Opm::EclipseState es1(deck1, parseContext);
-    Opm::EclipseState es2(deck2, parseContext);
+    Opm::EclipseState es1(*deck1, parseContext);
+    Opm::EclipseState es2(*deck2, parseContext);
 
     Opm::GridManager gridM1(es1.getInputGrid());
     Opm::GridManager gridM2(es2.getInputGrid());

--- a/tests/test_wellcollection.cpp
+++ b/tests/test_wellcollection.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(AddWellsAndGroupToCollection) {
     std::string scheduleFile("wells_group.data");
     ParseContext parseContext;
     DeckConstPtr deck =  parser->parseFile(scheduleFile, parseContext);
-    EclipseStateConstPtr eclipseState(new EclipseState(deck, parseContext));
+    EclipseStateConstPtr eclipseState(new EclipseState(*deck, parseContext));
     PhaseUsage pu = phaseUsageFromDeck(eclipseState);
 
     GroupTreeNodePtr field=eclipseState->getSchedule()->getGroupTree(2)->getNode("FIELD");

--- a/tests/test_wellsgroup.cpp
+++ b/tests/test_wellsgroup.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(ConstructGroupFromWell) {
     std::string scheduleFile("wells_group.data");
     ParseContext parseContext;
     DeckConstPtr deck =  parser->parseFile(scheduleFile, parseContext);
-    EclipseStateConstPtr eclipseState(new EclipseState(deck , parseContext));
+    EclipseStateConstPtr eclipseState(new EclipseState(*deck , parseContext));
     PhaseUsage pu = phaseUsageFromDeck(eclipseState);
 
     auto wells = eclipseState->getSchedule()->getWells();
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(ConstructGroupFromGroup) {
     ParseContext parseContext;
     std::string scheduleFile("wells_group.data");
     DeckConstPtr deck =  parser->parseFile(scheduleFile, parseContext);
-    EclipseStateConstPtr eclipseState(new EclipseState(deck , parseContext));
+    EclipseStateConstPtr eclipseState(new EclipseState(*deck , parseContext));
     PhaseUsage pu = phaseUsageFromDeck(eclipseState);
 
     std::vector<GroupTreeNodeConstPtr> nodes = eclipseState->getSchedule()->getGroupTree(2)->getNodes();

--- a/tests/test_wellsmanager.cpp
+++ b/tests/test_wellsmanager.cpp
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(New_Constructor_Works) {
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
 
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck, parseContext));
     Opm::GridManager gridManager(eclipseState->getInputGrid());
 
     {
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(WellsEqual) {
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
 
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck, parseContext));
     Opm::GridManager gridManager(eclipseState->getInputGrid());
 
     Opm::WellsManager wellsManager0(eclipseState, 0, *gridManager.c_grid(), NULL);
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(ControlsEqual) {
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
 
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck, parseContext));
     Opm::GridManager gridManager(eclipseState->getInputGrid());
 
     Opm::WellsManager wellsManager0(eclipseState, 0, *gridManager.c_grid(), NULL);
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE(WellShutOK) {
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
 
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck, parseContext));
     Opm::GridManager gridManager(eclipseState->getInputGrid());
 
     Opm::WellsManager wellsManager2(eclipseState, 2, *gridManager.c_grid(), NULL);
@@ -274,7 +274,7 @@ BOOST_AUTO_TEST_CASE(WellSTOPOK) {
     Opm::ParseContext parseContext;
     Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
 
-    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(deck, parseContext));
+    Opm::EclipseStateConstPtr eclipseState(new Opm::EclipseState(*deck, parseContext));
     Opm::GridManager gridManager(eclipseState->getInputGrid());
 
     Opm::WellsManager wellsManager(eclipseState, 0, *gridManager.c_grid(), NULL);


### PR DESCRIPTION
Three minor changes:
* TransMult and InitConfig are returned from parser as references, not shared_ptr
* Use the correct EclipseState constructor, the other will be deprecated.

Downstream of OPM/opm-parser#890.
