### PR TITLE
changed: remove embedded 'parameters' namespace in ParamGroup

### DIFF
--- a/examples/compute_eikonal_from_files.cpp
+++ b/examples/compute_eikonal_from_files.cpp
@@ -42,7 +42,7 @@
 
 namespace
 {
-    void warnIfUnusedParams(const Opm::parameter::ParameterGroup& param)
+    void warnIfUnusedParams(const Opm::ParameterGroup& param)
     {
         if (param.anyUnused()) {
             std::cout << "--------------------   Warning: unused parameters:   --------------------\n";
@@ -61,7 +61,7 @@ try
 {
     using namespace Opm;
 
-    parameter::ParameterGroup param(argc, argv);
+    ParameterGroup param(argc, argv);
 
     // Read grid.
     GridManager grid_manager(param.get<std::string>("grid_filename"));

--- a/examples/compute_initial_state.cpp
+++ b/examples/compute_initial_state.cpp
@@ -40,7 +40,7 @@
 
 namespace
 {
-    void warnIfUnusedParams(const Opm::parameter::ParameterGroup& param)
+    void warnIfUnusedParams(const Opm::ParameterGroup& param)
     {
         if (param.anyUnused()) {
             std::cout << "--------------------   Unused parameters:   --------------------\n";
@@ -84,7 +84,7 @@ try
     using namespace Opm;
 
     // Setup.
-    parameter::ParameterGroup param(argc, argv);
+    ParameterGroup param(argc, argv);
     std::cout << "---------------    Reading parameters     ---------------" << std::endl;
     const std::string deck_filename = param.get<std::string>("deck_filename");
     Opm::ParseContext parseContext;

--- a/examples/compute_tof.cpp
+++ b/examples/compute_tof.cpp
@@ -61,7 +61,7 @@ namespace
     const static double alq_invalid = -std::numeric_limits<double>::max();
     const static int vfp_invalid = -std::numeric_limits<int>::max();
 
-    void warnIfUnusedParams(const Opm::parameter::ParameterGroup& param)
+    void warnIfUnusedParams(const Opm::ParameterGroup& param)
     {
         if (param.anyUnused()) {
             std::cout << "--------------------   Unused parameters:   --------------------\n";
@@ -166,7 +166,7 @@ try
     using namespace Opm;
 
     std::cout << "\n================    Test program for incompressible tof computations     ===============\n\n";
-    parameter::ParameterGroup param(argc, argv);
+    ParameterGroup param(argc, argv);
     std::cout << "---------------    Reading parameters     ---------------" << std::endl;
 
     // Read the deck.

--- a/examples/compute_tof_from_files.cpp
+++ b/examples/compute_tof_from_files.cpp
@@ -58,7 +58,7 @@
 
 namespace
 {
-    void warnIfUnusedParams(const Opm::parameter::ParameterGroup& param)
+    void warnIfUnusedParams(const Opm::ParameterGroup& param)
     {
         if (param.anyUnused()) {
             std::cout << "--------------------   Warning: unused parameters:   --------------------\n";
@@ -77,7 +77,7 @@ try
 {
     using namespace Opm;
 
-    parameter::ParameterGroup param(argc, argv);
+    ParameterGroup param(argc, argv);
 
     // Read grid.
     GridManager grid_manager(param.get<std::string>("grid_filename"));

--- a/opm/core/flowdiagnostics/TofDiscGalReorder.cpp
+++ b/opm/core/flowdiagnostics/TofDiscGalReorder.cpp
@@ -40,7 +40,7 @@ namespace Opm
 
     /// Construct solver.
     TofDiscGalReorder::TofDiscGalReorder(const UnstructuredGrid& grid,
-                                         const parameter::ParameterGroup& param)
+                                         const ParameterGroup& param)
         : grid_(grid),
           use_cvi_(false),
           use_limiter_(false),

--- a/opm/core/flowdiagnostics/TofDiscGalReorder.hpp
+++ b/opm/core/flowdiagnostics/TofDiscGalReorder.hpp
@@ -32,9 +32,9 @@ namespace Opm
 {
 
     class IncompPropertiesInterface;
+    class ParameterGroup;
     class VelocityInterpolationInterface;
     class DGBasisInterface;
-    namespace parameter { class ParameterGroup; }
     template <typename T> class SparseTable;
 
     /// Implements a discontinuous Galerkin solver for
@@ -72,7 +72,7 @@ namespace Opm
         ///             - AsSimultaneousPostProcess  -- Apply to each cell independently, using un-
         ///                                             limited solution in neighbouring cells.
         TofDiscGalReorder(const UnstructuredGrid& grid,
-                          const parameter::ParameterGroup& param);
+                          const ParameterGroup& param);
 
 
         /// Solve for time-of-flight.

--- a/opm/core/linalg/LinearSolverFactory.cpp
+++ b/opm/core/linalg/LinearSolverFactory.cpp
@@ -59,7 +59,7 @@ namespace Opm
 
 
 
-    LinearSolverFactory::LinearSolverFactory(const parameter::ParameterGroup& param)
+    LinearSolverFactory::LinearSolverFactory(const ParameterGroup& param)
     {
 #if HAVE_SUITESPARSE_UMFPACK_H
         std::string default_solver = "umfpack";

--- a/opm/core/linalg/LinearSolverFactory.hpp
+++ b/opm/core/linalg/LinearSolverFactory.hpp
@@ -27,7 +27,7 @@
 namespace Opm
 {
 
-    namespace parameter { class ParameterGroup; }
+    class ParameterGroup;
 
 
     /// Concrete class encapsulating any available linear solver.
@@ -55,7 +55,7 @@ namespace Opm
         /// Any further parameters are passed on to the constructors
         /// of the actual solver used, see LinearSolverUmfpack,
         /// LinearSolverIstl and LinearSolverPetsc for details.
-        LinearSolverFactory(const parameter::ParameterGroup& param);
+        LinearSolverFactory(const ParameterGroup& param);
 
         /// Destructor.
         virtual ~LinearSolverFactory();

--- a/opm/core/linalg/LinearSolverIstl.cpp
+++ b/opm/core/linalg/LinearSolverIstl.cpp
@@ -111,7 +111,7 @@ namespace Opm
 
 
 
-    LinearSolverIstl::LinearSolverIstl(const parameter::ParameterGroup& param)
+    LinearSolverIstl::LinearSolverIstl(const ParameterGroup& param)
         : linsolver_residual_tolerance_(1e-8),
           linsolver_verbosity_(0),
           linsolver_type_(CG_AMG),

--- a/opm/core/linalg/LinearSolverIstl.hpp
+++ b/opm/core/linalg/LinearSolverIstl.hpp
@@ -52,7 +52,7 @@ namespace Opm
         /// Construct from parameters
         /// Accepted parameters are, with defaults, listed in the
         /// default constructor.
-        LinearSolverIstl(const parameter::ParameterGroup& param);
+        LinearSolverIstl(const ParameterGroup& param);
 
         /// Destructor.
         virtual ~LinearSolverIstl();

--- a/opm/core/props/BlackoilPropertiesBasic.cpp
+++ b/opm/core/props/BlackoilPropertiesBasic.cpp
@@ -26,7 +26,7 @@
 namespace Opm
 {
 
-    BlackoilPropertiesBasic::BlackoilPropertiesBasic(const parameter::ParameterGroup& param,
+    BlackoilPropertiesBasic::BlackoilPropertiesBasic(const ParameterGroup& param,
                                                      const int dim,
                                                      const int num_cells)
     {

--- a/opm/core/props/BlackoilPropertiesBasic.hpp
+++ b/opm/core/props/BlackoilPropertiesBasic.hpp
@@ -43,7 +43,7 @@ namespace Opm
         ///    - mu1, mu2, mu3    (1.0)      -- Viscosity in cP
         ///    - porosity         (1.0)      -- Porosity
         ///    - permeability     (100.0)    -- Permeability in mD
-        BlackoilPropertiesBasic(const parameter::ParameterGroup& param,
+        BlackoilPropertiesBasic(const ParameterGroup& param,
                                 const int dim,
                                 const int num_cells);
 

--- a/opm/core/props/BlackoilPropertiesFromDeck.cpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck.cpp
@@ -47,7 +47,7 @@ namespace Opm
     BlackoilPropertiesFromDeck::BlackoilPropertiesFromDeck(const Opm::Deck& deck,
                                                            const Opm::EclipseState& eclState,
                                                            const UnstructuredGrid& grid,
-                                                           const parameter::ParameterGroup& param,
+                                                           const ParameterGroup& param,
                                                            bool init_rock)
     {
         std::vector<int> compressedToCartesianIdx
@@ -81,7 +81,7 @@ namespace Opm
                                                            int number_of_cells,
                                                            const int* global_cell,
                                                            const int* cart_dims,
-                                                           const parameter::ParameterGroup& param,
+                                                           const ParameterGroup& param,
                                                            bool init_rock)
     {
         std::vector<int> compressedToCartesianIdx
@@ -106,7 +106,7 @@ namespace Opm
                                                            int number_of_cells,
                                                            const int* global_cell,
                                                            const int* cart_dims,
-                                                           const parameter::ParameterGroup& param,
+                                                           const ParameterGroup& param,
                                                            bool init_rock)
     {
         init(deck,
@@ -151,7 +151,7 @@ namespace Opm
                                                  int number_of_cells,
                                                  const int* global_cell,
                                                  const int* cart_dims,
-                                                 const parameter::ParameterGroup& param,
+                                                 const ParameterGroup& param,
                                                  bool init_rock)
     {
         // retrieve the cell specific PVT table index from the deck

--- a/opm/core/props/BlackoilPropertiesFromDeck.hpp
+++ b/opm/core/props/BlackoilPropertiesFromDeck.hpp
@@ -68,7 +68,7 @@ namespace Opm
         BlackoilPropertiesFromDeck(const Opm::Deck& deck,
                                    const Opm::EclipseState& eclState,
                                    const UnstructuredGrid& grid,
-                                   const parameter::ParameterGroup& param,
+                                   const ParameterGroup& param,
                                    bool init_rock=true);
 
         BlackoilPropertiesFromDeck(const Opm::Deck& deck,
@@ -83,7 +83,7 @@ namespace Opm
                                    int number_of_cells,
                                    const int* global_cell,
                                    const int* cart_dims,
-                                   const parameter::ParameterGroup& param,
+                                   const ParameterGroup& param,
                                    bool init_rock=true);
 
         BlackoilPropertiesFromDeck(const Opm::Deck& deck,
@@ -92,7 +92,7 @@ namespace Opm
                                    int number_of_cells,
                                    const int* global_cell,
                                    const int* cart_dims,
-                                   const parameter::ParameterGroup& param,
+                                   const ParameterGroup& param,
                                    bool init_rock=true);
 
         /// Destructor.
@@ -304,7 +304,7 @@ namespace Opm
                   int number_of_cells,
                   const int* global_cell,
                   const int* cart_dims,
-                  const parameter::ParameterGroup& param,
+                  const ParameterGroup& param,
                   bool init_rock);
 
         RockFromDeck rock_;

--- a/opm/core/props/IncompPropertiesBasic.cpp
+++ b/opm/core/props/IncompPropertiesBasic.cpp
@@ -28,7 +28,7 @@
 namespace Opm
 {
 
-    IncompPropertiesBasic::IncompPropertiesBasic(const parameter::ParameterGroup& param,
+    IncompPropertiesBasic::IncompPropertiesBasic(const ParameterGroup& param,
                                                  const int dim,
                                                  const int num_cells)
     {

--- a/opm/core/props/IncompPropertiesBasic.hpp
+++ b/opm/core/props/IncompPropertiesBasic.hpp
@@ -51,7 +51,7 @@ namespace Opm
         ///   - \c mu1 \c mu2, \c mu3    (1.0)      -- Viscosity in cP.
         ///   - \c porosity              (1.0)      -- Porosity.
         ///   - \c permeability          (100.0)    -- Permeability in mD.
-        IncompPropertiesBasic(const parameter::ParameterGroup& param,
+        IncompPropertiesBasic(const ParameterGroup& param,
                               const int dim,
                               const int num_cells);
 

--- a/opm/core/props/pvt/PvtPropertiesBasic.cpp
+++ b/opm/core/props/pvt/PvtPropertiesBasic.cpp
@@ -33,7 +33,7 @@ namespace Opm
     }
 
 
-    void PvtPropertiesBasic::init(const parameter::ParameterGroup& param)
+    void PvtPropertiesBasic::init(const ParameterGroup& param)
     {
         int num_phases = param.getDefault("num_phases", 2);
         if (num_phases > 3 || num_phases < 1) {

--- a/opm/core/props/pvt/PvtPropertiesBasic.hpp
+++ b/opm/core/props/pvt/PvtPropertiesBasic.hpp
@@ -44,7 +44,7 @@ namespace Opm
         ///   - num_phases        (2)      --  Must be 1, 2 or 3.
         ///   - rho1, rho2, rho3  (1.0e3)  --  Density in kg/m^3
         ///   - mu1, mu2, mu3     (1.0)    --  Viscosity in cP
-        void init(const parameter::ParameterGroup& param);
+        void init(const ParameterGroup& param);
 
         /// Initialize from arguments.
         /// Basic multi phase fluid pvt properties.

--- a/opm/core/props/rock/RockCompressibility.cpp
+++ b/opm/core/props/rock/RockCompressibility.cpp
@@ -33,7 +33,7 @@
 namespace Opm
 {
 
-    RockCompressibility::RockCompressibility(const parameter::ParameterGroup& param)
+    RockCompressibility::RockCompressibility(const ParameterGroup& param)
         : pref_(0.0),
           rock_comp_(0.0)
     {

--- a/opm/core/props/rock/RockCompressibility.hpp
+++ b/opm/core/props/rock/RockCompressibility.hpp
@@ -27,7 +27,7 @@
 namespace Opm
 {
 
-    namespace parameter { class ParameterGroup; }
+    class ParameterGroup;
 
     class RockCompressibility
     {
@@ -41,7 +41,7 @@ namespace Opm
         /// Accepts the following parameters (with defaults).
         ///    rock_compressibility_pref (100.0)   [given in bar]
         ///    rock_compressibility      (0.0)     [given in bar^{-1}]
-        RockCompressibility(const parameter::ParameterGroup& param);
+        RockCompressibility(const ParameterGroup& param);
 
         /// Returns true if there are compressibility effects.
         bool isActive() const;

--- a/opm/core/props/satfunc/SaturationPropsBasic.cpp
+++ b/opm/core/props/satfunc/SaturationPropsBasic.cpp
@@ -108,7 +108,7 @@ namespace Opm
 
 
     /// Initialize from parameters.
-    void SaturationPropsBasic::init(const parameter::ParameterGroup& param)
+    void SaturationPropsBasic::init(const ParameterGroup& param)
     {
         int num_phases = param.getDefault("num_phases", 2);
         if (num_phases > 2 || num_phases < 1) {

--- a/opm/core/props/satfunc/SaturationPropsBasic.hpp
+++ b/opm/core/props/satfunc/SaturationPropsBasic.hpp
@@ -43,7 +43,7 @@ namespace Opm
         /// The following parameters are accepted (defaults):
         ///    - num_phases   (2)        -- Must be 1 or 2.
         ///    - relperm_func ("Linear") -- Must be "Constant", "Linear" or "Quadratic".
-        void init(const parameter::ParameterGroup& param);
+        void init(const ParameterGroup& param);
 
         enum RelPermFunc { Constant, Linear, Quadratic };
 

--- a/opm/core/simulator/initState.hpp
+++ b/opm/core/simulator/initState.hpp
@@ -27,7 +27,7 @@ struct UnstructuredGrid;
 namespace Opm
 {
 
-    namespace parameter { class ParameterGroup; }
+    class ParameterGroup;
     class IncompPropertiesInterface;
     class BlackoilPropertiesInterface;
     class SimulationDataContainer;
@@ -75,7 +75,7 @@ namespace Opm
     template <class State>
     void initStateBasic(const UnstructuredGrid& grid,
                         const IncompPropertiesInterface& props,
-                        const parameter::ParameterGroup& param,
+                        const ParameterGroup& param,
                         const double gravity,
                         State& state);
 
@@ -113,7 +113,7 @@ namespace Opm
                         CCI begin_cell_centroids,
                         int dimensions,
                         const IncompPropertiesInterface& props,
-                        const parameter::ParameterGroup& param,
+                        const ParameterGroup& param,
                         const double gravity,
                         State& state);
 
@@ -136,7 +136,7 @@ namespace Opm
     template <class State>
     void initStateBasic(const UnstructuredGrid& grid,
                         const BlackoilPropertiesInterface& props,
-                        const parameter::ParameterGroup& param,
+                        const ParameterGroup& param,
                         const double gravity,
                         State& state);
 
@@ -166,7 +166,7 @@ namespace Opm
                         CCI begin_cell_centroids,
                         int dimensions,
                         const BlackoilPropertiesInterface& props,
-                        const parameter::ParameterGroup& param,
+                        const ParameterGroup& param,
                         const double gravity,
                         State& state);
 

--- a/opm/core/simulator/initState_impl.hpp
+++ b/opm/core/simulator/initState_impl.hpp
@@ -411,7 +411,7 @@ namespace Opm
     template <class State>
     void initStateBasic(const UnstructuredGrid& grid,
                         const IncompPropertiesInterface& props,
-                        const parameter::ParameterGroup& param,
+                        const ParameterGroup& param,
                         const double gravity,
                         State& state)
     {
@@ -432,7 +432,7 @@ namespace Opm
                         CCI begin_cell_centroids,
                         int dimensions,
                         const IncompPropertiesInterface& props,
-                        const parameter::ParameterGroup& param,
+                        const ParameterGroup& param,
                         const double gravity,
                         State& state)
 {
@@ -535,7 +535,7 @@ namespace Opm
     template <class State>
     void initStateBasic(const UnstructuredGrid& grid,
                         const BlackoilPropertiesInterface& props,
-                        const parameter::ParameterGroup& param,
+                        const ParameterGroup& param,
                         const double gravity,
                         State& state)
     {
@@ -555,7 +555,7 @@ namespace Opm
                         CCI begin_cell_centroids,
                         int dimensions,
                         const BlackoilPropertiesInterface& props,
-                        const parameter::ParameterGroup& param,
+                        const ParameterGroup& param,
                         const double gravity,
                         State& state)
     {

--- a/opm/core/transport/implicit/TransportSolverTwophaseImplicit.cpp
+++ b/opm/core/transport/implicit/TransportSolverTwophaseImplicit.cpp
@@ -45,7 +45,7 @@ namespace Opm
             const std::vector<double>& porevol,
             const double* gravity,
             const std::vector<double>& half_trans,
-            const parameter::ParameterGroup& param)
+            const ParameterGroup& param)
         : fluid_(props),
           model_(fluid_, grid, porevol, gravity, param.getDefault("guess_old_solution", false)),
           tsolver_(model_),

--- a/opm/core/transport/implicit/TransportSolverTwophaseImplicit.hpp
+++ b/opm/core/transport/implicit/TransportSolverTwophaseImplicit.hpp
@@ -61,7 +61,7 @@ namespace Opm
                                         const std::vector<double>& porevol,
                                         const double* gravity,
                                         const std::vector<double>& half_trans,
-                                        const parameter::ParameterGroup& param);
+                                        const ParameterGroup& param);
 
         virtual ~TransportSolverTwophaseImplicit();
 

--- a/opm/core/utility/parameters/Parameter.cpp
+++ b/opm/core/utility/parameters/Parameter.cpp
@@ -40,7 +40,6 @@
 #include <opm/core/utility/parameters/Parameter.hpp>
 
 namespace Opm {
-    namespace parameter {
 	std::string
         correct_parameter_tag(const ParameterMapItem& item)
         {
@@ -70,5 +69,4 @@ namespace Opm {
 		return "";
 	    }
 	}
-    } // namespace parameter
 } // namespace Opm

--- a/opm/core/utility/parameters/Parameter.hpp
+++ b/opm/core/utility/parameters/Parameter.hpp
@@ -43,8 +43,6 @@
 #include <opm/core/utility/parameters/ParameterStrings.hpp>
 
 namespace Opm {
-    /// See ParameterGroup.hpp for how to use the parameter system
-    namespace parameter {
 	/// @brief
 	/// @todo Doc me!
 	class Parameter : public ParameterMapItem {
@@ -213,6 +211,5 @@ namespace Opm {
 	    }
 	    static std::string type() {return ID_param_type__string;}
 	};
-    } // namespace parameter
 } // namespace Opm
 #endif  // OPM_PARAMETER_HPP

--- a/opm/core/utility/parameters/ParameterGroup.cpp
+++ b/opm/core/utility/parameters/ParameterGroup.cpp
@@ -49,8 +49,6 @@
 #include <opm/core/utility/parameters/ParameterTools.hpp>
 
 namespace Opm {
-    namespace parameter {
-
 	ParameterGroup::ParameterGroup()
 	: path_(ID_path_root), parent_(0), output_is_enabled_(true)
 	{
@@ -69,7 +67,7 @@ namespace Opm {
 
 	bool ParameterGroup::has(const std::string& name) const
         {
-	    std::pair<std::string, std::string> name_path = split(name);
+	    std::pair<std::string, std::string> name_path = splitParam(name);
 	    map_type::const_iterator it = map_.find(name_path.first);
 	    if (it == map_.end()) {
 		return false;
@@ -170,7 +168,7 @@ namespace Opm {
 	void ParameterGroup::insert(const std::string& name,
 				    const std::shared_ptr<ParameterMapItem>& data)
         {
-	    std::pair<std::string, std::string> name_path = split(name);
+	    std::pair<std::string, std::string> name_path = splitParam(name);
 	    map_type::const_iterator it = map_.find(name_path.first);
 	    assert(name_path.second == "");
 	    if (it == map_.end()) {
@@ -202,9 +200,9 @@ namespace Opm {
 	void ParameterGroup::insertParameter(const std::string& name,
                                              const std::string& value)
         {
-	    std::pair<std::string, std::string> name_path = split(name);
+	    std::pair<std::string, std::string> name_path = splitParam(name);
 	    while (name_path.first == "") {
-		name_path = split(name_path.second);
+		name_path = splitParam(name_path.second);
 	    }
 	    map_type::const_iterator it = map_.find(name_path.first);
 	    if (it == map_.end()) {
@@ -330,5 +328,4 @@ namespace Opm {
             return unhandled_arguments_;
         }
 
-    } // namespace parameter
 } // namespace Opm

--- a/opm/core/utility/parameters/ParameterGroup.hpp
+++ b/opm/core/utility/parameters/ParameterGroup.hpp
@@ -45,7 +45,6 @@
 #include <opm/core/utility/parameters/ParameterRequirement.hpp>
 
 namespace Opm {
-    namespace parameter {
 	/// ParameterGroup is a class that is used to provide run-time parameters.
 	/// The standard use of the class is to call create it with the
 	/// (int argc, char** argv) constructor (where the arguments are those
@@ -266,7 +265,6 @@ namespace Opm {
 	    static std::pair<std::string, std::string>
 	    filename_split(const std::string& filename);
 	};
-    } // namespace parameter
 } // namespace Opm
 
 #include <opm/core/utility/parameters/ParameterGroup_impl.hpp>

--- a/opm/core/utility/parameters/ParameterGroup_impl.hpp
+++ b/opm/core/utility/parameters/ParameterGroup_impl.hpp
@@ -48,8 +48,6 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 
 namespace Opm {
-    namespace parameter {
-
 	template<>
 	struct ParameterMapItemTrait<ParameterGroup> {
 	    static ParameterGroup
@@ -179,7 +177,7 @@ namespace Opm {
 				     const Requirement& r) const
         {
 	    setUsed();
-	    std::pair<std::string, std::string> name_path = split(name);
+	    std::pair<std::string, std::string> name_path = splitParam(name);
 	    map_type::const_iterator it = map_.find(name_path.first);
 	    if (it == map_.end()) {
 		if (parent_ != 0) {
@@ -225,7 +223,7 @@ namespace Opm {
 					    const Requirement& r) const
         {
 	    setUsed();
-	    std::pair<std::string, std::string> name_path = split(name);
+	    std::pair<std::string, std::string> name_path = splitParam(name);
 	    map_type::const_iterator it = map_.find(name_path.first);
 	    if (it == map_.end()) {
 		if (parent_ != 0) {
@@ -308,7 +306,6 @@ namespace Opm {
 	    }
 	    return value;
 	}
-    } // namespace parameter
 } // namespace Opm
 
 #endif // OPM_PARAMETERGROUP_IMPL_HEADER

--- a/opm/core/utility/parameters/ParameterMapItem.hpp
+++ b/opm/core/utility/parameters/ParameterMapItem.hpp
@@ -39,7 +39,6 @@
 #include <string>
 
 namespace Opm {
-    namespace parameter {
 	/// The parameter handlig system is structured as a tree,
 	/// where each node inhertis from ParameterMapItem.
 	///
@@ -67,7 +66,6 @@ namespace Opm {
                              std::string& conversion_error);
 	    static std::string type();
 	};
-    } // namespace parameter
 } // namespace Opm
 
 #endif // OPM_PARAMETERMAPITEM_HEADER

--- a/opm/core/utility/parameters/ParameterRequirement.hpp
+++ b/opm/core/utility/parameters/ParameterRequirement.hpp
@@ -43,7 +43,6 @@
 #include <vector>
 
 namespace Opm {
-    namespace parameter {
 	/// @brief
 	/// @todo Doc me!
 	/// @tparam
@@ -237,7 +236,6 @@ namespace Opm {
 	private:
 	    const std::vector<std::string> elements_;
 	};
-    } // namespace parameter
 } // namespace Opm
 
 #endif // OPM_PARAMETERREQUIREMENT_HEADER

--- a/opm/core/utility/parameters/ParameterStrings.hpp
+++ b/opm/core/utility/parameters/ParameterStrings.hpp
@@ -39,7 +39,6 @@
 #include <string>
 
 namespace Opm {
-    namespace parameter {
 	const std::string ID_true                   = "true";
 	const std::string ID_false                  = "false";
 
@@ -59,7 +58,6 @@ namespace Opm {
 	const std::string ID_delimiter_path       = "/";
 	const std::string ID_comment              = "//";
 	const std::string ID_delimiter_assignment = "=";
-    } // namespace parameter
 } // namespace Opm
 
 #endif // OPM_PARAMETERSTRINGS_HEADER

--- a/opm/core/utility/parameters/ParameterTools.cpp
+++ b/opm/core/utility/parameters/ParameterTools.cpp
@@ -40,8 +40,7 @@
 #include <opm/core/utility/parameters/ParameterStrings.hpp>
 
 namespace Opm {
-    namespace parameter {
-	std::pair<std::string, std::string> split(const std::string& name)
+	std::pair<std::string, std::string> splitParam(const std::string& name)
         {
 	    int pos = name.find(ID_delimiter_path);
 	    if (pos == int(std::string::npos)) {
@@ -51,5 +50,4 @@ namespace Opm {
                                       name.substr(pos + ID_delimiter_path.size()));
 	    }
 	}
-    } // namespace parameter
 } // namespace Opm

--- a/opm/core/utility/parameters/ParameterTools.hpp
+++ b/opm/core/utility/parameters/ParameterTools.hpp
@@ -40,9 +40,7 @@
 #include <utility>
 
 namespace Opm {
-    namespace parameter {
-	std::pair<std::string, std::string> split(const std::string& name);
-    } // namespace parameter
+	std::pair<std::string, std::string> splitParam(const std::string& name);
 } // namespace Opm
 
 #endif // OPM_PARAMETERTOOLS_HEADER

--- a/tests/test_equil.cpp
+++ b/tests/test_equil.cpp
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE (PhasePressure)
     std::shared_ptr<UnstructuredGrid>
         G(create_grid_cart3d(10, 1, 10), destroy_grid);
 
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     {
         using Opm::unit::kilogram;
         using Opm::unit::meter;
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE (CellSubset)
     std::shared_ptr<UnstructuredGrid>
         G(create_grid_cart3d(10, 1, 10), destroy_grid);
 
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     {
         using Opm::unit::kilogram;
         using Opm::unit::meter;
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE (RegMapping)
     std::shared_ptr<UnstructuredGrid>
         G(create_grid_cart3d(10, 1, 10), destroy_grid);
 
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     {
         using Opm::unit::kilogram;
         using Opm::unit::meter;

--- a/tests/test_linearsolver.cpp
+++ b/tests/test_linearsolver.cpp
@@ -109,7 +109,7 @@ void createRandomVectors(int NN, std::vector<double>& x, std::vector<double>& b,
     }
 }
 
-void run_test(const Opm::parameter::ParameterGroup& param)
+void run_test(const Opm::ParameterGroup& param)
 {
     int N=4;
     auto mat = createLaplacian(N);
@@ -126,7 +126,7 @@ void run_test(const Opm::parameter::ParameterGroup& param)
 
 BOOST_AUTO_TEST_CASE(DefaultTest)
 {
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     param.insertParameter(std::string("linsolver_max_iterations"), std::string("200"));
     param.insertParameter(std::string("linsolver_verbosity"), std::string("2"));
     run_test(param);
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(DefaultTest)
 #ifdef HAVE_DUNE_ISTL
 BOOST_AUTO_TEST_CASE(CGAMGTest)
 {
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     param.insertParameter(std::string("linsolver"), std::string("istl"));
     param.insertParameter(std::string("linsolver_type"), std::string("1"));
     param.insertParameter(std::string("linsolver_max_iterations"), std::string("200"));
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(CGAMGTest)
 
 BOOST_AUTO_TEST_CASE(CGILUTest)
 {
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     param.insertParameter(std::string("linsolver"), std::string("istl"));
     param.insertParameter(std::string("linsolver_type"), std::string("0"));
     param.insertParameter(std::string("linsolver_max_iterations"), std::string("200"));
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(CGILUTest)
 
 BOOST_AUTO_TEST_CASE(BiCGILUTest)
 {
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     param.insertParameter(std::string("linsolver"), std::string("istl"));
     param.insertParameter(std::string("linsolver_type"), std::string("2"));
     param.insertParameter(std::string("linsolver_max_iterations"), std::string("200"));
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE(BiCGILUTest)
 #if defined(HAS_DUNE_FAST_AMG) || DUNE_VERSION_NEWER(DUNE_ISTL, 2, 3)
 BOOST_AUTO_TEST_CASE(FastAMGTest)
 {
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     param.insertParameter(std::string("linsolver"), std::string("istl"));
     param.insertParameter(std::string("linsolver_type"), std::string("3"));
     param.insertParameter(std::string("linsolver_max_iterations"), std::string("200"));
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(FastAMGTest)
 
 BOOST_AUTO_TEST_CASE(KAMGTest)
 {
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     param.insertParameter(std::string("linsolver"), std::string("istl"));
     param.insertParameter(std::string("linsolver_type"), std::string("4"));
     param.insertParameter(std::string("linsolver_max_iterations"), std::string("200"));
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(KAMGTest)
 #if HAVE_PETSC
 BOOST_AUTO_TEST_CASE(PETScTest)
 {
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     param.insertParameter(std::string("linsolver"), std::string("petsc"));
     param.insertParameter(std::string("ksp_type"), std::string("cg"));
     param.insertParameter(std::string("pc_type"), std::string("jacobi"));

--- a/tests/test_parallel_linearsolver.cpp
+++ b/tests/test_parallel_linearsolver.cpp
@@ -42,7 +42,7 @@
 #include <cstdlib>
 #include <string>
 
-void run_test(const Opm::parameter::ParameterGroup& param)
+void run_test(const Opm::ParameterGroup& param)
 {
     int N=100;
     int start, end, istart, iend;
@@ -63,7 +63,7 @@ void run_test(const Opm::parameter::ParameterGroup& param)
 #ifdef HAVE_DUNE_ISTL
 BOOST_AUTO_TEST_CASE(CGAMGTest)
 {
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     param.insertParameter(std::string("linsolver"), std::string("istl"));
     param.insertParameter(std::string("linsolver_type"), std::string("1"));
     param.insertParameter(std::string("linsolver_max_iterations"), std::string("200"));
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(CGAMGTest)
 
 BOOST_AUTO_TEST_CASE(CGILUTest)
 {
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     param.insertParameter(std::string("linsolver"), std::string("istl"));
     param.insertParameter(std::string("linsolver_type"), std::string("0"));
     param.insertParameter(std::string("linsolver_max_iterations"), std::string("200"));
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(CGILUTest)
 
 BOOST_AUTO_TEST_CASE(BiCGILUTest)
 {
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     param.insertParameter(std::string("linsolver"), std::string("istl"));
     param.insertParameter(std::string("linsolver_type"), std::string("2"));
     param.insertParameter(std::string("linsolver_max_iterations"), std::string("200"));

--- a/tests/test_param.cpp
+++ b/tests/test_param.cpp
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(commandline_syntax_init)
                              "/group/item=overridingstring",
                              0 };
     const std::size_t argc = argv.size() - 1;
-    parameter::ParameterGroup p(argc, argv.data());
+    ParameterGroup p(argc, argv.data());
     BOOST_CHECK(p.get<std::string>("topitem") == "somestring");
     std::ostringstream os;
     p.writeParamToStream(os);
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(xml_syntax_init)
                              "unhandledargument",
                              0};
     const std::size_t argc = argv.size() - 1;
-    parameter::ParameterGroup p(argc, argv.data(), false);
+    ParameterGroup p(argc, argv.data(), false);
     BOOST_CHECK(p.get<std::string>("topitem") == "somestring");
     std::ostringstream os;
     p.writeParamToStream(os);
@@ -120,5 +120,5 @@ BOOST_AUTO_TEST_CASE(failing_strict_xml_syntax_init)
                              "unhandledargument",
                              0 };
     const std::size_t argc = argv.size() - 1;
-    BOOST_CHECK_THROW(parameter::ParameterGroup p(argc, argv.data()), std::runtime_error);
+    BOOST_CHECK_THROW(ParameterGroup p(argc, argv.data()), std::runtime_error);
 }

--- a/tests/test_satfunc.cpp
+++ b/tests/test_satfunc.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE (GwsegStandard)
     
     //std::cout << "==================================== GwsegStandard ====================================" << std::endl;
 
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     
     Opm::GridManager gm(1, 1, 10, 1.0, 1.0, 5.0);
     const UnstructuredGrid& grid = *(gm.c_grid());
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE (GwsegEPSBase)
     
     //std::cout << "==================================== GwsegEPSBase ====================================" << std::endl;
     
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     
     Opm::GridManager gm(1, 1, 10, 1.0, 1.0, 5.0);
     const UnstructuredGrid& grid = *(gm.c_grid());
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE (GwsegEPS_A)
     
     //std::cout << "==================================== GwsegEPS_A ====================================" << std::endl;
     
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     
     Opm::GridManager gm(1, 1, 10, 1.0, 1.0, 5.0);
     const UnstructuredGrid& grid = *(gm.c_grid());
@@ -486,7 +486,7 @@ BOOST_AUTO_TEST_CASE (GwsegEPS_C)
     
     //std::cout << "==================================== GwsegEPS_C ====================================" << std::endl;
     
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     
     Opm::GridManager gm(1, 1, 10, 1.0, 1.0, 5.0);
     const UnstructuredGrid& grid = *(gm.c_grid());
@@ -589,7 +589,7 @@ BOOST_AUTO_TEST_CASE (GwsegEPS_D)
     
     //std::cout << "==================================== GwsegEPS_D ====================================" << std::endl;
 
-    Opm::parameter::ParameterGroup param;
+    Opm::ParameterGroup param;
     
     Opm::GridManager gm(1, 1, 10, 1.0, 1.0, 5.0);
     const UnstructuredGrid& grid = *(gm.c_grid());

--- a/tests/test_shadow.cpp
+++ b/tests/test_shadow.cpp
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE(shadowPorosity)
     const double defaultPorosity = 1.0;
     const double newPorosity = 0.5;
 
-    parameter::ParameterGroup param;
+    ParameterGroup param;
     IncompPropertiesBasic basic (param, 2, 1);
     IncompPropertiesShadow shadow (basic);
     BOOST_CHECK_CLOSE (*(shadow.porosity()), defaultPorosity, 0.001);


### PR DESCRIPTION
inconsistent and unnecessary.

this is purely a cosmetic change, the only exception was a function with
the generic name 'split', which was renamed to splitParam to avoid confusion.
@atgeirr As you (were too modest to) request.

Note, I have not done any attempt at reindenting things (I don't feel particularly guilty as the code is a mess in the first place, mixing tabs and spaces and such :p).