### PR TITLE
set the Rv and Rs factors to the saturated values for cells which have no gas and no oil

### DIFF
--- a/opm/core/simulator/initStateEquil.hpp
+++ b/opm/core/simulator/initStateEquil.hpp
@@ -25,7 +25,7 @@
 #include <opm/core/grid/GridHelpers.hpp>
 #include <opm/core/simulator/EquilibrationHelpers.hpp>
 #include <opm/core/simulator/BlackoilState.hpp>
-#include <opm/core/props/BlackoilPropertiesInterface.hpp>
+#include <opm/core/props/BlackoilPropertiesFromDeck.hpp>
 #include <opm/core/props/BlackoilPhases.hpp>
 #include <opm/core/utility/RegionMapping.hpp>
 #include <opm/core/utility/Units.hpp>
@@ -163,7 +163,7 @@ namespace Opm
         phaseSaturations(const Grid&             grid,
                          const Region&           reg,
                          const CellRange&        cells,
-                         BlackoilPropertiesInterface& props,
+                         BlackoilPropertiesFromDeck& props,
                          const std::vector<double> swat_init,
                          std::vector< std::vector<double> >& phase_pressures);
 


### PR DESCRIPTION
the purpose of this is to get a more defined behaviour when doing the
gravity correction/upstream cell determination in the flux term.

I consider this to be just a kludge, so if anyone has a better idea of
what the composition for the non-existing gas and oil phases is,
please tell me. (note that generic compositional models do not exhibit
this issue because the composition of all fluids is always fully
defined because each component is assumed to dissolve in every phase.)

also be aware that this PR is independent of OPM/opm-simulators#845.