### PR TITLE
Store whether timestep failed or not

### DIFF
--- a/opm/core/simulator/AdaptiveSimulatorTimer.cpp
+++ b/opm/core/simulator/AdaptiveSimulatorTimer.cpp
@@ -42,6 +42,7 @@ namespace Opm
         , dt_( 0.0 )
         , current_step_( 0 )
         , steps_()
+        , lastStepFailed_( false )
     {
         // reserve memory for sub steps
         steps_.reserve( 10 );

--- a/opm/core/simulator/AdaptiveSimulatorTimer.hpp
+++ b/opm/core/simulator/AdaptiveSimulatorTimer.hpp
@@ -93,6 +93,12 @@ namespace Opm
         /// \brief start date time of simulation
         boost::posix_time::ptime startDateTime() const;
 
+        /// \brief Return true if last time step failed
+        bool lastStepFailed() const {return lastStepFailed_;}
+
+        /// \brief tell the timestepper whether timestep failed or not
+        void setLastStepFailed(bool lastStepFailed) {lastStepFailed_ = lastStepFailed;}
+
         /// return copy of object
         virtual std::unique_ptr< SimulatorTimerInterface > clone() const;
 
@@ -108,6 +114,8 @@ namespace Opm
         int current_step_;
 
         std::vector< double > steps_;
+        bool lastStepFailed_;
+
     };
 
 } // namespace Opm

--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -295,12 +295,13 @@ namespace Opm {
                 last_well_state = well_state;
 
                 report.converged = substepTimer.done();
+                substepTimer.setLastStepFailed(false);
 
             }
             else // in case of no convergence (linearIterations < 0)
             {
                 report.converged = false;
-
+                substepTimer.setLastStepFailed(true);
                 // increase restart counter
                 if( restarts >= solver_restart_max_ ) {
                     const auto msg = std::string("Solver failed to converge after ")

--- a/opm/core/simulator/SimulatorTimer.hpp
+++ b/opm/core/simulator/SimulatorTimer.hpp
@@ -110,6 +110,10 @@ namespace Opm
         /// Return true if op++() has been called numSteps() times.
         bool done() const;
 
+        /// Always return false. Timestep failures is handled in the
+        /// substepTimer
+        bool lastStepFailed() const {return false;}
+
         /// return copy of object
         virtual std::unique_ptr< SimulatorTimerInterface > clone() const;
 

--- a/opm/core/simulator/SimulatorTimerInterface.hpp
+++ b/opm/core/simulator/SimulatorTimerInterface.hpp
@@ -101,6 +101,9 @@ namespace Opm
             return std::mktime(&t);
         }
 
+        /// Return true if last time step failed
+        virtual bool lastStepFailed() const = 0;
+
         /// return copy of current timer instance
         virtual std::unique_ptr< SimulatorTimerInterface > clone () const = 0;
     };


### PR DESCRIPTION
Used in flow ebos to tell the simulator to recalculate the cached
quantities for failed time steps.