### PR TITLE
Do not extrapolate initial rs and rv values in the depth tables

### DIFF
--- a/opm/core/simulator/EquilibrationHelpers.hpp
+++ b/opm/core/simulator/EquilibrationHelpers.hpp
@@ -273,7 +273,7 @@ namespace Opm
                     if (sat_gas > 0.0) {
                         return satRs(press, temp);
                     } else {
-                        return std::min(satRs(press, temp), linearInterpolation(depth_, rs_, depth));
+                        return std::min(satRs(press, temp), linearInterpolationNoExtrapolation(depth_, rs_, depth));
                     }
                 }
 
@@ -353,7 +353,7 @@ namespace Opm
                     if (std::abs(sat_oil) > 1e-16) {
                         return satRv(press, temp);
                     } else {
-                        return std::min(satRv(press, temp), linearInterpolation(depth_, rv_, depth));
+                        return std::min(satRv(press, temp), linearInterpolationNoExtrapolation(depth_, rv_, depth));
                     }
                 }
 

--- a/opm/core/utility/linearInterpolation.hpp
+++ b/opm/core/utility/linearInterpolation.hpp
@@ -70,6 +70,22 @@ namespace Opm
 	return  (yv[ix2] - yv[ix1])/(xv[ix2] - xv[ix1])*(x - xv[ix1]) + yv[ix1];
     }
 
+    inline double linearInterpolationNoExtrapolation(const std::vector<double>& xv,
+                                                     const std::vector<double>& yv, double x)
+    {
+        // Return end values if x is outside xv
+        if (x < xv.front()) {
+            return yv.front();
+        }
+        if (x > xv.back()) {
+            return yv.back();
+        }
+
+        int ix1 = tableIndex(xv, x);
+        int ix2 = ix1 + 1;
+        return  (yv[ix2] - yv[ix1])/(xv[ix2] - xv[ix1])*(x - xv[ix1]) + yv[ix1];
+    }
+
     inline double linearInterpolation(const std::vector<double>& xv,
                                       const std::vector<double>& yv,
                                       double x, int& ix1)


### PR DESCRIPTION
Makes initial rs values when outside depth range compatible with Ecl. 