### PR TITLE
[WIP] changes needed to compute well potentials each time step. 

### DIFF
--- a/opm/core/wells/InjectionSpecification.cpp
+++ b/opm/core/wells/InjectionSpecification.cpp
@@ -34,7 +34,7 @@ namespace Opm
       BHP_limit_(-1e100),
       reinjection_fraction_target_(1),
       voidage_replacment_fraction_(1),
-      guide_rate_(1.0),
+      guide_rate_(-1.0),
       guide_rate_type_(NONE_GRT)
     {
 

--- a/opm/core/wells/ProductionSpecification.cpp
+++ b/opm/core/wells/ProductionSpecification.cpp
@@ -36,7 +36,7 @@ namespace Opm
       liquid_max_rate_(-1e100),
       reservoir_flow_max_rate_(-1e100),
       BHP_limit_(-1e100),
-      guide_rate_(1.0),
+      guide_rate_(-1.0),
       guide_rate_type_(NONE_GRT)
     {
     }

--- a/opm/core/wells/WellCollection.cpp
+++ b/opm/core/wells/WellCollection.cpp
@@ -426,6 +426,7 @@ namespace Opm
                         // not sure if no water and no oil, what will happen here, zero guide_rate?
                         well_node.prodSpec().guide_rate_ = guide_rate;
                         well_node.prodSpec().guide_rate_type_ = ProductionSpecification::LIQ;
+                        break;
                     }
                     case ProductionSpecification::NONE: {
                         // Group control is not in use for this group.

--- a/opm/core/wells/WellCollection.cpp
+++ b/opm/core/wells/WellCollection.cpp
@@ -482,4 +482,15 @@ namespace Opm
         } // end of for (int w = 0; w < nw; ++w)
     }
 
