### PR TITLE
updating the group control limit for individual control wells

### DIFF
--- a/opm/core/wells/WellCollection.cpp
+++ b/opm/core/wells/WellCollection.cpp
@@ -282,7 +282,7 @@ namespace Opm
 
     void WellCollection::updateWellTargets(const std::vector<double>& well_rates)
     {
-        if ( !needUpdateWellTargets() ) {
+        if ( !needUpdateWellTargets() && groupTargetConverged(well_rates)) {
             return;
         }
 
@@ -321,6 +321,19 @@ namespace Opm
     bool WellCollection::groupControlActive() const
     {
         return group_control_active_;
+    }
+
+
+    bool WellCollection::groupTargetConverged(const std::vector<double>& well_rates) const
+    {
+        // TODO: eventually, there should be only one root node
+        // TODO: we also need to check the injection target, while we have not done that.
+        for (const std::shared_ptr<WellsGroupInterface>& root_node : roots_) {
+            if ( !root_node->groupProdTargetConverged(well_rates) ) {
+                return false;
+            }
+        }
+        return true;
     }
 
 }

--- a/opm/core/wells/WellCollection.hpp
+++ b/opm/core/wells/WellCollection.hpp
@@ -139,6 +139,13 @@ namespace Opm
         /// Whether we have active group control
         bool groupControlActive() const;
 
+        /// Whether the group target is converged
+        // It is considered converged if eitehr the group targets are matched or the group targets are not matched while the wells are
+        // running under their own limits so that they can not produce more
+        // It is considered not converged if the group targets are not matched while some of the wells are still running under group control
+        // The strategy may need to be adjusted when more complicated multi-layered group control situation applied, not sure about thatyet.
+        bool groupTargetConverged(const std::vector<double>& well_rates) const;
+
     private:
         // To account for the possibility of a forest
         std::vector<std::shared_ptr<WellsGroupInterface> > roots_;

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -857,20 +857,14 @@ namespace Opm
                 const double relative_tolerance = 0.01;
                 // the bigger one of the two values
                 const double bigger_of_two = std::max(production_rate, production_target);
-                // if production_rate is greater than production_target, there must be something wrong
-                // in the logic or the implementation
-                if (production_rate - production_target > relative_tolerance * bigger_of_two) {
-                    const std::string msg = " The group " + name() + " is over producing the target, something might be wrong ";
-                    OPM_THROW(std::runtime_error, msg);
-                }
 
-                if (production_target - production_rate > relative_tolerance * bigger_of_two) {
+                if (std::abs(production_target - production_rate) > relative_tolerance * bigger_of_two) {
                     // underproducing the target while potentially can produce more
                     // then we should not consider the effort to match the group target is done yet
                     if (canProduceMore()) {
                         return false;
                     } else {
-                        // can not produce more
+                        // can not produce more to meet the target
                         OpmLog::info("group " + name() + " can not meet its target!");
                     }
                 }
@@ -1296,6 +1290,7 @@ namespace Opm
             if (!phase_used[BlackoilPhases::Aqua]) {
                 OPM_THROW(std::runtime_error, "Water phase not active and LRAT control specified.");
             }
+
             distr[phase_pos[BlackoilPhases::Liquid]] = 1.0;
             distr[phase_pos[BlackoilPhases::Aqua]] = 1.0;
             break;

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -793,6 +793,18 @@ namespace Opm
                 const double children_guide_rate = children_[i]->productionGuideRate(true);
                 children_[i]->applyProdGroupControl(prod_mode, (children_guide_rate / my_guide_rate) * rate_for_group_control, true);
                 children_[i]->setTargetUpdated(true);
+            } else {
+                // for the well not under group control, we need to update their group control limit
+                // to provide a mechanism for the well to return to group control
+                // putting its own rate back to the rate_for_group_control for redistribution
+                const double rate = std::abs(children_[i]->getProductionRate(well_rates, prod_mode) * children_[i]->efficiencyFactor());
+                const double temp_rate_for_group_control = rate_for_group_control + rate;
+
+                // TODO: the following might not be the correct thing to do for mutliple-layer group
+                const double children_guide_rate = children_[i]->productionGuideRate(false);
+                const double temp_my_guide_rate = my_guide_rate + children_guide_rate;
+                children_[i]->applyProdGroupControl(prod_mode, (children_guide_rate / temp_my_guide_rate) * temp_rate_for_group_control, false);
+                children_[i]->setTargetUpdated(true);
             }
         }
     }

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -889,7 +889,7 @@ namespace Opm
     {
         double total_production_rate = 0.0;
         for (const std::shared_ptr<const WellsGroupInterface>& child_node : children_) {
-            total_production_rate += child_node->getProductionRate(well_rates, prod_mode);
+            total_production_rate += child_node->getProductionRate(well_rates, prod_mode) * child_node->efficiencyFactor();
         }
         return total_production_rate;
     }

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -820,6 +820,17 @@ namespace Opm
         // do nothing
     }
 
