### PR TITLE
Remove black oil props from init

### DIFF
--- a/examples/compute_initial_state.cpp
+++ b/examples/compute_initial_state.cpp
@@ -148,8 +148,8 @@ try
     /*gasPhaseIdx=*/Opm::BlackoilPhases::Vapour> MaterialTraits;
     typedef Opm::EclMaterialLawManager<MaterialTraits> MaterialLawManager;
 
-    auto materialLawManager = std::make_shared<MaterialLawManager>();
-    materialLawManager->initFromDeck(deck, eclipseState, compressedToCartesianIdx);
+    MaterialLawManager materialLawManager = MaterialLawManager();
+    materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
     // Initialisation.
     //initBlackoilSurfvolUsingRSorRV(UgGridHelpers::numCells(grid), props, state);

--- a/opm/core/simulator/EquilibrationHelpers.hpp
+++ b/opm/core/simulator/EquilibrationHelpers.hpp
@@ -1,5 +1,6 @@
 /*
   Copyright 2014 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 IRIS
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -20,7 +21,6 @@
 #ifndef OPM_EQUILIBRATIONHELPERS_HEADER_INCLUDED
 #define OPM_EQUILIBRATIONHELPERS_HEADER_INCLUDED
 
-#include <opm/core/props/BlackoilPhases.hpp>
 #include <opm/core/utility/linearInterpolation.hpp>
 #include <opm/core/utility/RegionMapping.hpp>
 #include <opm/core/utility/RootFinders.hpp>
@@ -478,13 +478,11 @@ namespace Opm
             EquilReg(const EquilRecord& rec,
                      std::shared_ptr<Miscibility::RsFunction> rs,
                      std::shared_ptr<Miscibility::RsFunction> rv,
-                     const int pvtIdx,
-                     const PhaseUsage&  pu)
+                     const int pvtIdx)
                 : rec_    (rec)
                 , rs_     (rs)
                 , rv_     (rv)
                 , pvtIdx_ (pvtIdx)
-                , pu_     (pu)
 
             {
             }
@@ -554,18 +552,12 @@ namespace Opm
             const int
             pvtIdx() const { return this->pvtIdx_; }
 
-            /**
-             * Retrieve active fluid phase summary.
-             */
-            const PhaseUsage&
-            phaseUsage() const { return this->pu_; }
 
         private:
             EquilRecord rec_;     /**< Equilibration data */
             std::shared_ptr<Miscibility::RsFunction> rs_;      /**< RS calculator */
             std::shared_ptr<Miscibility::RsFunction> rv_;      /**< RV calculator */
             const int pvtIdx_;
-            PhaseUsage  pu_;      /**< Active phase summary */
         };
 
 
@@ -588,7 +580,7 @@ namespace Opm
                 fluidState_.setSaturation(FluidSystem::waterPhaseIdx, 0.0);
                 fluidState_.setSaturation(FluidSystem::oilPhaseIdx, 0.0);
                 fluidState_.setSaturation(FluidSystem::gasPhaseIdx, 0.0);
-                std::fill(pc_, pc_ + BlackoilPhases::MaxNumPhases, 0.0);
+                std::fill(pc_, pc_ + FluidSystem::numPhases, 0.0);
 
             }
 
@@ -609,7 +601,7 @@ namespace Opm
             const int cell_;
             const double target_pc_;
             mutable SatOnlyFluidState fluidState_;
-            mutable double pc_[BlackoilPhases::MaxNumPhases];
+            mutable double pc_[FluidSystem::numPhases];
         };
 
         template <class FluidSystem, class MaterialLawManager>
@@ -722,7 +714,7 @@ namespace Opm
                 fluidState_.setSaturation(FluidSystem::waterPhaseIdx, 0.0);
                 fluidState_.setSaturation(FluidSystem::oilPhaseIdx, 0.0);
                 fluidState_.setSaturation(FluidSystem::gasPhaseIdx, 0.0);
-                std::fill(pc_, pc_ + BlackoilPhases::MaxNumPhases, 0.0);
+                std::fill(pc_, pc_ + FluidSystem::numPhases, 0.0);
             }
             double operator()(double s) const
             {
@@ -745,7 +737,7 @@ namespace Opm
             const int cell_;
             const double target_pc_;
             mutable SatOnlyFluidState fluidState_;
-            mutable double pc_[BlackoilPhases::MaxNumPhases];
+            mutable double pc_[FluidSystem::numPhases];
         };
 
 

