### PR TITLE
Convergence failure is "problem" not "error"

### DIFF
--- a/opm/core/props/rock/RockCompressibility.cpp
+++ b/opm/core/props/rock/RockCompressibility.cpp
@@ -42,7 +42,8 @@ namespace Opm
     }
 
     RockCompressibility::RockCompressibility(const Opm::Deck& deck,
-                                             const Opm::EclipseState& eclipseState)
+                                             const Opm::EclipseState& eclipseState,
+                                             const bool is_io_rank)
         : pref_(0.0),
           rock_comp_(0.0)
     {
@@ -63,14 +64,14 @@ namespace Opm
         } else if (deck.hasKeyword("ROCK")) {
             const auto& rockKeyword = deck.getKeyword("ROCK");
             if (rockKeyword.size() != 1) {
-                // here it would be better not to use std::cout directly but to add the
-                // warning to some "warning list"...
-                OpmLog::warning("Can only handle a single region in ROCK ("
-                                + std::to_string(rockKeyword.size())
-                                + " regions specified)."
-                                + " Ignoring all except for the first.\n" 
-                                + "In file " + rockKeyword.getFileName()
-                                + ", line " + std::to_string(rockKeyword.getLineNumber()) + "\n");
+                if (is_io_rank) {
+                    OpmLog::warning("Can only handle a single region in ROCK ("
+                                    + std::to_string(rockKeyword.size())
+                                    + " regions specified)."
+                                    + " Ignoring all except for the first.\n"
+                                    + "In file " + rockKeyword.getFileName()
+                                    + ", line " + std::to_string(rockKeyword.getLineNumber()) + "\n");
+                }
             }
 
             pref_ = rockKeyword.getRecord(0).getItem("PREF").getSIDouble(0);

--- a/opm/core/props/rock/RockCompressibility.hpp
+++ b/opm/core/props/rock/RockCompressibility.hpp
@@ -36,7 +36,8 @@ namespace Opm
         /// Construct from input deck.
         /// Looks for the keywords ROCK and ROCKTAB.
         RockCompressibility(const Opm::Deck& deck,
-                            const Opm::EclipseState& eclipseState);
+                            const Opm::EclipseState& eclipseState,
+                            const bool is_io_rank = true);
 
         /// Construct from parameters.
         /// Accepts the following parameters (with defaults).

--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -291,7 +291,12 @@ namespace Opm {
             {
                 // increase restart counter
                 if( restarts >= solver_restart_max_ ) {
-                    OPM_THROW(Opm::NumericalProblem,"Solver failed to converge after " << restarts << " restarts.");
+                    const auto msg = std::string("Solver failed to converge after ")
+                        + std::to_string(restarts) + " restarts.";
+                    if (solver_verbose_) {
+                        OpmLog::error(msg);
+                    }
+                    OPM_THROW_NOLOG(Opm::NumericalProblem, msg);
                 }
 
                 const double newTimeStep = restart_factor_ * dt;

--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -306,7 +306,7 @@ namespace Opm {
                     std::string msg;
                     msg = "Solver convergence failed, restarting solver with new time step ("
                         + std::to_string(unit::convert::to( newTimeStep, unit::day )) + " days).\n";
-                    OpmLog::error(msg);
+                    OpmLog::problem(msg);
 		}
                 // reset states
                 state      = last_state;


### PR DESCRIPTION
This should address the issue raised in OPM/opm-simulators#824.

Also (not directly related) ensures that logging is only happening on the first rank in a parallel run (the event it is fixed for is the rare event of complete breakdown of time-stepping).

Requires OPM/opm-common#185 (but not vice versa).