### PR TITLE
AdaptiveTimeStepping: fix stupid (but harmless) mistake in the sub-step info message

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -267,7 +267,7 @@ namespace Opm {
                         ss << "well iterations = " << report.total_well_iterations << ", ";
                     }
                     ss << "newton iterations = " << report.total_newton_iterations << ", "
-                       << "linearizations = " << report.total_newton_iterations
+                       << "linearizations = " << report.total_linearizations
                        << " (" << report.assemble_time << " sec), "
                        << "linear iterations = " << report.total_linear_iterations
                        << " (" << report.linear_solve_time << " sec)";


### PR DESCRIPTION
that was a copy-and-pasto: newton iterations = linearizations - 1