--- a/opm/core/simulator/EquilibrationHelpers.hpp
+++ b/opm/core/simulator/EquilibrationHelpers.hpp
@@ -568,7 +568,7 @@ namespace Opm
         template <class FluidSystem,  class MaterialLaw, class MaterialLawManager>
         struct PcEq
         {
-            PcEq(std::shared_ptr<MaterialLawManager> materialLawManager,
+            PcEq(const MaterialLawManager& materialLawManager,
                  const int phase,
                  const int cell,
                  const double target_pc)
@@ -587,7 +587,7 @@ namespace Opm
 
             double operator()(double s) const
             {
-                const auto& matParams = materialLawManager_->materialLawParams(cell_);
+                const auto& matParams = materialLawManager_.materialLawParams(cell_);
                 fluidState_.setSaturation(phase_, s);
                 MaterialLaw::capillaryPressures(pc_, matParams, fluidState_);
                 double sign = (phase_ == FluidSystem::waterPhaseIdx)? -1.0 : 1.0;
@@ -596,7 +596,7 @@ namespace Opm
             }
         private:
 
-            std::shared_ptr<MaterialLawManager> materialLawManager_;
+            const MaterialLawManager& materialLawManager_;
             const int phase_;
             const int cell_;
             const double target_pc_;
@@ -605,9 +605,9 @@ namespace Opm
         };
 
         template <class FluidSystem, class MaterialLawManager>
-        double minSaturations(std::shared_ptr<MaterialLawManager> materialLawManager, const int phase, const int cell) {
+        double minSaturations(const MaterialLawManager& materialLawManager, const int phase, const int cell) {
             const auto& scaledDrainageInfo =
-                materialLawManager->oilWaterScaledEpsInfoDrainage(cell);
+                materialLawManager.oilWaterScaledEpsInfoDrainage(cell);
 
             // Find minimum and maximum saturations.
             switch(phase) {
@@ -632,9 +632,9 @@ namespace Opm
         }
 
         template <class FluidSystem, class MaterialLawManager>
-        double maxSaturations(std::shared_ptr<MaterialLawManager> materialLawManager, const int phase, const int cell) {
+        double maxSaturations(const MaterialLawManager& materialLawManager, const int phase, const int cell) {
             const auto& scaledDrainageInfo =
-                materialLawManager->oilWaterScaledEpsInfoDrainage(cell);
+                materialLawManager.oilWaterScaledEpsInfoDrainage(cell);
 
             // Find minimum and maximum saturations.
             switch(phase) {
@@ -664,7 +664,7 @@ namespace Opm
         /// Compute saturation of some phase corresponding to a given
         /// capillary pressure.
         template <class FluidSystem, class MaterialLaw, class MaterialLawManager >
-        inline double satFromPc(std::shared_ptr<MaterialLawManager> materialLawManager,
+        inline double satFromPc(const MaterialLawManager& materialLawManager,
                                 const int phase,
                                 const int cell,
                                 const double target_pc,
@@ -700,7 +700,7 @@ namespace Opm
         template <class FluidSystem, class MaterialLaw, class MaterialLawManager>
         struct PcEqSum
         {
-            PcEqSum(std::shared_ptr<MaterialLawManager> materialLawManager,
+            PcEqSum(const MaterialLawManager& materialLawManager,
                     const int phase1,
                     const int phase2,
                     const int cell,
@@ -718,7 +718,7 @@ namespace Opm
             }
             double operator()(double s) const
             {
-                const auto& matParams = materialLawManager_->materialLawParams(cell_);
+                const auto& matParams = materialLawManager_.materialLawParams(cell_);
                 fluidState_.setSaturation(phase1_, s);
                 fluidState_.setSaturation(phase2_, 1.0 - s);
 
@@ -731,7 +731,7 @@ namespace Opm
                 return pc1 + pc2 - target_pc_;
             }
         private:
-            std::shared_ptr<MaterialLawManager> materialLawManager_;
+            const MaterialLawManager& materialLawManager_;
             const int phase1_;
             const int phase2_;
             const int cell_;
@@ -748,7 +748,7 @@ namespace Opm
         /// is given as a sum of two other functions.
 
         template <class FluidSystem, class MaterialLaw, class MaterialLawManager>
-        inline double satFromSumOfPcs(std::shared_ptr<MaterialLawManager> materialLawManager,
+        inline double satFromSumOfPcs(const MaterialLawManager& materialLawManager,
                                       const int phase1,
                                       const int phase2,
                                       const int cell,
@@ -778,7 +778,7 @@ namespace Opm
 
         /// Compute saturation from depth. Used for constant capillary pressure function
         template <class FluidSystem, class MaterialLaw, class MaterialLawManager>
-        inline double satFromDepth(std::shared_ptr<MaterialLawManager> materialLawManager,
+        inline double satFromDepth(const MaterialLawManager& materialLawManager,
                                    const double cellDepth,
                                    const double contactDepth,
                                    const int phase,
@@ -798,7 +798,7 @@ namespace Opm
 
         /// Return true if capillary pressure function is constant
         template <class FluidSystem, class MaterialLaw, class MaterialLawManager>
-        inline bool isConstPc(std::shared_ptr<MaterialLawManager> materialLawManager,
+        inline bool isConstPc(const MaterialLawManager& materialLawManager,
                               const int                          phase,
                               const int                          cell)
         {

--- a/opm/core/simulator/initStateEquil.hpp
+++ b/opm/core/simulator/initStateEquil.hpp
@@ -147,7 +147,7 @@ namespace Opm
         phaseSaturations(const Grid&             grid,
                          const Region&           reg,
                          const CellRange&        cells,
-                         std::shared_ptr<MaterialLawManager> materialLawManager,
+                         MaterialLawManager& materialLawManager,
                          const std::vector<double> swat_init,
                          std::vector< std::vector<double> >& phase_pressures);
 
@@ -226,7 +226,7 @@ namespace Opm
             class InitialStateComputer {
             public:
                 template<class MaterialLawManager, class Grid>
-                InitialStateComputer(std::shared_ptr<MaterialLawManager> materialLawManager,
+                InitialStateComputer(MaterialLawManager& materialLawManager,
                                      const Opm::EclipseState& eclipseState,
                                      const Grid&                        G    ,
                                      const double grav = unit::gravity,
@@ -386,7 +386,7 @@ namespace Opm
                 void
                 calcPressSatRsRv(const RMap&                       reg  ,
                                  const std::vector< EquilRecord >& rec  ,
-                                 std::shared_ptr<MaterialLawManager> materialLawManager,
+                                 MaterialLawManager& materialLawManager,
                                  const Grid&                       G    ,
                                  const double grav)
                 {

--- a/opm/core/simulator/initStateEquil_impl.hpp
+++ b/opm/core/simulator/initStateEquil_impl.hpp
@@ -433,7 +433,7 @@ namespace Opm
                        const CellRange&                    cells,
                        std::vector< std::vector<double> >& press)
         {
-            const bool water = FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx);
+            const bool water = FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx);
             const bool oil = FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx);
             const bool gas = FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx);
             const int oilpos = FluidSystem::oilPhaseIdx;

--- a/opm/core/simulator/initStateEquil_impl.hpp
+++ b/opm/core/simulator/initStateEquil_impl.hpp
@@ -597,7 +597,7 @@ namespace Opm
         phaseSaturations(const Grid&             G,
                          const Region&           reg,
                          const CellRange&        cells,
-                         std::shared_ptr<MaterialLawManager> materialLawManager,
+                         MaterialLawManager& materialLawManager,
                          const std::vector<double> swat_init,
                          std::vector< std::vector<double> >& phase_pressures)
         {
@@ -633,8 +633,8 @@ namespace Opm
             for (typename CellRange::const_iterator ci = cells.begin(); ci != cells.end(); ++ci, ++local_index) {
                 const int cell = *ci;
                 const auto& scaledDrainageInfo =
-                    materialLawManager->oilWaterScaledEpsInfoDrainage(cell);
-                const auto& matParams = materialLawManager->materialLawParams(cell);
+                    materialLawManager.oilWaterScaledEpsInfoDrainage(cell);
+                const auto& matParams = materialLawManager.materialLawParams(cell);
 
                 // Find saturations from pressure differences by
                 // inverting capillary pressure functions.
@@ -653,7 +653,7 @@ namespace Opm
                             phase_saturations[waterpos][local_index] = sw;
                         } else { // Scale Pc to reflect imposed sw
                             sw = swat_init[cell];
-                            sw = materialLawManager->applySwatinit(cell, pcov, sw);
+                            sw = materialLawManager.applySwatinit(cell, pcov, sw);
                             phase_saturations[waterpos][local_index] = sw;
                         }
                     }
@@ -684,7 +684,7 @@ namespace Opm
                         // Re-scale Pc to reflect imposed sw for vanishing oil phase.
                         // This seems consistent with ecl, and fails to honour 
                         // swat_init in case of non-trivial gas-oil cap pressure.
-                        sw = materialLawManager->applySwatinit(cell, pcgw, sw);
+                        sw = materialLawManager.applySwatinit(cell, pcgw, sw);
                     }
                     sw = satFromSumOfPcs<FluidSystem, MaterialLaw, MaterialLawManager>(materialLawManager, waterpos, gaspos, cell, pcgw);
                     sg = 1.0 - sw;

--- a/tests/test_equil.cpp
+++ b/tests/test_equil.cpp
@@ -210,10 +210,10 @@ BOOST_AUTO_TEST_CASE (PhasePressure)
     initDefaultFluidSystem();
 
     Opm::EQUIL::EquilReg
-            region(record,
-                   std::make_shared<Opm::EQUIL::Miscibility::NoMixing>(),
-                   std::make_shared<Opm::EQUIL::Miscibility::NoMixing>(),
-                   0);
+        region(record,
+        std::make_shared<Opm::EQUIL::Miscibility::NoMixing>(),
+        std::make_shared<Opm::EQUIL::Miscibility::NoMixing>(),
+        0);
 
     std::vector<int> cells(G->number_of_cells);
     std::iota(cells.begin(), cells.end(), 0);

--- a/tests/test_equil.cpp
+++ b/tests/test_equil.cpp
@@ -410,8 +410,8 @@ BOOST_AUTO_TEST_CASE (DeckAllDead)
 
     std::vector<int> compressedToCartesianIdx
         = Opm::compressedToCartesian(grid->number_of_cells, grid->global_cell);
-    auto materialLawManager = std::make_shared<MaterialLawManager>();
-    materialLawManager->initFromDeck(deck, eclipseState, compressedToCartesianIdx);
+    MaterialLawManager materialLawManager = MaterialLawManager();
+    materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
     typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
 
@@ -449,8 +449,8 @@ BOOST_AUTO_TEST_CASE (CapillaryInversion)
     // Create material law manager.
     std::vector<int> compressedToCartesianIdx
         = Opm::compressedToCartesian(grid.number_of_cells, grid.global_cell);
-    auto materialLawManager = std::make_shared<MaterialLawManager>();
-    materialLawManager->initFromDeck(deck, eclipseState, compressedToCartesianIdx);
+    MaterialLawManager materialLawManager = MaterialLawManager();
+    materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
     typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
     typedef MaterialLawManager::MaterialLaw MaterialLaw;
@@ -515,8 +515,8 @@ BOOST_AUTO_TEST_CASE (DeckWithCapillary)
     // Create material law manager.
     std::vector<int> compressedToCartesianIdx
         = Opm::compressedToCartesian(grid.number_of_cells, grid.global_cell);
-    auto materialLawManager = std::make_shared<MaterialLawManager>();
-    materialLawManager->initFromDeck(deck, eclipseState, compressedToCartesianIdx);
+    MaterialLawManager materialLawManager = MaterialLawManager();
+    materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
     typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
 
@@ -566,8 +566,8 @@ BOOST_AUTO_TEST_CASE (DeckWithCapillaryOverlap)
     // Create material law manager.
     std::vector<int> compressedToCartesianIdx
         = Opm::compressedToCartesian(grid.number_of_cells, grid.global_cell);
-    auto materialLawManager = std::make_shared<MaterialLawManager>();
-    materialLawManager->initFromDeck(deck, eclipseState, compressedToCartesianIdx);
+    MaterialLawManager materialLawManager = MaterialLawManager();
+    materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
     typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
 
@@ -639,8 +639,8 @@ BOOST_AUTO_TEST_CASE (DeckWithLiveOil)
     // Create material law manager.
     std::vector<int> compressedToCartesianIdx
         = Opm::compressedToCartesian(grid.number_of_cells, grid.global_cell);
-    auto materialLawManager = std::make_shared<MaterialLawManager>();
-    materialLawManager->initFromDeck(deck, eclipseState, compressedToCartesianIdx);
+    MaterialLawManager materialLawManager = MaterialLawManager();
+    materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
     typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
 
@@ -727,8 +727,8 @@ BOOST_AUTO_TEST_CASE (DeckWithLiveGas)
     // Create material law manager.
     std::vector<int> compressedToCartesianIdx
         = Opm::compressedToCartesian(grid.number_of_cells, grid.global_cell);
-    auto materialLawManager = std::make_shared<MaterialLawManager>();
-    materialLawManager->initFromDeck(deck, eclipseState, compressedToCartesianIdx);
+    MaterialLawManager materialLawManager = MaterialLawManager();
+    materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
     typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
 
@@ -818,8 +818,8 @@ BOOST_AUTO_TEST_CASE (DeckWithRSVDAndRVVD)
     // Create material law manager.
     std::vector<int> compressedToCartesianIdx
         = Opm::compressedToCartesian(grid.number_of_cells, grid.global_cell);
-    auto materialLawManager = std::make_shared<MaterialLawManager>();
-    materialLawManager->initFromDeck(deck, eclipseState, compressedToCartesianIdx);
+    MaterialLawManager materialLawManager = MaterialLawManager();
+    materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
     typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
 
@@ -930,11 +930,11 @@ BOOST_AUTO_TEST_CASE (DeckWithSwatinit)
     // Create material law manager.
     std::vector<int> compressedToCartesianIdx
         = Opm::compressedToCartesian(grid.number_of_cells, grid.global_cell);
-    auto materialLawManager = std::make_shared<MaterialLawManager>();
-    materialLawManager->initFromDeck(deck, eclipseState, compressedToCartesianIdx);
+    MaterialLawManager materialLawManager = MaterialLawManager();
+    materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
-    auto materialLawManagerScaled = std::make_shared<MaterialLawManager>();
-    materialLawManagerScaled->initFromDeck(deck, eclipseState, compressedToCartesianIdx);
+    MaterialLawManager materialLawManagerScaled = MaterialLawManager();
+    materialLawManagerScaled.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
     // reference saturations
     const std::vector<double> s[3]{
@@ -981,7 +981,7 @@ BOOST_AUTO_TEST_CASE (DeckWithSwatinit)
         fluidState.setSaturation(FluidSystem::waterPhaseIdx, sw);
         fluidState.setSaturation(FluidSystem::oilPhaseIdx, so);
         fluidState.setSaturation(FluidSystem::gasPhaseIdx, sg);
-        const auto& matParams = materialLawManager->materialLawParams(c);
+        const auto& matParams = materialLawManager.materialLawParams(c);
         MaterialLaw::capillaryPressures(pc, matParams, fluidState);
         pc_original[3*c + 0] = pc[FluidSystem::oilPhaseIdx] - pc[FluidSystem::waterPhaseIdx];
         pc_original[3*c + 1] = 0.0;
@@ -1022,7 +1022,7 @@ BOOST_AUTO_TEST_CASE (DeckWithSwatinit)
         fluidState.setSaturation(FluidSystem::waterPhaseIdx, sw);
         fluidState.setSaturation(FluidSystem::oilPhaseIdx, so);
         fluidState.setSaturation(FluidSystem::gasPhaseIdx, sg);
-        const auto& matParams = materialLawManagerScaled->materialLawParams(c);
+        const auto& matParams = materialLawManagerScaled.materialLawParams(c);
         MaterialLaw::capillaryPressures(pc, matParams, fluidState);
         pc_scaled[3*c + 0] = pc[FluidSystem::oilPhaseIdx] - pc[FluidSystem::waterPhaseIdx];
         pc_scaled[3*c + 1] = 0.0;
@@ -1039,7 +1039,7 @@ BOOST_AUTO_TEST_CASE (DeckWithSwatinit)
         fluidState.setSaturation(FluidSystem::oilPhaseIdx, so);
         fluidState.setSaturation(FluidSystem::gasPhaseIdx, sg);
 
-        const auto& matParams = materialLawManager->materialLawParams(c);
+        const auto& matParams = materialLawManager.materialLawParams(c);
         MaterialLaw::capillaryPressures(pc, matParams, fluidState);
         pc_unscaled[3*c + 0] = pc[FluidSystem::oilPhaseIdx] - pc[FluidSystem::waterPhaseIdx];
         pc_unscaled[3*c + 1] = 0.0;

--- a/tests/test_equil.cpp
+++ b/tests/test_equil.cpp
@@ -88,9 +88,9 @@ static void initDefaultFluidSystem() {
         { 6.21542e+07, 1 }
     };
 
-    double rhoRefO = 700; // [kg]
-    double rhoRefG = 1000; // [kg]
-    double rhoRefW = 1000; // [kg]
+    double rhoRefO = 700; // [kg/m3]
+    double rhoRefG = 1000; // [kg/m3]
+    double rhoRefW = 1000; // [kg/m3]
 
     FluidSystem::initBegin(/*numPvtRegions=*/1);
     FluidSystem::setEnableDissolvedGas(false);
@@ -125,17 +125,10 @@ static void initDefaultFluidSystem() {
     oilPvt->initEnd();
     waterPvt->initEnd();
 
-    typedef std::shared_ptr<Opm::GasPvtMultiplexer<double> > GasPvtSharedPtr;
-    FluidSystem::setGasPvt(GasPvtSharedPtr(gasPvt));
-
-    typedef std::shared_ptr<Opm::OilPvtMultiplexer<double> > OilPvtSharedPtr;
-    FluidSystem::setOilPvt(OilPvtSharedPtr(oilPvt));
-
-    typedef std::shared_ptr<Opm::WaterPvtMultiplexer<double> > WaterPvtSharedPtr;
-    FluidSystem::setWaterPvt(WaterPvtSharedPtr(waterPvt));
-
+    FluidSystem::setGasPvt(std::move(gasPvt));
+    FluidSystem::setOilPvt(std::move(oilPvt));
+    FluidSystem::setWaterPvt(std::move(waterPvt));
     FluidSystem::initEnd();
-
 }
 }
 

--- a/tests/test_equil.cpp
+++ b/tests/test_equil.cpp
@@ -38,8 +38,6 @@
 #include <opm/parser/eclipse/EclipseState/InitConfig/Equil.hpp>
 #include <opm/parser/eclipse/Units/Dimension.hpp>
 
-#include <opm/core/pressure/msmfem/partition.h>
-
 #include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <array>
@@ -355,18 +353,26 @@ BOOST_AUTO_TEST_CASE (RegMapping)
         };
 
     std::vector<int> eqlnum(G->number_of_cells);
+    // [ 0 1; 2 3]
     {
-        std::vector<int> cells(G->number_of_cells);
-        std::iota(cells.begin(), cells.end(), 0);
-
-        const int cdim[] = { 2, 1, 2 };
-        int ncoarse = cdim[0];
-        for (std::size_t d = 1; d < 3; ++d) { ncoarse *= cdim[d]; }
-
-        partition_unif_idx(G->dimensions, G->number_of_cells,
-                           G->cartdims, cdim,
-                           &cells[0], &eqlnum[0]);
+        for (int i = 0; i < 5; ++i) {
+            for (int j = 0; j < 5; ++j) {
+                eqlnum[i*10 + j] = 0;
+            }
+            for (int j = 5; j < 10; ++j) {
+                eqlnum[i*10 + j] = 1;
+            }
+        }
+        for (int i = 5; i < 10; ++i) {
+            for (int j = 0; j < 5; ++j) {
+                eqlnum[i*10 + j] = 2;
+            }
+            for (int j = 5; j < 10; ++j) {
+                eqlnum[i*10 + j] = 3;
+            }
+        }
     }
+
     Opm::RegionMapping<> eqlmap(eqlnum);
 
     PPress ppress(2, PVal(G->number_of_cells, 0));

--- a/tests/test_equil.cpp
+++ b/tests/test_equil.cpp
@@ -67,8 +67,9 @@ typedef Opm::EclMaterialLawManager<MaterialTraits> MaterialLawManager;
     BOOST_CHECK_CLOSE((value), (expected), (reltol)); \
 }
 
-
-void initDefaultFluidSystem() {
+namespace
+{
+static void initDefaultFluidSystem() {
     std::vector<std::pair<double, double> > Bo = {
         { 101353, 1. },
         { 6.21542e+07, 1 }
@@ -96,25 +97,25 @@ void initDefaultFluidSystem() {
     FluidSystem::setEnableVaporizedOil(false);
     FluidSystem::setReferenceDensities(rhoRefO, rhoRefW, rhoRefG, /*regionIdx=*/0);
 
-    Opm::GasPvtMultiplexer<double> *gasPvt = new Opm::GasPvtMultiplexer<double>;
+    auto gasPvt = std::make_shared<Opm::GasPvtMultiplexer<double>>();
     gasPvt->setApproach(Opm::GasPvtMultiplexer<double>::DryGasPvt);
-    auto& dryGasPvt = gasPvt->template getRealPvt<Opm::GasPvtMultiplexer<double>::DryGasPvt>();
+    auto& dryGasPvt = gasPvt->getRealPvt<Opm::GasPvtMultiplexer<double>::DryGasPvt>();
     dryGasPvt.setNumRegions(/*numPvtRegion=*/1);
     dryGasPvt.setReferenceDensities(/*regionIdx=*/0, rhoRefO, rhoRefG, rhoRefW);
     dryGasPvt.setGasFormationVolumeFactor(/*regionIdx=*/0, Bg);
     dryGasPvt.setGasViscosity(/*regionIdx=*/0, mug);
 
-    Opm::OilPvtMultiplexer<double> *oilPvt = new Opm::OilPvtMultiplexer<double>;
+    auto oilPvt = std::make_shared<Opm::OilPvtMultiplexer<double>>();
     oilPvt->setApproach(Opm::OilPvtMultiplexer<double>::DeadOilPvt);
-    auto& deadOilPvt = oilPvt->template getRealPvt<Opm::OilPvtMultiplexer<double>::DeadOilPvt>();
+    auto& deadOilPvt = oilPvt->getRealPvt<Opm::OilPvtMultiplexer<double>::DeadOilPvt>();
     deadOilPvt.setNumRegions(/*numPvtRegion=*/1);
     deadOilPvt.setReferenceDensities(/*regionIdx=*/0, rhoRefO, rhoRefG, rhoRefW);
     deadOilPvt.setInverseOilFormationVolumeFactor(/*regionIdx=*/0, Bo);
     deadOilPvt.setOilViscosity(/*regionIdx=*/0, muo);
 
-    Opm::WaterPvtMultiplexer<double> *waterPvt = new Opm::WaterPvtMultiplexer<double>;
+    auto waterPvt = std::make_shared<Opm::WaterPvtMultiplexer<double>>();
     waterPvt->setApproach(Opm::WaterPvtMultiplexer<double>::ConstantCompressibilityWaterPvt);
-    auto& ccWaterPvt = waterPvt->template getRealPvt<Opm::WaterPvtMultiplexer<double>::ConstantCompressibilityWaterPvt>();
+    auto& ccWaterPvt = waterPvt->getRealPvt<Opm::WaterPvtMultiplexer<double>::ConstantCompressibilityWaterPvt>();
     ccWaterPvt.setNumRegions(/*numPvtRegions=*/1);
     ccWaterPvt.setReferenceDensities(/*regionIdx=*/0, rhoRefO, rhoRefG, rhoRefW);
     ccWaterPvt.setViscosity(/*regionIdx=*/0, 1);
@@ -135,6 +136,7 @@ void initDefaultFluidSystem() {
 
     FluidSystem::initEnd();
 
+}
 }
 
 BOOST_AUTO_TEST_SUITE ()


### PR DESCRIPTION
This PR untangle the EQUIL initialization from opm-core legacy property, blackoilState and blackoilPhase objects. 

