### PR TITLE
Only call writeTimeStep for real sub steps.

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -230,7 +230,10 @@ namespace Opm {
                 }
 
                 // write data if outputWriter was provided
-                if( outputWriter ) {
+                // if the time step is done we do not need
+                // to write it as this will be done by the simulator
+                // anyway.
+                if( outputWriter && !substepTimer.done() ) {
                     bool substep = true;
                     const auto& physicalModel = solver.model();
                     outputWriter->writeTimeStep( substepTimer, state, well_state, physicalModel, substep);


### PR DESCRIPTION
Previously, we also called it when the full time step was done.

As the simulator writes that information anyway and we cannot call it a sub step, we omit the final write in the adaptive time stepper.

This is the patch proposed in OPM/opm-simulators#823. Closes OPM/opm-simulators#823.