### PR TITLE
fix some valgrind errors in the init code

### DIFF
--- a/opm/core/simulator/initState_impl.hpp
+++ b/opm/core/simulator/initState_impl.hpp
@@ -896,12 +896,15 @@ namespace Opm
             for (int col = 0; col < np; ++col) {
                 z[0] += A_a[0 + np*col]*s[col];
                 z[1] += A_l[1 + np*col]*s[col];
-                z[2] += A_v[2 + np*col]*s[col];
+                if (np > 2)
+                    z[2] += A_v[2 + np*col]*s[col];
 
             }
-            double ztmp = z[2];
-            z[2] += z[1]*rs[c];
-            z[1] += ztmp*rv[c];
+            if (np > 2) {
+                double ztmp = z[2];
+                z[2] += z[1]*rs[c];
+                z[1] += ztmp*rv[c];
+            }
 
         }
     }


### PR DESCRIPTION
this fixes some valgrind errors which I found while doing the twophase capability for flow_ebos: In all previously tested cases, these errors were probably non-fatal because the memory illegally accessed here is likely to be allocated (but after this function was finished it contained garbage).

note that I'm not completely sure if this patch is semantically correct, so I'd appreciate some input who understands it. (what is a "z" anyway? I remember a computer game by that name, but that's definitely not it.)