### PR TITLE
changed: pass fipnum array into adaptive time stepping loop

### DIFF
--- a/opm/core/simulator/AdaptiveTimeStepping.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping.hpp
@@ -72,6 +72,7 @@ namespace Opm {
                     in a sub cycle of time steps
 
             \param  timer        simulator timer providing time and timestep
+            \param  fipnum       Fluid-in-place numbering array
             \param  solver       solver object that must implement a method step( dt, state, well_state )
             \param  state        current state of the solution variables
             \param  well_state   additional well state object
@@ -80,13 +81,15 @@ namespace Opm {
         template <class Solver, class State, class WellState, class Output>
         SimulatorReport step( const SimulatorTimer& timer,
                               Solver& solver, State& state, WellState& well_state,
-                              Output& outputWriter );
+                              Output& outputWriter,
+                              const std::vector<int>* fipnum = nullptr);
 
     protected:
         template <class Solver, class State, class WellState, class Output>
         SimulatorReport stepImpl( const SimulatorTimer& timer,
                                   Solver& solver, State& state, WellState& well_state,
-                                  Output* outputWriter);
+                                  Output* outputWriter,
+                                  const std::vector<int>* fipnum);
 
         void init(const parameter::ParameterGroup& param);
 

--- a/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
+++ b/opm/core/simulator/AdaptiveTimeStepping_impl.hpp
@@ -152,15 +152,17 @@ namespace Opm {
     SimulatorReport AdaptiveTimeStepping::
     step( const SimulatorTimer& simulatorTimer, Solver& solver, State& state, WellState& well_state )
     {
-        return stepImpl( simulatorTimer, solver, state, well_state );
+        return stepImpl( simulatorTimer, solver, state, well_state,  nullptr, nullptr );
     }
 
     template <class Solver, class State, class WellState, class Output>
     SimulatorReport AdaptiveTimeStepping::
-    step( const SimulatorTimer& simulatorTimer, Solver& solver, State& state, WellState& well_state,
-          Output& outputWriter )
+    step( const SimulatorTimer& simulatorTimer,
+          Solver& solver, State& state, WellState& well_state,
+          Output& outputWriter,
+          const std::vector<int>* fipnum)
     {
-        return stepImpl( simulatorTimer, solver, state, well_state, &outputWriter );
+        return stepImpl( simulatorTimer, solver, state, well_state, &outputWriter, fipnum );
     }
 
 
@@ -169,7 +171,8 @@ namespace Opm {
     SimulatorReport AdaptiveTimeStepping::
     stepImpl( const SimulatorTimer& simulatorTimer,
               Solver& solver, State& state, WState& well_state,
-              Output* outputWriter )
+              Output* outputWriter,
+              const std::vector<int>* fipnum)
     {
         SimulatorReport report;
         const double timestep = simulatorTimer.currentStepLength();
@@ -279,6 +282,9 @@ namespace Opm {
                 // to write it as this will be done by the simulator
                 // anyway.
                 if( outputWriter && !substepTimer.done() ) {
+                    if (fipnum) {
+                        solver.computeFluidInPlace(state, *fipnum);
+                    }
                     Opm::time::StopWatch perfTimer;
                     perfTimer.start();
                     bool substep = true;


### PR DESCRIPTION
needed as substep summary reports requires FIP data to be available.
add calculation of this data if output is requested and summary config holds
relevant keywords.