+
+    bool WellCollection::requireWellPotentials() const
+    {
+        for (const auto& well_node : leaf_nodes_) {
+            if (well_node->isGuideRateWellPotential()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/opm/core/wells/WellCollection.cpp
+++ b/opm/core/wells/WellCollection.cpp
@@ -194,6 +194,8 @@ namespace Opm
             roots_[i]->applyProdGroupControls();
             roots_[i]->applyInjGroupControls();
         }
+
+        group_control_applied_ = true;
     }
 
     /// Applies explicit reinjection controls. This must be called at each timestep to be correct.
@@ -321,6 +323,13 @@ namespace Opm
     bool WellCollection::groupControlActive() const
     {
         return group_control_active_;
+    }
+
+
+
+    bool WellCollection::groupControlApplied() const
+    {
+        return group_control_applied_;
     }
 
 

--- a/opm/core/wells/WellCollection.cpp
+++ b/opm/core/wells/WellCollection.cpp
@@ -284,9 +284,8 @@ namespace Opm
 
     void WellCollection::updateWellTargets(const std::vector<double>& well_rates)
     {
-        if ( !needUpdateWellTargets() && groupTargetConverged(well_rates)) {
-            return;
-        }
+
+        // TODO: if it gets converged, should we still update targets?
 
         // set the target_updated to be false
         for (WellNode* well_node : leaf_nodes_) {
@@ -298,8 +297,7 @@ namespace Opm
         // While there will be somre more complication invloved for sure.
         for (size_t i = 0; i < leaf_nodes_.size(); ++i) {
             // find a node needs to update targets, then update targets for all the wellls inside the group.
-            // if (leaf_nodes_[i]->shouldUpdateWellTargets() && !leaf_nodes_[i]->individualControl()) {
-            if (!leaf_nodes_[i]->individualControl() && !leaf_nodes_[i]->targetUpdated()) {
+            if (!leaf_nodes_[i]->targetUpdated()) {
                 WellsGroupInterface* parent_node = leaf_nodes_[i]->getParent();
                 // update the target within this group.
                 if (leaf_nodes_[i]->isProducer()) {

--- a/opm/core/wells/WellCollection.hpp
+++ b/opm/core/wells/WellCollection.hpp
@@ -146,6 +146,12 @@ namespace Opm
         // The strategy may need to be adjusted when more complicated multi-layered group control situation applied, not sure about thatyet.
         bool groupTargetConverged(const std::vector<double>& well_rates) const;
 
+
+        /// Setting the guide rates with well potentials
+        void setGuideRatesWithPotentials(const Wells* wells,
+                                         const PhaseUsage& phase_usage,
+                                         const std::vector<double>& well_potentials) const;
+
     private:
         // To account for the possibility of a forest
         std::vector<std::shared_ptr<WellsGroupInterface> > roots_;

--- a/opm/core/wells/WellCollection.hpp
+++ b/opm/core/wells/WellCollection.hpp
@@ -155,6 +155,9 @@ namespace Opm
                                          const PhaseUsage& phase_usage,
                                          const std::vector<double>& well_potentials) const;
 
+
+        bool requireWellPotentials() const;
+
     private:
         // To account for the possibility of a forest
         std::vector<std::shared_ptr<WellsGroupInterface> > roots_;

--- a/opm/core/wells/WellCollection.hpp
+++ b/opm/core/wells/WellCollection.hpp
@@ -139,6 +139,9 @@ namespace Opm
         /// Whether we have active group control
         bool groupControlActive() const;
 
+        /// Whether we have applied the group control
+        bool groupControlApplied() const;
+
         /// Whether the group target is converged
         // It is considered converged if eitehr the group targets are matched or the group targets are not matched while the wells are
         // running under their own limits so that they can not produce more
@@ -163,7 +166,8 @@ namespace Opm
 
         bool group_control_active_ = false;
 
-
+        // This is used to mark whether apply or update the group control
+        bool group_control_applied_ = false;
     };
 
 } // namespace Opm

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -1131,6 +1131,7 @@ namespace Opm
             // Put the well under group control immediately when GRUP control mdoe is specified
             if (injSpec().control_mode_ == InjectionSpecification::GRUP) {
                 set_current_control(self_index_, group_control_index_, wells_);
+                individual_control_ = false;
             }
         } else {
             // We will now modify the last control, that
@@ -1254,9 +1255,11 @@ namespace Opm
             // TODO: basically, one group control index is not enough eventually. There can be more than one sources for the
             // group control
             group_control_index_ = well_controls_get_num(wells_->ctrls[self_index_]) - 1;
-            // it should only apply for nodes with GRUP injeciton control
-            individual_control_ = false;
-            set_current_control(self_index_, group_control_index_, wells_);
+            // Put the well under group control immediately when GRUP control mdoe is specified
+            if (injSpec().control_mode_ == InjectionSpecification::GRUP) {
+                set_current_control(self_index_, group_control_index_, wells_);
+                individual_control_ = false;
+            }
         } else {
             well_controls_iset_type(wells_->ctrls[self_index_] , group_control_index_ , RESERVOIR_RATE);
             well_controls_iset_target(wells_->ctrls[self_index_] , group_control_index_ , ntarget);
@@ -1343,6 +1346,7 @@ namespace Opm
             // Put the well under group control immediately when GRUP control mdoe is specified
             if (prodSpec().control_mode_ == ProductionSpecification::GRUP) {
                 set_current_control(self_index_, group_control_index_, wells_);
+                individual_control_ = false;
             }
         } else {
             // We will now modify the last control, that

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -921,7 +921,8 @@ namespace Opm
           self_index_(-1),
           group_control_index_(-1),
           shut_well_(true), // This is default for now
-          target_updated_(false) // This is default for now, not sure whether to use the default value
+          target_updated_(false), // This is default for now, not sure whether to use the default value
+          is_guiderate_wellpotential_(false)
     {
     }
 
@@ -1648,6 +1649,18 @@ namespace Opm
     void WellNode::setTargetUpdated(const bool flag)
     {
         target_updated_ = flag;
+    }
+
+
+    bool WellNode::isGuideRateWellPotential() const
+    {
+        return is_guiderate_wellpotential_;
+    }
+
+
+    void WellNode::setIsGuideRateWellPotential(const bool flag)
+    {
+        is_guiderate_wellpotential_ = flag;
     }
 
 

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -1075,7 +1075,7 @@ namespace Opm
                                         const bool only_group)
     {
         if ( !isInjector() ) {
-            // assert(target == 0.0);
+            assert(target == 0.0 || std::isnan(target));
             return;
         }
 
@@ -1280,7 +1280,7 @@ namespace Opm
                                          const bool only_group)
     {
         if ( !isProducer() ) {
-            assert(target == 0.0);
+            assert(target == 0.0 || std::isnan(target));
             return;
         }
 

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -863,13 +863,20 @@ namespace Opm
                 const double bigger_of_two = std::max(production_rate, production_target);
 
                 if (std::abs(production_target - production_rate) > relative_tolerance * bigger_of_two) {
-                    // underproducing the target while potentially can produce more
-                    // then we should not consider the effort to match the group target is done yet
-                    if (canProduceMore()) {
-                        return false;
-                    } else {
-                        // can not produce more to meet the target
-                        OpmLog::info("group " + name() + " can not meet its target!");
+                    if (production_rate < production_target) {
+                        // underproducing the target while potentially can produce more
+                        // then we should not consider the effort to match the group target is done yet
+                        if (canProduceMore()) {
+                            return false;
+                        } else {
+                            // can not produce more to meet the target
+                            OpmLog::info("group " + name() + " can not meet its target!");
+                        }
+                    } else { // overproducing the target, the only possibility is that all the wells/groups are under individual control
+                        // while somehow our algorithms did not make the wells/groups return group controls
+                        // either we should fix the algorithm of determining the target for well to return group controls
+                        // or we should do something here
+                        OpmLog::info("group " + name() + " is overproducing its target!");
                     }
                 }
             }

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -871,12 +871,14 @@ namespace Opm
                         } else {
                             // can not produce more to meet the target
                             OpmLog::info("group " + name() + " can not meet its target!");
+                            return true;
                         }
                     } else { // overproducing the target, the only possibility is that all the wells/groups are under individual control
                         // while somehow our algorithms did not make the wells/groups return group controls
                         // either we should fix the algorithm of determining the target for well to return group controls
                         // or we should do something here
                         OpmLog::info("group " + name() + " is overproducing its target!");
+                        return false;
                     }
                 }
             }

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -788,7 +788,7 @@ namespace Opm
         }
 
         // the rates left for the wells under group control to split
