### PR TITLE
removing the unused parameter:: for LinearSolverPetsc

### DIFF
--- a/opm/core/linalg/LinearSolverPetsc.cpp
+++ b/opm/core/linalg/LinearSolverPetsc.cpp
@@ -228,7 +228,7 @@ namespace{
 
 } // anonymous namespace.
 
-    LinearSolverPetsc::LinearSolverPetsc(const parameter::ParameterGroup& param)
+    LinearSolverPetsc::LinearSolverPetsc(const ParameterGroup& param)
         : ksp_type_( param.getDefault( std::string( "ksp_type" ), std::string( "gmres" ) ) )
         , pc_type_( param.getDefault( std::string( "pc_type" ), std::string( "sor" ) ) )
         , ksp_view_( param.getDefault( std::string( "ksp_view" ), int( false ) ) )

--- a/opm/core/linalg/LinearSolverPetsc.hpp
+++ b/opm/core/linalg/LinearSolverPetsc.hpp
@@ -42,7 +42,7 @@ namespace Opm
         /// Construct from parameters
         /// Accepted parameters are, with defaults, listed in the
         /// default constructor.
-        LinearSolverPetsc(const parameter::ParameterGroup& param);
+        LinearSolverPetsc(const ParameterGroup& param);
 
         /// Destructor.
         virtual ~LinearSolverPetsc();


### PR DESCRIPTION
to fix the compilation when PETsc exists.

This fixes the issue #1166. 