### PR TITLE
Timestepper based on user input

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -72,7 +72,7 @@ namespace Opm {
         , solver_restart_max_( param.getDefault("solver.restart", int(10) ) )
         , solver_verbose_( param.getDefault("solver.verbose", bool(true) ) && terminal_output )
         , timestep_verbose_( param.getDefault("timestep.verbose", bool(true) ) && terminal_output )
-        , suggested_next_timestep_( -1.0 )
+        , suggested_next_timestep_( unit::convert::from(param.getDefault("timestep.initial_step_length", double(1.0) ), unit::day) )
         , full_timestep_initially_( param.getDefault("full_timestep_initially", bool(false) ) )
     {
         // valid are "pid" and "pid+iteration"
@@ -95,6 +95,10 @@ namespace Opm {
             const double decayrate  = param.getDefault("timestep.control.decayrate",  double(0.75) );
             const double growthrate = param.getDefault("timestep.control.growthrate", double(1.25) );
             timeStepControl_ = TimeStepControlType( new SimpleIterationCountTimeStepControl( iterations, decayrate, growthrate ) );
+        } else if ( control == "hardcoded") {
+            const std::string filename    = param.getDefault("timestep.control.filename", std::string("timesteps"));
+            timeStepControl_ = TimeStepControlType( new HardcodedTimeStepControl( filename ) );
+
         }
         else
             OPM_THROW(std::runtime_error,"Unsupported time step control selected "<< control );
@@ -202,7 +206,7 @@ namespace Opm {
 
                 // compute new time step estimate
                 double dtEstimate =
-                    timeStepControl_->computeTimeStepSize( dt, linearIterations, relativeChange );
+                    timeStepControl_->computeTimeStepSize( dt, linearIterations, relativeChange, substepTimer.simulationTimeElapsed());
 
                 // limit the growth of the timestep size by the growth factor
                 dtEstimate = std::min( dtEstimate, double(max_growth_ * dt) );

--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -72,7 +72,7 @@ namespace Opm {
         , solver_restart_max_( param.getDefault("solver.restart", int(10) ) )
         , solver_verbose_( param.getDefault("solver.verbose", bool(true) ) && terminal_output )
         , timestep_verbose_( param.getDefault("timestep.verbose", bool(true) ) && terminal_output )
-        , suggested_next_timestep_( unit::convert::from(param.getDefault("timestep.initial_step_length", double(1.0) ), unit::day) )
+        , suggested_next_timestep_( -1.0 )
         , full_timestep_initially_( param.getDefault("full_timestep_initially", bool(false) ) )
     {
         // valid are "pid" and "pid+iteration"

--- a/opm/core/simulator/TimeStepControl.cpp
+++ b/opm/core/simulator/TimeStepControl.cpp
@@ -84,29 +84,25 @@ namespace Opm
     ////////////////////////////////////////////////////////
 
     HardcodedTimeStepControl::
-    HardcodedTimeStepControl( const std::string filename)
+    HardcodedTimeStepControl( const std::string& filename)
     {
         std::ifstream infile (filename);
-        double time;
+        std::string::size_type sz;
         std::string line;
-        std::getline(infile, line); //assumes two lines before the timing starts.
-        std::getline(infile, line);
+        while ( std::getline(infile, line)) {
+            if( line[0] != '-') { // ignore lines starting with '-'
+                const double time = std::stod(line,&sz); // read the first number i.e. the actual substep time
+                subStepTime_.push_back( time * unit::day );
+            }
 
-        while (!infile.eof() ) {
-            infile >> time; // read the time in days
-            std::string line;
-            std::getline(infile, line); // skip the rest of the line
-            timesteps_.push_back( time * unit::day );
         }
-
     }
 
     double HardcodedTimeStepControl::
     computeTimeStepSize( const double /*dt */, const int /*iterations */, const RelativeChangeInterface& /* relativeChange */ , const double simulationTimeElapsed) const
     {
-        auto nextTime = std::upper_bound(timesteps_.begin(), timesteps_.end(), simulationTimeElapsed);
-        double dtEstimate = (*nextTime - simulationTimeElapsed);
-        return dtEstimate;
+        auto nextTime = std::upper_bound(subStepTime_.begin(), subStepTime_.end(), simulationTimeElapsed);
+        return (*nextTime - simulationTimeElapsed);
     }
 
 

--- a/opm/core/simulator/TimeStepControl.cpp
+++ b/opm/core/simulator/TimeStepControl.cpp
@@ -87,6 +87,9 @@ namespace Opm
     HardcodedTimeStepControl( const std::string& filename)
     {
         std::ifstream infile (filename);
+        if (!infile.is_open()) {
+            OPM_THROW(std::runtime_error,"Incorrect or no filename is provided to the hardcodedTimeStep. Use timestep.control.filename=your_file_name");
+        }
         std::string::size_type sz;
         std::string line;
         while ( std::getline(infile, line)) {

--- a/opm/core/simulator/TimeStepControl.hpp
+++ b/opm/core/simulator/TimeStepControl.hpp
@@ -121,21 +121,24 @@ namespace Opm
     ///
     ///  HardcodedTimeStepControl
     ///  Input generated from summary file using the ert application:
+    ///
     ///  ecl_summary DECK TIME > filename
-    //
+    ///
+    ///  Assumes time is given in days
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
     class HardcodedTimeStepControl : public TimeStepControlInterface
     {
     public:
         /// \brief constructor
         /// \param filename   filename contaning the timesteps
-        HardcodedTimeStepControl( const std::string filename);
+        explicit HardcodedTimeStepControl( const std::string& filename);
 
         /// \brief \copydoc TimeStepControlInterface::computeTimeStepSize
         double computeTimeStepSize( const double dt, const int /* iterations */, const RelativeChangeInterface& /*relativeChange */, const double simulationTimeElapsed) const;
 
     protected:
-        std::vector<double> timesteps_;
+        // store the time (in days) of the substeps the simulator should use
+        std::vector<double> subStepTime_;
     };
 
 

--- a/opm/core/simulator/TimeStepControl.hpp
+++ b/opm/core/simulator/TimeStepControl.hpp
@@ -48,7 +48,7 @@ namespace Opm
                                              const bool verbose = false);
 
         /// \brief \copydoc TimeStepControlInterface::computeTimeStepSize
-        double computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& /* relativeChange */ ) const;
+        double computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& /* relativeChange */, const double /*simulationTimeElapsed */ ) const;
 
     protected:
         const int     target_iterations_;
@@ -82,7 +82,7 @@ namespace Opm
                             const bool verbose = false );
 
         /// \brief \copydoc TimeStepControlInterface::computeTimeStepSize
-        double computeTimeStepSize( const double dt, const int /* iterations */, const RelativeChangeInterface& relativeChange ) const;
+        double computeTimeStepSize( const double dt, const int /* iterations */, const RelativeChangeInterface& relativeChange, const double /*simulationTimeElapsed */ ) const;
 
     protected:
         const double tol_;
@@ -111,10 +111,31 @@ namespace Opm
                                              const bool verbose = false);
 
         /// \brief \copydoc TimeStepControlInterface::computeTimeStepSize
-        double computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& relativeChange ) const;
+        double computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& relativeChange, const double /*simulationTimeElapsed */ ) const;
 
     protected:
         const int     target_iterations_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    ///
+    ///  HardcodedTimeStepControl
+    ///  Input generated from summary file using the ert application:
+    ///  ecl_summary DECK TIME > filename
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    class HardcodedTimeStepControl : public TimeStepControlInterface
+    {
+    public:
+        /// \brief constructor
+        /// \param filename   filename contaning the timesteps
+        HardcodedTimeStepControl( const std::string filename);
+
+        /// \brief \copydoc TimeStepControlInterface::computeTimeStepSize
+        double computeTimeStepSize( const double dt, const int /* iterations */, const RelativeChangeInterface& /*relativeChange */, const double simulationTimeElapsed) const;
+
+    protected:
+        std::vector<double> timesteps_;
     };
 
 

--- a/opm/core/simulator/TimeStepControlInterface.hpp
+++ b/opm/core/simulator/TimeStepControlInterface.hpp
@@ -56,7 +56,7 @@ namespace Opm
         /// \param timeError   object to compute || u^n+1 - u^n || / || u^n+1 ||
         ///
         /// \return suggested time step size for the next step
-        virtual double computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& relativeChange ) const = 0;
+        virtual double computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& relativeChange , const double simulationTimeElapsed) const = 0;
 
         /// virtual destructor (empty)
         virtual ~TimeStepControlInterface () {}


### PR DESCRIPTION
A new timestepper that reads timesteps from "timesteps" generated using
ecl_summary "DECK" TIME > timesteps
and applies it to the simulator

Also a parameter timestep.initial_step_length (default 1 day) is added
to controll the frist timestep.

Can be tested specifying 
timestep.control=hardcoded and
timestep.control.filename=timesteps