-        const double rate_for_group_control = target_rate - rate_individual_control;
+        const double rate_for_group_control = std::max(target_rate - rate_individual_control, 0.0);
 
         const double my_guide_rate = productionGuideRate(true);
 

--- a/opm/core/wells/WellsGroup.hpp
+++ b/opm/core/wells/WellsGroup.hpp
@@ -514,6 +514,10 @@ namespace Opm
 
         bool targetUpdated() const;
 
+        bool isGuideRateWellPotential() const;
+
+        void setIsGuideRateWellPotential(const bool flag);
+
         virtual void setTargetUpdated(const bool flag);
 
         virtual bool canProduceMore() const;
@@ -527,6 +531,10 @@ namespace Opm
         bool shut_well_;
         // TODO: used when updating well targets
         bool target_updated_;
+        // whether the guide rate is specified with well potential
+        // TODO: we have never handle the guide rates for groups, maybe this
+        // is something will go to WellsGroupInterface later
+        bool is_guiderate_wellpotential_;
     };
 
     /// Creates the WellsGroupInterface for the given well

--- a/opm/core/wells/WellsGroup.hpp
+++ b/opm/core/wells/WellsGroup.hpp
@@ -211,6 +211,7 @@ namespace Opm
                                             const std::vector<double>& conversion_coeffs) = 0;
 
         virtual void applyVREPGroupControl(const double target,
+                                           const InjectionSpecification::InjectorType injector_type,
                                            const std::vector<double>& well_voidage_rates,
                                            const std::vector<double>& conversion_coeffs,
                                            const bool only_group) = 0;
@@ -366,6 +367,7 @@ namespace Opm
                                             const std::vector<double>& conversion_coeffs);
 
         virtual void applyVREPGroupControl(const double target,
+                                           const InjectionSpecification::InjectorType injector_type,
                                            const std::vector<double>& well_voidage_rates,
                                            const std::vector<double>& conversion_coeffs,
                                            const bool only_group);
@@ -484,6 +486,7 @@ namespace Opm
                                             const std::vector<double>& conversion_coeffs);
 
         virtual void applyVREPGroupControl(const double target,
+                                           const InjectionSpecification::InjectorType injector_type,
                                            const std::vector<double>& well_voidage_rates,
                                            const std::vector<double>& conversion_coeffs,
                                            const bool only_group);

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -748,7 +748,7 @@ namespace Opm
             WellNode& wellnode = *well_collection_.getLeafNodes()[wix];
 
             // TODO: looks like only handling OIL phase guide rate for producers
-            if (well->getGuideRatePhase(timeStep) != GuideRate::UNDEFINED) {
+            if (well->getGuideRatePhase(timeStep) != GuideRate::UNDEFINED && well->getGuideRate(timeStep) >= 0.) {
                 if (well_data[wix].type == PRODUCER) {
                     wellnode.prodSpec().guide_rate_ = well->getGuideRate(timeStep);
                     if (well->getGuideRatePhase(timeStep) == GuideRate::OIL) {
@@ -768,6 +768,8 @@ namespace Opm
                 } else {
                     OPM_THROW(std::runtime_error, "Unknown well type " << well_data[wix].type << " for well " << well->name());
                 }
+            } else {
+                wellnode.setIsGuideRateWellPotential(true);
             }
         }
     }

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -331,7 +331,6 @@ namespace Opm
                                const UnstructuredGrid& grid)
         : w_(0), is_parallel_run_(false)
     {
-        std::vector<double> dummy_well_potentials;
         // TODO: not sure about the usage of this WellsManager constructor
         // TODO: not sure whether this is the correct thing to do here.
         DynamicListEconLimited dummy_list_econ_limited;
@@ -339,7 +338,7 @@ namespace Opm
              UgGridHelpers::globalCell(grid), UgGridHelpers::cartDims(grid), 
              UgGridHelpers::dimensions(grid),
              UgGridHelpers::cell2Faces(grid), UgGridHelpers::beginFaceCentroids(grid),
-             dummy_list_econ_limited, dummy_well_potentials,
+             dummy_list_econ_limited,
              std::unordered_set<std::string>());
 
     }

