### PR TITLE
Fix fallout if no group controll (NONE) is specified for a group

### DIFF
--- a/opm/core/wells/WellCollection.cpp
+++ b/opm/core/wells/WellCollection.cpp
@@ -301,10 +301,16 @@ namespace Opm
                 WellsGroupInterface* parent_node = leaf_nodes_[i]->getParent();
                 // update the target within this group.
                 if (leaf_nodes_[i]->isProducer()) {
+                    if (parent_node->prodSpec().control_mode_ == ProductionSpecification::NONE) {
+                        continue;
+                    }
                     parent_node->updateWellProductionTargets(well_rates);
                 }
 
                 if (leaf_nodes_[i]->isInjector()) {
+                    if (parent_node->injSpec().control_mode_ == InjectionSpecification::NONE) {
+                        continue;
+                    }
                     parent_node->updateWellInjectionTargets(well_rates);
                 }
             }


### PR DESCRIPTION
This fixes a case where no group control is specified for a group. 
For applying this patch to the SPE9 case:  
```
--- a/wells_test_suite/GROUP/SPE9_GROUP/SPE9_CP_GROUP.DATA
+++ b/wells_test_suite/GROUP/SPE9_GROUP/SPE9_CP_GROUP.DATA
@@ -432,8 +432,8 @@ WELSPECS
  'INJE2 '  'A'  4  20  9110 'WATER'    60   /
  'PRODU7 ' 'A'  4   6  9110 'OIL'      60   /
  'PRODU9 ' 'A'  14  8  9110 'OIL'      60   /
- 'PRODU15' 'A'  11 14  9110 'OIL'      60   /
- 'PRODU23' 'A'  15 22  9110 'OIL'      60   /
+ 'PRODU15' 'B'  11 14  9110 'OIL'      60   /
+ 'PRODU23' 'B'  15 22  9110 'OIL'      60   /
 /
```
This will fail in the current master. Since no control is specified for group B. 
But work with this patch. 