### PR TITLE
FIX memory leakage in well_controls

### DIFF
--- a/opm/core/wells/well_controls.c
+++ b/opm/core/wells/well_controls.c
@@ -127,6 +127,8 @@ well_controls_destroy(struct WellControls *ctrl)
         free             (ctrl->distr);
         free             (ctrl->target);
         free             (ctrl->type);
+        free             (ctrl->alq);
+        free             (ctrl->vfp);
     }
 
     free(ctrl);


### PR DESCRIPTION
The Alq and vfp is set free in well_controls_destroy to avoid memory
leakage. Valgrind stopped complaining after this fix. 

@and Can you verify that this fixes the memory issue you reported. 
