### PR TITLE
Add energy phase

### DIFF
--- a/opm/core/props/BlackoilPhases.hpp
+++ b/opm/core/props/BlackoilPhases.hpp
@@ -28,16 +28,23 @@ namespace Opm
     {
     public:
         static const int MaxNumPhases = 3;
-        // enum ComponentIndex { Water = 0, Oil = 1, Gas = 2 };
-        enum PhaseIndex { Aqua = 0, Liquid = 1, Vapour = 2, Energy = 3 };
 
+        // "Crypto phases" are "phases" (or rather "conservation quantities") in the
+        // sense that they can be active or not and canonical indices can be translated
+        // to and from active ones. That said, they are not considered by num_phases or
+        // MaxNumPhases. The crypto phases which are currently implemented are solvent,
+        // polymer and energy.
+        static const int NumCryptoPhases = 3;
+
+        // enum ComponentIndex { Water = 0, Oil = 1, Gas = 2 };
+        enum PhaseIndex { Aqua = 0, Liquid = 1, Vapour = 2, Solvent = 3, Polymer = 4, Energy = 5 };
     };
 
     struct PhaseUsage : public BlackoilPhases
     {
         int num_phases;
-        int phase_used[MaxNumPhases + 1];
-        int phase_pos[MaxNumPhases + 1];
+        int phase_used[MaxNumPhases + NumCryptoPhases];
+        int phase_pos[MaxNumPhases + NumCryptoPhases];
         bool has_solvent;
         bool has_polymer;
         bool has_energy;

--- a/opm/core/props/BlackoilPhases.hpp
+++ b/opm/core/props/BlackoilPhases.hpp
@@ -29,17 +29,18 @@ namespace Opm
     public:
         static const int MaxNumPhases = 3;
         // enum ComponentIndex { Water = 0, Oil = 1, Gas = 2 };
-        enum PhaseIndex { Aqua = 0, Liquid = 1, Vapour = 2 };
+        enum PhaseIndex { Aqua = 0, Liquid = 1, Vapour = 2, Energy = 3 };
 
     };
 
     struct PhaseUsage : public BlackoilPhases
     {
         int num_phases;
-        int phase_used[MaxNumPhases];
-        int phase_pos[MaxNumPhases];
+        int phase_used[MaxNumPhases + 1];
+        int phase_pos[MaxNumPhases + 1];
         bool has_solvent;
         bool has_polymer;
+        bool has_energy;
     };
 
     /// Check or assign presence of a formed, free phase.  Limited to

--- a/opm/core/props/phaseUsageFromDeck.hpp
+++ b/opm/core/props/phaseUsageFromDeck.hpp
@@ -50,9 +50,16 @@ namespace Opm
             pu.phase_used[BlackoilPhases::Vapour] = 1;
         }
         pu.num_phases = 0;
-        for (int i = 0; i < BlackoilPhases::MaxNumPhases; ++i) {
-            pu.phase_pos[i] = pu.num_phases;
-            pu.num_phases += pu.phase_used[i];
+        int numActivePhases = 0;
+        for (int phaseIdx = 0; phaseIdx < BlackoilPhases::MaxNumPhases; ++phaseIdx) {
+            if (!pu.phase_used[numActivePhases]) {
+                pu.phase_pos[phaseIdx] = -1;
+            }
+            else {
+                pu.phase_pos[phaseIdx] = numActivePhases;
+                ++ numActivePhases;
+                pu.num_phases = numActivePhases;
+            }
         }
 
         // Only 2 or 3 phase systems handled.
@@ -78,6 +85,17 @@ namespace Opm
             pu.has_polymer = true;
         }
 
+        // Add energy info
+        pu.has_energy = phase.active(Phase::ENERGY);
+        if (pu.has_energy) {
+            // this is quite a hack: even though energy is not considered as in
+            // MaxNumPhases and pu.num_phases because this would break a lot of
+            // assumptions in old code, it is nevertheless an index to be translated
+            // to. polymer and solvent are even larger hacks because not even this can be
+            // done for them.
+            pu.phase_pos[BlackoilPhases::Energy] = numActivePhases;
+            ++ numActivePhases;
+        }
         return pu;
     }
 
@@ -135,6 +153,9 @@ namespace Opm
         if (phase.active(Phase::POLYMER)) {
             pu.has_polymer = true;
         }
+
+        // Add energy info
+        pu.has_energy = phase.active(Phase::ENERGY);
 
         return pu;
     }


### PR DESCRIPTION
this adds a energy "phase" analogous to solvents and polymer to PhaseUsage. It also fixes a compiler warning which appears because the `Phase` class of opm-parser now has an 'ENERGY' enum.