### PR TITLE
Fixing thp initialization

### DIFF
--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -84,8 +84,8 @@ namespace Opm
                         for (int p = 0; p < np; ++p) {
                             wellrates_[np*w + p] = 0.0;
                         }
-                        bhp_[w] = 0;
-                        thp_[w] = 0;
+                        bhp_[w] = 0.;
+                        thp_[w] = 0.;
                         continue;
                     }
 
@@ -138,20 +138,20 @@ namespace Opm
                         //    little above or below (depending on if
                         //    the well is an injector or producer)
                         //    pressure in first perforation cell.
-                                    if (well_controls_get_current_type(ctrl) == BHP) {
-                                        bhp_[w] = well_controls_get_current_target( ctrl );
-                                    } else {
-                                        const int first_cell = wells->well_cells[wells->well_connpos[w]];
-                                        const double safety_factor = (wells->type[w] == INJECTOR) ? 1.01 : 0.99;
-                                        bhp_[w] = safety_factor*state.pressure()[first_cell];
+                        if (well_controls_get_current_type(ctrl) == BHP) {
+                            bhp_[w] = well_controls_get_current_target( ctrl );
+                        } else {
+                            const int first_cell = wells->well_cells[wells->well_connpos[w]];
+                            const double safety_factor = (wells->type[w] == INJECTOR) ? 1.01 : 0.99;
+                            bhp_[w] = safety_factor*state.pressure()[first_cell];
                         }
 
                         // 3. Thp: assign thp equal to thp control, if applicable,
                         //    otherwise assign equal to bhp value.
-                                    if (well_controls_get_current_type(ctrl) == THP) {
-                                        thp_[w] = well_controls_get_current_target( ctrl );
-                                    } else {
-                                        thp_[w] = bhp_[w];
+                        if (well_controls_get_current_type(ctrl) == THP) {
+                            thp_[w] = well_controls_get_current_target( ctrl );
+                        } else {
+                            thp_[w] = bhp_[w];
                         }
                     }
                 }

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -104,13 +104,6 @@ namespace Opm
                             const int first_cell = wells->well_cells[wells->well_connpos[w]];
                             bhp_[w] = state.pressure()[first_cell];
                         }
-                        // 3. Thp: assign thp equal to thp control, if applicable,
-                        //    otherwise assign equal to bhp value.
-                        if (well_controls_get_current_type(ctrl) == THP) {
-                            thp_[w] = well_controls_get_current_target( ctrl );
-                        } else {
-                            thp_[w] = bhp_[w];
-                        }
                     } else {
                         // Open well:
                         // 1. Rates: initialize well rates to match controls
@@ -145,13 +138,16 @@ namespace Opm
                             const double safety_factor = (wells->type[w] == INJECTOR) ? 1.01 : 0.99;
                             bhp_[w] = safety_factor*state.pressure()[first_cell];
                         }
+                    }
 
-                        // 3. Thp: assign thp equal to thp control, if applicable,
-                        //    otherwise assign equal to bhp value.
-                        if (well_controls_get_current_type(ctrl) == THP) {
-                            thp_[w] = well_controls_get_current_target( ctrl );
-                        } else {
-                            thp_[w] = bhp_[w];
+                    // 3. Thp: assign thp equal to thp target/limit, if applicable,
+                    //    otherwise keep it zero. Basically, the value should not be used
+                    //    in the simulation at all.
+                    const int nwc = well_controls_get_num(ctrl);
+                    for (int ctrl_index = 0; ctrl_index < nwc; ++ctrl_index) {
+                        if (well_controls_iget_type(ctrl, ctrl_index) == THP) {
+                            thp_[w] = well_controls_iget_target(ctrl, ctrl_index);
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
When no THP target/limit is involved in the well control, we should not assign a non-zero value to the THP value.  It means, we will always output zero THP value for this well. 

It does not change previously matched results from the THP control case. 