### PR TITLE
RelpermDiagnostics: fix the build

### DIFF
--- a/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
@@ -66,7 +66,7 @@ namespace Opm {
             const std::string cellIdx = "(" + std::to_string(ijk[0]) + ", " + 
                                    std::to_string(ijk[1]) + ", " +
                                    std::to_string(ijk[2]) + ")";
-            scaledEpsInfo_[c].extractScaled(epsGridProperties, cartIdx);
+            scaledEpsInfo_[c].extractScaled(deck, eclState, epsGridProperties, cartIdx);
 
             // SGU <= 1.0 - SWL
             if (scaledEpsInfo_[c].Sgu > (1.0 - scaledEpsInfo_[c].Swl)) {


### PR DESCRIPTION
this broke because EclEpsScalingPointsInfo::extractScaled() now
requires the deck and the EclipseState as additional parameters.

this is required to fix the build once OPM/opm-material#169 has been merged.