### PR TITLE
set the VREP control as current control when applying VREP control

### DIFF
--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -1223,6 +1223,7 @@ namespace Opm
             group_control_index_ = well_controls_get_num(wells_->ctrls[self_index_]) - 1;
             // it should only apply for nodes with GRUP injeciton control
             individual_control_ = false;
+            set_current_control(self_index_, group_control_index_, wells_);
         } else {
             well_controls_iset_type(wells_->ctrls[self_index_] , group_control_index_ , RESERVOIR_RATE);
             well_controls_iset_target(wells_->ctrls[self_index_] , group_control_index_ , ntarget);


### PR DESCRIPTION
Not sure it is always the best thing to do here, while it can help the consistence of the two current controls in the well_controls and well_state, and also the individual_control_. 

It will be required by the incoming downstream group control PR in opm-simulators. 