### PR TITLE
Pass PhaseUsage to WellState::report

### DIFF
--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -213,7 +213,7 @@ namespace Opm
             return wellRates().size() / numWells();
         }
 
-        virtual data::Wells report(const PhaseUsage &pu) const
+        virtual data::Wells report(const PhaseUsage&) const
         {
             return { { /* WellState offers no completion data, so that has to be added later */ },
                 this->bhp(),

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -34,6 +34,7 @@
 
 namespace Opm
 {
+    class PhaseUsage;
 
     /// The state of a set of wells.
     class WellState
@@ -212,7 +213,7 @@ namespace Opm
             return wellRates().size() / numWells();
         }
 
-        virtual data::Wells report() const
+        virtual data::Wells report(const PhaseUsage &pu) const
         {
             return { { /* WellState offers no completion data, so that has to be added later */ },
                 this->bhp(),


### PR DESCRIPTION
Used by OPM/opm-simulators#833 to output correct phases.