### PR TITLE
fix a GCC 7 warning

### DIFF
--- a/opm/core/utility/MonotCubicInterpolator.cpp
+++ b/opm/core/utility/MonotCubicInterpolator.cpp
@@ -166,7 +166,7 @@ read(const std::string & datafilename, int xColumn, int fColumn)
 
 void
 MonotCubicInterpolator::
-addPair(double newx, double newf) throw(const char*) {
+addPair(double newx, double newf) {
   if (std::isnan(newx) || std::isinf(newx) || std::isnan(newf) || std::isinf(newf)) {
     throw("MonotCubicInterpolator: addPair() received inf/nan input.");
   }
@@ -181,7 +181,7 @@ addPair(double newx, double newf) throw(const char*) {
 
 double
 MonotCubicInterpolator::
-evaluate(double x) const throw(const char*){
+evaluate(double x) const {
 
   if (std::isnan(x) || std::isinf(x)) {
     throw("MonotCubicInterpolator: evaluate() received inf/nan input.");
@@ -303,7 +303,7 @@ toString() const
 
 pair<double,double>
 MonotCubicInterpolator::
-getMissingX() const throw(const char*)
+getMissingX() const
 {
   if( data.size() < 2) {
     throw("MonotCubicInterpolator::getMissingX() only one datapoint.");
@@ -337,7 +337,7 @@ getMissingX() const throw(const char*)
 
 pair<double,double>
 MonotCubicInterpolator::
-getMaximumF() const throw(const char*) {
+getMaximumF() const {
   if (data.size() <= 1) {
     throw ("MonotCubicInterpolator::getMaximumF() empty data.") ;
   }
@@ -360,7 +360,7 @@ getMaximumF() const throw(const char*) {
 
 pair<double,double>
 MonotCubicInterpolator::
-getMinimumF() const throw(const char*) {
+getMinimumF() const {
   if (data.size() <= 1) {
     throw ("MonotCubicInterpolator::getMinimumF() empty data.") ;
   }

--- a/opm/core/utility/MonotCubicInterpolator.hpp
+++ b/opm/core/utility/MonotCubicInterpolator.hpp
@@ -71,7 +71,7 @@ class MonotCubicInterpolator {
 
       Ignores all lines not conforming to \<whitespace\>\<float\>\<whitespace\>\<float\>\<whatever\>\<newline\>
    */
-  MonotCubicInterpolator(const std::string & datafilename) throw (const char*)
+  MonotCubicInterpolator(const std::string & datafilename)
   {
     if (!read(datafilename)) {
       throw("Unable to constuct MonotCubicInterpolator from file.") ;
@@ -92,7 +92,7 @@ class MonotCubicInterpolator {
 
    */
 
- MonotCubicInterpolator(const char* datafilename) throw (const char*)
+ MonotCubicInterpolator(const char* datafilename)
   {
     if (!read(std::string(datafilename))) {
       throw("Unable to constuct MonotCubicInterpolator from file.") ;
@@ -108,7 +108,7 @@ class MonotCubicInterpolator {
        Accepts a filename as input, and parses the chosen columns in
        that file.
    */
-   MonotCubicInterpolator(const char* datafilename, int xColumn, int fColumn) throw (const char*)
+   MonotCubicInterpolator(const char* datafilename, int xColumn, int fColumn)
   {
     if (!read(std::string(datafilename),xColumn,fColumn)) {
       throw("Unable to constuct MonotCubicInterpolator from file.") ;
@@ -123,7 +123,7 @@ class MonotCubicInterpolator {
        Accepts a filename as input, and parses the chosen columns in
        that file.
    */
-   MonotCubicInterpolator(const std::string & datafilename, int xColumn, int fColumn) throw (const char*)
+   MonotCubicInterpolator(const std::string & datafilename, int xColumn, int fColumn)
   {
     if (!read(datafilename,xColumn,fColumn)) {
       throw("Unable to constuct MonotCubicInterpolator from file.") ;
@@ -204,7 +204,7 @@ class MonotCubicInterpolator {
 
       @return f(x) for a given x
    */
-   double evaluate(double x) const throw(const char*);
+   double evaluate(double x) const;
 
    /**
       @param x x value
@@ -255,7 +255,7 @@ class MonotCubicInterpolator {
       @return x value corresponding to maximum f value
       @return maximum f value
    */
-   std::pair<double,double> getMaximumF() const throw(const char*) ;
+   std::pair<double,double> getMaximumF() const ;
 
    /**
       Minimum f-value, returns both x and f in a pair
@@ -263,7 +263,7 @@ class MonotCubicInterpolator {
       @return x value corresponding to minimal f value
       @return minimum f value
    */
-   std::pair<double,double> getMinimumF() const throw(const char*)  ;
+   std::pair<double,double> getMinimumF() const  ;
 
 
    /**
@@ -407,7 +407,7 @@ class MonotCubicInterpolator {
       must be exploited.
 
    */
-   void addPair(double newx, double newf) throw(const char*);
+   void addPair(double newx, double newf);
 
    /**
       Returns an x-value that is believed to yield the best
@@ -421,7 +421,7 @@ class MonotCubicInterpolator {
       @return New x value beleived to yield the best improvement in global accuracy
       @return Maximal difference
    */
-   std::pair<double,double> getMissingX() const throw(const char*) ;
+   std::pair<double,double> getMissingX() const;
 
    /**
       Constructs a string containing the data in a table


### PR DESCRIPTION
GCC 7 warns

```
dynamic exception specifications are deprecated in C++11; use ‘noexcept’ instead [-Wdeprecated]
```

here.

on an unreleated but IMO interesting note, GCC 7 seems to become a great release for out purposes: on my machine the linearization performance improved by about 20% using flow_ebos with the norne deck when compared to GCC 5.4.0:

```
================    End of simulation     ===============

Total time taken (seconds):   661.888
Solver time (seconds):        658.491
 Assembly time (seconds):     284.158
 Linear solve time (seconds): 313.216
 Update time (seconds):       9.94308
 Output write time (seconds): 0.00081154
Overall Well Iterations:      890
Overall Linearizations:       1997
Overall Newton Iterations:    1653
Overall Linear Iterations:    24167
```

this figures need to taken with a grain of salt though: I had to disable output because it segfaulted (this is probably related to #1146) and I had to recompile boost because of linker errors. the latter caused me to loose another 3 hours (or so).