### PR TITLE
Temporarily disabled EQUIL + SWATINIT test.

### DIFF
--- a/tests/test_equil.cpp
+++ b/tests/test_equil.cpp
@@ -809,6 +809,10 @@ BOOST_AUTO_TEST_CASE (DeckWithRSVDAndRVVD)
     }
 }
 
+#if 0
+
+Test disabled by Joakim 21.03.2017 to recover green test chain.
+
 BOOST_AUTO_TEST_CASE (DeckWithSwatinit)
 {
     Opm::GridManager gm(1, 1, 20, 1.0, 1.0, 5.0);
@@ -892,5 +896,7 @@ BOOST_AUTO_TEST_CASE (DeckWithSwatinit)
         }
     }
 }
+
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
As describeded here: https://github.com/OPM/opm-core/issues/1148 the PR: https://github.com/OPM/opm-parser/pull/1051 has broken the test of `EQUIL` in decks with `SWATINIT`. In opm-core - I really do not know how to fix this situation, and no one have stepped up to assist yet.

So - in agreement with @atgeirr I will merge this PR temporarily disabling the test if Travis goes green. Hopefully @totto82, @andlaus  or someone else with intimate knowledge of endscaling and `SWATINIT` can resolve the situation properly.

Sorry about the mess.