### PR TITLE
Undo premature API change adaption.

### DIFF
--- a/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
@@ -66,7 +66,7 @@ namespace Opm {
             const std::string cellIdx = "(" + std::to_string(ijk[0]) + ", " + 
                                    std::to_string(ijk[1]) + ", " +
                                    std::to_string(ijk[2]) + ")";
-            scaledEpsInfo_[c].extractScaled(deck, eclState, epsGridProperties, cartIdx);
+            scaledEpsInfo_[c].extractScaled(epsGridProperties, cartIdx);
 
             // SGU <= 1.0 - SWL
             if (scaledEpsInfo_[c].Sgu > (1.0 - scaledEpsInfo_[c].Swl)) {


### PR DESCRIPTION
This snuck in without me noticing it in the units-merging-fest, I guess I should have noticed on Jenkins though. Sorry for any trouble, will self-merge to get this compiling again.