--- a/opm/core/wells/WellsManager.hpp
+++ b/opm/core/wells/WellsManager.hpp
@@ -192,8 +192,8 @@ namespace Opm
                                    const std::unordered_set<std::string>& deactivated_wells,
                                    const DynamicListEconLimited& list_econ_limited);
 
-        void setupGuideRates(std::vector<const Well*>& wells, const size_t timeStep, std::vector<WellData>& well_data, std::map<std::string, int>& well_names_to_index,
-                             const PhaseUsage& phaseUsage, const std::vector<double>& well_potentials);
+        void setupGuideRates(std::vector<const Well*>& wells, const size_t timeStep, std::vector<WellData>& well_data, std::map<std::string, int>& well_names_to_index);
+
         // Data
         Wells* w_;
         WellCollection well_collection_;

--- a/opm/core/wells/WellsManager.hpp
+++ b/opm/core/wells/WellsManager.hpp
@@ -94,7 +94,6 @@ namespace Opm
                      FC begin_face_centroids,
                      const DynamicListEconLimited& list_econ_limited,
                      bool is_parallel_run=false,
-                     const std::vector<double>& well_potentials=std::vector<double>(),
                      const std::unordered_set<std::string>& deactivated_wells = std::unordered_set<std::string> ());
 
         WellsManager(const Opm::EclipseState& eclipseState,
@@ -163,7 +162,6 @@ namespace Opm
                   const C2F& cell_to_faces,
                   FC begin_face_centroids,
                   const DynamicListEconLimited& list_econ_limited,
-                  const std::vector<double>& well_potentials,
                   const std::unordered_set<std::string>& deactivated_wells);
         // Disable copying and assignment.
         WellsManager(const WellsManager& other);

--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -339,7 +339,7 @@ WellsManager::init(const Opm::EclipseState& eclipseState,
                    const C2F&                      cell_to_faces,
                    FC                              begin_face_centroids,
                    const DynamicListEconLimited&   list_econ_limited,
-                   const std::vector<double>&      well_potentials,
+                   const std::vector<double>&      /* well_potentials */,
                    const std::unordered_set<std::string>&    deactivated_wells)
 {
     if (dimensions != 3) {

--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -445,8 +445,8 @@ WellsManager::init(const Opm::EclipseState& eclipseState,
     well_collection_.setWellsPointer(w_);
 
     if (well_collection_.groupControlActive()) {
-        setupGuideRates(wells, timeStep, well_data, well_names_to_index, pu, well_potentials);
-        well_collection_.applyGroupControls();
+        // here does not consider the well potentials related guide rate setting
+        setupGuideRates(wells, timeStep, well_data, well_names_to_index);
     }
 
     // Debug output.

--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -318,13 +318,12 @@ WellsManager(const Opm::EclipseState& eclipseState,
              FC                              begin_face_centroids,
              const DynamicListEconLimited&   list_econ_limited,
              bool                            is_parallel_run,
-             const std::vector<double>&      well_potentials,
              const std::unordered_set<std::string>&    deactivated_wells)
     : w_(0), is_parallel_run_(is_parallel_run)
 {
     init(eclipseState, timeStep, number_of_cells, global_cell,
          cart_dims, dimensions,
-         cell_to_faces, begin_face_centroids, list_econ_limited, well_potentials, deactivated_wells);
+         cell_to_faces, begin_face_centroids, list_econ_limited, deactivated_wells);
 }
 
 /// Construct wells from deck.
@@ -339,7 +338,6 @@ WellsManager::init(const Opm::EclipseState& eclipseState,
                    const C2F&                      cell_to_faces,
                    FC                              begin_face_centroids,
                    const DynamicListEconLimited&   list_econ_limited,
-                   const std::vector<double>&      /* well_potentials */,
                    const std::unordered_set<std::string>&    deactivated_wells)
 {
     if (dimensions != 3) {


### PR DESCRIPTION
The major reason for this PR is to help to fulfill the computation of the well potentials for each `time step` instead of using the well potentials from the end of `last report step`. As a result, setting the `guide rate` based on `well potentials` can be done in the initialization of the `WellsManager` anymore. 

And also, make the `distr` in `well_controls` recognize the injection phase. 

More description will be found in the PR description in the OPM/opm-simulators#1118. 