### PR TITLE
Add contructor for adaptiveTimeStepper that uses values from TUNING

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping.hpp
@@ -45,6 +45,17 @@ namespace Opm {
         AdaptiveTimeStepping( const parameter::ParameterGroup& param,
                               const bool terminal_output = true );
 
+        //! \brief contructor taking parameter object
+        //! \param tuning Pointer to ecl TUNING keyword
+        //! \param time_step current report step
+        //! \param param The parameter object
+        //! \param pinfo The information about the data distribution
+        //!              and communication for a parallel run.
+        AdaptiveTimeStepping( const Tuning& tuning,
+                              size_t time_step,
+                              const parameter::ParameterGroup& param,
+                              const bool terminal_output = true );
+
         /** \brief  step method that acts like the solver::step method
                     in a sub cycle of time steps
 
@@ -76,6 +87,8 @@ namespace Opm {
         void stepImpl( const SimulatorTimer& timer,
                        Solver& solver, State& state, WellState& well_state,
                        Output* outputWriter);
+
+        void init(const parameter::ParameterGroup& param);
 
         typedef std::unique_ptr< TimeStepControlInterface > TimeStepControlType;
 


### PR DESCRIPTION
Some of the tuning values from the TUNING keywords is used to tune the
time-stepping instead of the equivalent ones in param_.

This only implements part of the TUNING keyword. (The ones that where already implemented in OPM) Even thought I don't have any immediate plans for extending the usage of TUNING in the simulator, using TUNING instead of specifying parameters directly saves me some time in my work. 