### PR TITLE
Make it optinal to apply SWATINIT

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -168,6 +168,7 @@ list (APPEND TEST_DATA_FILES
 	tests/liveoil.DATA
 	tests/capillary.DATA
 	tests/capillary_overlap.DATA
+        tests/capillarySwatinit.DATA
 	tests/compressed_gridproperty.data
 	tests/deadfluids.DATA
 	tests/equil_livegas.DATA

--- a/tests/capillarySwatinit.DATA
+++ b/tests/capillarySwatinit.DATA
@@ -1,0 +1,86 @@
+-- Most of the following sections are not actually needed by the test,
+-- but it is required by the Eclipse reference manual that they are
+-- present. Also, the higher level opm-parser classes
+-- (i.e. Opm::EclipseState et al.) assume that they are present.
+
+-------------------------------------
+RUNSPEC
+
+WATER
+OIL
+GAS
+
+DIMENS
+40 40 40 /
+
+TABDIMS
+  1    1   40   20    1   20  /
+  
+EQLDIMS
+-- NTEQUL
+     1 /
+
+-------------------------------------
+GRID
+
+-- Opm::EclipseState assumes that _some_ grid gets defined, so let's
+-- specify a fake one...
+
+DXV
+40*1 /
+
+DYV
+40*1 /
+
+DZV
+40*1 /
+
+DEPTHZ
+1681*123.456 /
+
+-------------------------------------
+PROPS
+
+PVDO
+100 1.0 1.0
+200 0.9 1.0
+/
+
+PVDG
+100 0.010 0.1
+200 0.005 0.2
+/
+
+PVTW
+1.0 1.0 4.0E-5 0.96 0.0
+/
+
+SWOF
+0.2 0 1 0.4
+1   1 0 0.1
+/
+
+SGOF
+0   0 1 0.2
+0.8 1 0 0.5
+/
+
+DENSITY
+700 1000 1
+/
+
+SWATINIT
+ 5*0
+ 10*0.5
+ 5*1 /
+
+-------------------------------------
+SOLUTION
+
+EQUIL
+50 150 50 0.25 20 0.35 1* 1* 0
+/
+
+-------------------------------------
+SCHEDULE
+-- empty section


### PR DESCRIPTION
The reasoning behind this PR is to make it possible to initialize the case
without SWATINIT in order to compute the same defaulted THPRES values as
Ecl. The initialization needs to be re-computed to account for SWATINIT
in the simulations. But this is already the case in flow_ebos 