### PR TITLE
Increase max iterations for capillary curve inversion.

### DIFF
--- a/opm/core/simulator/EquilibrationHelpers.hpp
+++ b/opm/core/simulator/EquilibrationHelpers.hpp
@@ -734,7 +734,7 @@ namespace Opm
             } else if (f1 > 0.0) {
                 return s1;
             } else {
-                const int max_iter = 30;
+                const int max_iter = 60;
                 const double tol = 1e-6;
                 int iter_used = -1;
                 typedef RegulaFalsi<ThrowOnError> ScalarSolver;


### PR DESCRIPTION
Triggered by a new two-phase case.

It is not clear why the scalar solver fails to converge quickly in this case, but as it
 - only affects the initialization
 - can be easily addressed with no effect on any other cases
... it may not be worth spending a lot of time investigating it.