### PR TITLE
mark initHydroCarbonState() as inline

### DIFF
--- a/opm/core/utility/initHydroCarbonState.hpp
+++ b/opm/core/utility/initHydroCarbonState.hpp
@@ -6,7 +6,7 @@
 namespace Opm
 {
 
-void initHydroCarbonState(BlackoilState& state, const PhaseUsage& pu, const int num_cells, const bool has_disgas, const bool has_vapoil) {
+inline void initHydroCarbonState(BlackoilState& state, const PhaseUsage& pu, const int num_cells, const bool has_disgas, const bool has_vapoil) {
     enum { Oil = BlackoilPhases::Liquid, Gas = BlackoilPhases::Vapour, Water = BlackoilPhases::Aqua };
     // hydrocarbonstate is only used when gas and oil is present
     assert(pu.phase_used[Oil]);


### PR DESCRIPTION
this allows it to be used in multiple compile units without the linker running amok.