+
+    bool WellsGroup::canProduceMore() const
+    {
+        for (const std::shared_ptr<const WellsGroupInterface>& child_node : children_) {
+            if (child_node->canProduceMore()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     double WellsGroup::getProductionRate(const std::vector<double>& well_rates,
                                          const ProductionSpecification::ControlMode prod_mode) const
     {
@@ -1504,7 +1515,8 @@ namespace Opm
 
 
 
-    double WellNode::getAccumulativeEfficiencyFactor() const {
+    double WellNode::getAccumulativeEfficiencyFactor() const
+    {
         // TODO: not sure whether a well can be exempted from repsponding to the efficiency factor
         // for the parent group.
         double efficiency_factor = efficiencyFactor();
@@ -1518,18 +1530,27 @@ namespace Opm
     }
 
 
-    int WellNode::selfIndex() const {
+    int WellNode::selfIndex() const
+    {
         return self_index_;
     }
 
 
-    bool WellNode::targetUpdated() const {
+    bool WellNode::targetUpdated() const
+    {
         return target_updated_;
     }
 
 
-    void WellNode::setTargetUpdated(const bool flag) {
+    void WellNode::setTargetUpdated(const bool flag)
+    {
         target_updated_ = flag;
+    }
+
+
+    bool WellNode::canProduceMore() const
+    {
+        return (isProducer() && !individualControl());
     }
 
 }

--- a/opm/core/wells/WellsGroup.hpp
+++ b/opm/core/wells/WellsGroup.hpp
@@ -235,6 +235,10 @@ namespace Opm
 
         virtual void setTargetUpdated(const bool flag) = 0;
 
+        // bascially, for the group or wells under group control
+        // they have the potential to adjust their targets to produce more to match the higher level target
+        virtual bool canProduceMore() const = 0;
+
         double efficiencyFactor() const;
 
         void setEfficiencyFactor(const double efficiency_factor);
@@ -369,6 +373,8 @@ namespace Opm
         virtual double getProductionRate(const std::vector<double>& well_rates,
                                          const ProductionSpecification::ControlMode prod_mode) const;
 
+        virtual bool canProduceMore() const;
+
     private:
         std::vector<std::shared_ptr<WellsGroupInterface> > children_;
     };
@@ -496,6 +502,8 @@ namespace Opm
         bool targetUpdated() const;
 
         virtual void setTargetUpdated(const bool flag);
+
+        virtual bool canProduceMore() const;
 
     private:
         Wells* wells_;

--- a/opm/core/wells/WellsGroup.hpp
+++ b/opm/core/wells/WellsGroup.hpp
@@ -163,10 +163,10 @@ namespace Opm
                                                                ProductionSpecification::ControlMode mode) = 0;
 
         /// Gets the target rate for the given mode.
-        double getTarget(ProductionSpecification::ControlMode mode);
+        double getTarget(ProductionSpecification::ControlMode mode) const;
 
         /// Gets the target rate for the given mode.
-        double getTarget(InjectionSpecification::ControlMode mode);
+        double getTarget(InjectionSpecification::ControlMode mode) const;
 
         /// Applies any production group control relevant to all children nodes.
         /// If no group control is set, this is called recursively to the children.
@@ -238,6 +238,14 @@ namespace Opm
         // bascially, for the group or wells under group control
         // they have the potential to adjust their targets to produce more to match the higher level target
         virtual bool canProduceMore() const = 0;
+
+        // checking wether group production target converged
+        // if the group is producing following the target, then it should be considered okay
+        // if the group is not producing following the target, then we should check wether the group
+        // should be able to produce more to match the target.
+        // if the group can not produce more, we also consider the effort to match the group target is
+        // also done and the group target converged while we should give a message
+        virtual bool groupProdTargetConverged(const std::vector<double>& well_rates) const = 0;
 
         double efficiencyFactor() const;
 
@@ -375,6 +383,8 @@ namespace Opm
 
         virtual bool canProduceMore() const;
 
+        virtual bool groupProdTargetConverged(const std::vector<double>& well_rates) const;
+
     private:
         std::vector<std::shared_ptr<WellsGroupInterface> > children_;
     };
@@ -504,6 +514,8 @@ namespace Opm
         virtual void setTargetUpdated(const bool flag);
 
         virtual bool canProduceMore() const;
+
+        virtual bool groupProdTargetConverged(const std::vector<double>& well_rates) const;
 
     private:
         Wells* wells_;


### PR DESCRIPTION
to provide a better standard for the wells under individual control to
return to group control. For example, some wells get really big group
control limit and switch to individual control, it is very difficult for
them to return to group control with that kind of unreasonable fixed
group limit.

It will be needed for the downstream opm-simulator development for the group control for flow-ebos. 