### PR TITLE
Improve simulator report

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping.hpp
@@ -65,8 +65,8 @@ namespace Opm {
             \param  well_state  additional well state object
         */
         template <class Solver, class State, class WellState>
-        void step( const SimulatorTimer& timer,
-                   Solver& solver, State& state, WellState& well_state );
+        SimulatorReport step( const SimulatorTimer& timer,
+                              Solver& solver, State& state, WellState& well_state );
 
         /** \brief  step method that acts like the solver::step method
                     in a sub cycle of time steps
@@ -78,15 +78,15 @@ namespace Opm {
             \param  outputWriter writer object to write sub steps
         */
         template <class Solver, class State, class WellState, class Output>
-        void step( const SimulatorTimer& timer,
-                   Solver& solver, State& state, WellState& well_state,
-                   Output& outputWriter );
+        SimulatorReport step( const SimulatorTimer& timer,
+                              Solver& solver, State& state, WellState& well_state,
+                              Output& outputWriter );
 
     protected:
         template <class Solver, class State, class WellState, class Output>
-        void stepImpl( const SimulatorTimer& timer,
-                       Solver& solver, State& state, WellState& well_state,
-                       Output* outputWriter);
+        SimulatorReport stepImpl( const SimulatorTimer& timer,
+                                  Solver& solver, State& state, WellState& well_state,
+                                  Output* outputWriter);
 
         void init(const parameter::ParameterGroup& param);
 

--- a/opm/core/simulator/SimulatorReport.cpp
+++ b/opm/core/simulator/SimulatorReport.cpp
@@ -27,9 +27,16 @@ namespace Opm
         : pressure_time(0.0),
           transport_time(0.0),
           total_time(0.0),
+          total_well_iterations(0),
+          solver_time(0.0),
+          assemble_time(0.0),
+          linear_solve_time(0.0),
+          update_time(0.0),
+          output_write_time(0.0),
           total_linearizations( 0 ),
           total_newton_iterations( 0 ),
           total_linear_iterations( 0 ),
+          converged(false),
           verbose_(verbose)
     {
     }
@@ -38,7 +45,14 @@ namespace Opm
     {
         pressure_time += sr.pressure_time;
         transport_time += sr.transport_time;
+        linear_solve_time += sr.linear_solve_time;
+        solver_time += sr.solver_time;
+        assemble_time += sr.assemble_time;
+        update_time += sr.update_time;
+        output_write_time += sr.output_write_time;
         total_time += sr.total_time;
+        total_well_iterations += sr.total_well_iterations;
+        total_linearizations += sr.total_linearizations;
         total_newton_iterations += sr.total_newton_iterations;
         total_linear_iterations += sr.total_linear_iterations;
     }
@@ -60,12 +74,19 @@ namespace Opm
     {
         if ( verbose_ )
         {
-            os << "Total time taken (seconds):  " << total_time
-               << "\nSolver time (seconds):       " << pressure_time
-               << "\nOverall Linearizations:      " << total_linearizations
-               << "\nOverall Newton Iterations:   " << total_newton_iterations
-               << "\nOverall Linear Iterations:   " << total_linear_iterations
-               << std::endl;
+            os << "Total time taken (seconds):   " << total_time << "\n"
+               << "Solver time (seconds):        " << solver_time << "\n";
+            if (assemble_time > 0.0 || linear_solve_time > 0.0) {
+                os << " Assembly time (seconds):     " << assemble_time << "\n"
+                   << " Linear solve time (seconds): " << linear_solve_time  << "\n"
+                   << " Update time (seconds):       " << update_time  << "\n"
+                   << " Output write time (seconds): " << output_write_time  << "\n";
+
+            }
+            os << "Overall Well Iterations:      " << total_well_iterations << "\n"
+               << "Overall Linearizations:       " << total_linearizations << "\n"
+               << "Overall Newton Iterations:    " << total_newton_iterations << "\n"
+               << "Overall Linear Iterations:    " << total_linear_iterations << "\n";
         }
     }
 

--- a/opm/core/simulator/SimulatorReport.hpp
+++ b/opm/core/simulator/SimulatorReport.hpp
@@ -31,13 +31,23 @@ namespace Opm
         double pressure_time;
         double transport_time;
         double total_time;
+        double solver_time;
+        double assemble_time;
+        double linear_solve_time;
+        double update_time;
+        double output_write_time;
 
+        unsigned int total_well_iterations;
         unsigned int total_linearizations;
         unsigned int total_newton_iterations;
         unsigned int total_linear_iterations;
 
+        bool converged;
+
         /// Default constructor initializing all times to 0.0.
         SimulatorReport(bool verbose=true);
+        /// Copy constructor
+        SimulatorReport(const SimulatorReport&) = default;
         /// Increment this report's times by those in sr.
         void operator+=(const SimulatorReport& sr);
         /// Print a report to the given stream.


### PR DESCRIPTION
this allows the performance report at the end of the simulation to be more relevant. in particular, the time needed for linearization and that for linear solves is kept track independently.

note that to take advantage of this, the actual simulators need to use the new possibilities. that is done in a separate opm-simulators PR. 