### PR TITLE
add missing semicolon to fix the build

### DIFF
--- a/tests/DuneIstlTestHelpers.hpp
+++ b/tests/DuneIstlTestHelpers.hpp
@@ -61,7 +61,7 @@ struct MPIFixture {
 };
 
 
-BOOST_GLOBAL_FIXTURE(MPIFixture)
+BOOST_GLOBAL_FIXTURE(MPIFixture);
 
 struct MyMatrix
 {


### PR DESCRIPTION
some versions of boost seem to be more picky about this than others...